### PR TITLE
Add discussion phase between night actions and voting

### DIFF
--- a/src/main/kotlin/ConsolePlayerIO.kt
+++ b/src/main/kotlin/ConsolePlayerIO.kt
@@ -16,7 +16,7 @@ class ConsolePlayerIO : PlayerIO {
         }
     }
 
-    override fun promptText(playerName: String, title: String, content: String): String {
+    override fun promptFreeText(playerName: String, title: String, content: String): String {
         sendMessage(playerName, title, content)
         return readLine() ?: ""
     }

--- a/src/main/kotlin/ConsolePlayerIO.kt
+++ b/src/main/kotlin/ConsolePlayerIO.kt
@@ -15,4 +15,9 @@ class ConsolePlayerIO : PlayerIO {
             println("「$input」は候補にいません。もう一度入力してください。")
         }
     }
+
+    override fun promptText(playerName: String, title: String, content: String): String {
+        sendMessage(playerName, title, content)
+        return readLine() ?: ""
+    }
 }

--- a/src/main/kotlin/HumanPlayer.kt
+++ b/src/main/kotlin/HumanPlayer.kt
@@ -34,6 +34,14 @@ class HumanPlayer(override val role: Role, override val name: String, private va
         io.sendMessage(name, "霊視結果", "${target.name} は「${result.displayName}」です。")
     }
 
+    override fun discuss(players: List<Player>): String =
+        io.promptText(name, "議論", "発言してください")
+
+    override fun onDiscussionRound(round: Int, statements: List<Pair<String, String>>) {
+        val content = statements.joinToString("\n") { (speaker, statement) -> "$speaker: $statement" }
+        io.sendMessage(name, "議論（${round}ラウンド目）結果", content)
+    }
+
     override fun onPlayerAttacked(player: Player) {
         if (player === this) {
             io.sendMessage(name, "襲撃通知", "あなたは襲撃されました。")

--- a/src/main/kotlin/HumanPlayer.kt
+++ b/src/main/kotlin/HumanPlayer.kt
@@ -35,7 +35,7 @@ class HumanPlayer(override val role: Role, override val name: String, private va
     }
 
     override fun discuss(players: List<Player>): String =
-        io.promptText(name, "議論", "発言してください")
+        io.promptFreeText(name, "議論", "発言してください")
 
     override fun onDiscussionRound(round: Int, statements: List<Pair<String, String>>) {
         val content = statements.joinToString("\n") { (speaker, statement) -> "$speaker: $statement" }

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -8,9 +8,7 @@ fun main() {
     var nightNumber = 1
     try {
         while (true) {
-            manager.runNightActions(nightNumber)
-            manager.runDiscussion()
-            manager.runVoting()
+            manager.runTurn(nightNumber)
             nightNumber++
         }
     } catch (signal: GameOverSignal) {

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -9,6 +9,7 @@ fun main() {
     try {
         while (true) {
             manager.runNightActions(nightNumber)
+            manager.runDiscussion()
             manager.runVoting()
             nightNumber++
         }

--- a/src/main/kotlin/Player.kt
+++ b/src/main/kotlin/Player.kt
@@ -10,5 +10,7 @@ interface Player {
     fun onPlayerAttacked(player: Player)
     fun onDivineResult(target: Player, result: DivineResult)
     fun onMediumReveal(target: Player, result: MediumResult)
+    fun discuss(players: List<Player>): String
+    fun onDiscussionRound(round: Int, statements: List<Pair<String, String>>)
     fun onGameOver(winnerSide: Side)
 }

--- a/src/main/kotlin/PlayerIO.kt
+++ b/src/main/kotlin/PlayerIO.kt
@@ -3,5 +3,5 @@ package org.example
 interface PlayerIO {
     fun sendMessage(playerName: String, title: String, content: String)
     fun prompt(playerName: String, title: String, content: String, candidates: List<Player>): Player
-    fun promptText(playerName: String, title: String, content: String): String
+    fun promptFreeText(playerName: String, title: String, content: String): String
 }

--- a/src/main/kotlin/PlayerIO.kt
+++ b/src/main/kotlin/PlayerIO.kt
@@ -3,4 +3,5 @@ package org.example
 interface PlayerIO {
     fun sendMessage(playerName: String, title: String, content: String)
     fun prompt(playerName: String, title: String, content: String, candidates: List<Player>): Player
+    fun promptText(playerName: String, title: String, content: String): String
 }

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -1,6 +1,10 @@
 package org.example
 
 class PlayerManager(allPlayers: List<Player>) {
+    companion object {
+        private const val DISCUSSION_ROUNDS = 3
+    }
+
     private val _allPlayers: List<Player> = allPlayers
     private val _alivePlayers: MutableList<Player> = _allPlayers.toMutableList()
     private val _executedPlayers: MutableList<Player> = mutableListOf()
@@ -20,7 +24,7 @@ class PlayerManager(allPlayers: List<Player>) {
         _allPlayers.forEach { it.notifyRole() }
     }
 
-    fun runNightActions(nightNumber: Int) {
+    private fun runNightActions(nightNumber: Int) {
         val decisions = _alivePlayers.map { it to it.nightAction(_alivePlayers, nightNumber == 1) }
 
         val attacks = decisions.map { it.second }.filterIsInstance<NightAction.Attack>()
@@ -49,14 +53,20 @@ class PlayerManager(allPlayers: List<Player>) {
         if (guards.none { it.target === target }) attack(target)
     }
 
-    fun runDiscussion() {
-        repeat(3) { index ->
+    fun runTurn(nightNumber: Int) {
+        runNightActions(nightNumber)
+        runDiscussion()
+        runVoting()
+    }
+
+    private fun runDiscussion() {
+        repeat(DISCUSSION_ROUNDS) { index ->
             val statements = _alivePlayers.map { it.name to it.discuss(_alivePlayers) }
             _alivePlayers.forEach { it.onDiscussionRound(index + 1, statements) }
         }
     }
 
-    fun runVoting() {
+    private fun runVoting() {
         val votes = _alivePlayers.map { it.vote(_alivePlayers) }
         val mostVoted = votes.groupBy { it }.maxBy { it.value.size }.key
         execute(mostVoted)

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -49,6 +49,13 @@ class PlayerManager(allPlayers: List<Player>) {
         if (guards.none { it.target === target }) attack(target)
     }
 
+    fun runDiscussion() {
+        repeat(3) { index ->
+            val statements = _alivePlayers.map { it.name to it.discuss(_alivePlayers) }
+            _alivePlayers.forEach { it.onDiscussionRound(index + 1, statements) }
+        }
+    }
+
     fun runVoting() {
         val votes = _alivePlayers.map { it.vote(_alivePlayers) }
         val mostVoted = votes.groupBy { it }.maxBy { it.value.size }.key


### PR DESCRIPTION
Closes #10

## Summary

- 夜行動と投票の間に議論フェーズを追加
- 各プレイヤーが個別に発言を入力し、全員の発言が揃ったらまとめて公開する、というラウンドを3回繰り返す
- `PlayerIO.promptText()` で自由記述入力を追加、`Player.discuss()` / `onDiscussionRound()` で議論の入出力を担当

## Test plan

- [ ] ゲームを起動し、夜行動後に議論フェーズが始まることを確認
- [ ] 各プレイヤーが順番に発言を求められることを確認
- [ ] 全員の発言が揃ったら全員に公開されることを確認
- [ ] 3ラウンド繰り返した後、投票フェーズに進むことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)