### PR TITLE
Add Hunter role

### DIFF
--- a/src/main/kotlin/NightAction.kt
+++ b/src/main/kotlin/NightAction.kt
@@ -5,4 +5,5 @@ sealed interface NightAction {
     data class Attack(val target: Player) : NightAction
     data class Divine(val target: Player) : NightAction
     data object MediumReveal : NightAction
+    data class Guard(val target: Player) : NightAction
 }

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -30,6 +30,7 @@ class PlayerManager(allPlayers: List<Player>) {
                 is NightAction.MediumReveal -> _executedPlayers.lastOrNull()?.let { target ->
                     player.onMediumReveal(target, target.role.mediumResult)
                 }
+                is NightAction.Guard -> Unit
             }
         }
     }

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -22,17 +22,31 @@ class PlayerManager(allPlayers: List<Player>) {
 
     fun runNightActions(nightNumber: Int) {
         val decisions = _alivePlayers.map { it to it.nightAction(_alivePlayers, nightNumber) }
+
+        val attacks = decisions.map { it.second }.filterIsInstance<NightAction.Attack>()
+        val guards = decisions.map { it.second }.filterIsInstance<NightAction.Guard>()
+        attackIfNotGuarded(attacks, guards)
+
+        revealNightSecrets(decisions)
+    }
+
+    private fun revealNightSecrets(decisions: List<Pair<Player, NightAction>>) {
         decisions.forEach { (player, decision) ->
             when (decision) {
                 is NightAction.None -> Unit
-                is NightAction.Attack -> attack(decision.target)
+                is NightAction.Attack -> Unit
+                is NightAction.Guard -> Unit
                 is NightAction.Divine -> player.onDivineResult(decision.target, decision.target.role.divineResult)
                 is NightAction.MediumReveal -> _executedPlayers.lastOrNull()?.let { target ->
                     player.onMediumReveal(target, target.role.mediumResult)
                 }
-                is NightAction.Guard -> Unit
             }
         }
+    }
+
+    private fun attackIfNotGuarded(attacks: List<NightAction.Attack>, guards: List<NightAction.Guard>) {
+        val target = attacks.firstOrNull()?.target ?: return
+        if (guards.none { it.target === target }) attack(target)
     }
 
     fun runVoting() {

--- a/src/main/kotlin/Role.kt
+++ b/src/main/kotlin/Role.kt
@@ -26,6 +26,14 @@ enum class Role(val displayName: String, val side: Side, val divineResult: Divin
     VILLAGER("村人", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
         override fun nightAction(self: Player, players: List<Player>, io: PlayerIO, nightNumber: Int): NightAction =
             NightAction.None
+    },
+    HUNTER("狩人", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
+        override fun nightAction(self: Player, players: List<Player>, io: PlayerIO, nightNumber: Int): NightAction {
+            if (nightNumber == 1) return NightAction.None
+            val candidates = players.filterNot { it === self }
+            val target = io.prompt(self.name, "夜の行動", "護衛する対象を選んでください", candidates)
+            return NightAction.Guard(target)
+        }
     };
 
     abstract fun nightAction(self: Player, players: List<Player>, io: PlayerIO, nightNumber: Int): NightAction

--- a/src/main/kotlin/SmallLodge.kt
+++ b/src/main/kotlin/SmallLodge.kt
@@ -2,7 +2,7 @@ package org.example
 
 object SmallLodge : Lodge {
     override fun create(): List<Player> = listOf(
-        HumanPlayer(Role.VILLAGER, "1", ConsolePlayerIO()),
+        HumanPlayer(Role.HUNTER, "1", ConsolePlayerIO()),
         HumanPlayer(Role.VILLAGER, "2", ConsolePlayerIO()),
         HumanPlayer(Role.VILLAGER, "3", ConsolePlayerIO()),
         HumanPlayer(Role.WEREWOLF, "4", ConsolePlayerIO()),


### PR DESCRIPTION
## Summary
- 狩人（HUNTER）役職を追加
- 2日目の夜から護衛対象を選択し、護衛対象と人狼の襲撃対象が一致した場合に襲撃を失敗させる
- 夜のアクション解決を `attackIfNotGuarded` / `revealNightSecrets` に分離し、将来の複数人狼にも対応できる構造に整理

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)