### PR TITLE
Split nightAction into firstNightAction and normalNightAction

### DIFF
--- a/src/main/kotlin/HumanPlayer.kt
+++ b/src/main/kotlin/HumanPlayer.kt
@@ -5,8 +5,8 @@ class HumanPlayer(override val role: Role, override val name: String, private va
         io.sendMessage(name, "役職通知", "あなたの役職は「${role.displayName}」です。")
     }
 
-    override fun nightAction(players: List<Player>, nightNumber: Int): NightAction =
-        role.nightAction(this, players, io, nightNumber)
+    override fun nightAction(players: List<Player>, isFirstNight: Boolean): NightAction =
+        role.nightAction(this, players, io, isFirstNight)
 
     override fun vote(players: List<Player>): Player {
         val candidates = players.filterNot { it === this }

--- a/src/main/kotlin/Player.kt
+++ b/src/main/kotlin/Player.kt
@@ -4,7 +4,7 @@ interface Player {
     val name: String
     val role: Role
     fun notifyRole()
-    fun nightAction(players: List<Player>, nightNumber: Int): NightAction
+    fun nightAction(players: List<Player>, isFirstNight: Boolean): NightAction
     fun vote(players: List<Player>): Player
     fun onPlayerExecuted(player: Player)
     fun onPlayerAttacked(player: Player)

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -21,7 +21,7 @@ class PlayerManager(allPlayers: List<Player>) {
     }
 
     fun runNightActions(nightNumber: Int) {
-        val decisions = _alivePlayers.map { it to it.nightAction(_alivePlayers, nightNumber) }
+        val decisions = _alivePlayers.map { it to it.nightAction(_alivePlayers, nightNumber == 1) }
 
         val attacks = decisions.map { it.second }.filterIsInstance<NightAction.Attack>()
         val guards = decisions.map { it.second }.filterIsInstance<NightAction.Guard>()

--- a/src/main/kotlin/Role.kt
+++ b/src/main/kotlin/Role.kt
@@ -2,39 +2,44 @@ package org.example
 
 enum class Role(val displayName: String, val side: Side, val divineResult: DivineResult, val mediumResult: MediumResult) {
     WEREWOLF("人狼", Side.WEREWOLF, DivineResult.WEREWOLF, MediumResult.WEREWOLF) {
-        override fun nightAction(self: Player, players: List<Player>, io: PlayerIO, nightNumber: Int): NightAction {
-            if (nightNumber == 1) return NightAction.None
+        override fun firstNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction = NightAction.None
+        override fun normalNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction {
             val candidates = players.filterNot { it === self }
             val target = io.prompt(self.name, "夜の行動", "襲撃先を選んでください", candidates)
             return NightAction.Attack(target)
         }
     },
     SEER("占い師", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
-        override fun nightAction(self: Player, players: List<Player>, io: PlayerIO, nightNumber: Int): NightAction {
+        override fun firstNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction {
+            val target = players.filterNot { it === self }.random()
+            return NightAction.Divine(target)
+        }
+        override fun normalNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction {
             val candidates = players.filterNot { it === self }
-            val target = if (nightNumber == 1)
-                candidates.random()
-            else
-                io.prompt(self.name, "夜の行動", "占う対象を選んでください", candidates)
+            val target = io.prompt(self.name, "夜の行動", "占う対象を選んでください", candidates)
             return NightAction.Divine(target)
         }
     },
     MEDIUM("霊能者", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
-        override fun nightAction(self: Player, players: List<Player>, io: PlayerIO, nightNumber: Int): NightAction =
-            NightAction.MediumReveal
+        override fun firstNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction = NightAction.MediumReveal
+        override fun normalNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction = NightAction.MediumReveal
     },
     VILLAGER("村人", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
-        override fun nightAction(self: Player, players: List<Player>, io: PlayerIO, nightNumber: Int): NightAction =
-            NightAction.None
+        override fun firstNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction = NightAction.None
+        override fun normalNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction = NightAction.None
     },
     HUNTER("狩人", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
-        override fun nightAction(self: Player, players: List<Player>, io: PlayerIO, nightNumber: Int): NightAction {
-            if (nightNumber == 1) return NightAction.None
+        override fun firstNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction = NightAction.None
+        override fun normalNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction {
             val candidates = players.filterNot { it === self }
             val target = io.prompt(self.name, "夜の行動", "護衛する対象を選んでください", candidates)
             return NightAction.Guard(target)
         }
     };
 
-    abstract fun nightAction(self: Player, players: List<Player>, io: PlayerIO, nightNumber: Int): NightAction
+    abstract fun firstNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction
+    abstract fun normalNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction
+
+    fun nightAction(self: Player, players: List<Player>, io: PlayerIO, isFirstNight: Boolean): NightAction =
+        if (isFirstNight) firstNightAction(self, players, io) else normalNightAction(self, players, io)
 }


### PR DESCRIPTION
## Summary
- `nightAction` を `firstNightAction` / `normalNightAction` に分割し、振り分けを基底メソッドに集約
- 各役職は両メソッドを `abstract` として明示的に実装する形に変更（実装漏れをコンパイルエラーで検出できる）
- `nightNumber: Int` を `isFirstNight: Boolean` に変更し、`PlayerManager` 側で評価して渡す

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)