### PR TITLE
Separate role mechanics from decision-making in Player/Role

### DIFF
--- a/src/main/kotlin/HumanPlayer.kt
+++ b/src/main/kotlin/HumanPlayer.kt
@@ -5,13 +5,8 @@ class HumanPlayer(override val role: Role, override val name: String, private va
         io.sendMessage(name, "役職通知", "あなたの役職は「${role.displayName}」です。")
     }
 
-    override fun nightAction(players: List<Player>, isFirstNight: Boolean): NightAction =
-        role.nightAction(this, players, io, isFirstNight)
-
-    override fun vote(players: List<Player>): Player {
-        val candidates = players.filterNot { it === this }
-        return io.prompt(name, "投票", "投票先を選んでください", candidates)
-    }
+    override fun selectTarget(players: List<Player>, context: SelectionContext): Player =
+        io.prompt(name, context.title, context.description, context.candidates(this, players))
 
     override fun onGameOver(winnerSide: Side) {
         val result = if (role.side == winnerSide) "勝利" else "敗北"

--- a/src/main/kotlin/Player.kt
+++ b/src/main/kotlin/Player.kt
@@ -4,8 +4,7 @@ interface Player {
     val name: String
     val role: Role
     fun notifyRole()
-    fun nightAction(players: List<Player>, isFirstNight: Boolean): NightAction
-    fun vote(players: List<Player>): Player
+    fun selectTarget(players: List<Player>, context: SelectionContext): Player
     fun onPlayerExecuted(player: Player)
     fun onPlayerAttacked(player: Player)
     fun onDivineResult(target: Player, result: DivineResult)

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -25,7 +25,7 @@ class PlayerManager(allPlayers: List<Player>) {
     }
 
     private fun runNightActions(nightNumber: Int) {
-        val decisions = _alivePlayers.map { it to it.nightAction(_alivePlayers, nightNumber == 1) }
+        val decisions = _alivePlayers.map { it to it.role.buildNightAction(it, _alivePlayers, nightNumber == 1) }
 
         val attacks = decisions.map { it.second }.filterIsInstance<NightAction.Attack>()
         val guards = decisions.map { it.second }.filterIsInstance<NightAction.Guard>()
@@ -67,7 +67,7 @@ class PlayerManager(allPlayers: List<Player>) {
     }
 
     private fun runVoting() {
-        val votes = _alivePlayers.map { it.vote(_alivePlayers) }
+        val votes = _alivePlayers.map { it.selectTarget(_alivePlayers, SelectionContext.VOTE) }
         val mostVoted = votes.groupBy { it }.maxBy { it.value.size }.key
         execute(mostVoted)
     }

--- a/src/main/kotlin/Role.kt
+++ b/src/main/kotlin/Role.kt
@@ -2,44 +2,33 @@ package org.example
 
 enum class Role(val displayName: String, val side: Side, val divineResult: DivineResult, val mediumResult: MediumResult) {
     WEREWOLF("人狼", Side.WEREWOLF, DivineResult.WEREWOLF, MediumResult.WEREWOLF) {
-        override fun firstNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction = NightAction.None
-        override fun normalNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction {
-            val candidates = players.filterNot { it === self }
-            val target = io.prompt(self.name, "夜の行動", "襲撃先を選んでください", candidates)
-            return NightAction.Attack(target)
-        }
+        override fun firstNightAction(self: Player, players: List<Player>): NightAction = NightAction.None
+        override fun normalNightAction(self: Player, players: List<Player>): NightAction =
+            NightAction.Attack(self.selectTarget(players, SelectionContext.ATTACK))
     },
     SEER("占い師", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
-        override fun firstNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction {
-            val target = players.filterNot { it === self }.random()
-            return NightAction.Divine(target)
-        }
-        override fun normalNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction {
-            val candidates = players.filterNot { it === self }
-            val target = io.prompt(self.name, "夜の行動", "占う対象を選んでください", candidates)
-            return NightAction.Divine(target)
-        }
+        override fun firstNightAction(self: Player, players: List<Player>): NightAction =
+            NightAction.Divine(SelectionContext.DIVINE.candidates(self, players).random())
+        override fun normalNightAction(self: Player, players: List<Player>): NightAction =
+            NightAction.Divine(self.selectTarget(players, SelectionContext.DIVINE))
     },
     MEDIUM("霊能者", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
-        override fun firstNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction = NightAction.MediumReveal
-        override fun normalNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction = NightAction.MediumReveal
+        override fun firstNightAction(self: Player, players: List<Player>): NightAction = NightAction.MediumReveal
+        override fun normalNightAction(self: Player, players: List<Player>): NightAction = NightAction.MediumReveal
     },
     VILLAGER("村人", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
-        override fun firstNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction = NightAction.None
-        override fun normalNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction = NightAction.None
+        override fun firstNightAction(self: Player, players: List<Player>): NightAction = NightAction.None
+        override fun normalNightAction(self: Player, players: List<Player>): NightAction = NightAction.None
     },
     HUNTER("狩人", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
-        override fun firstNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction = NightAction.None
-        override fun normalNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction {
-            val candidates = players.filterNot { it === self }
-            val target = io.prompt(self.name, "夜の行動", "護衛する対象を選んでください", candidates)
-            return NightAction.Guard(target)
-        }
+        override fun firstNightAction(self: Player, players: List<Player>): NightAction = NightAction.None
+        override fun normalNightAction(self: Player, players: List<Player>): NightAction =
+            NightAction.Guard(self.selectTarget(players, SelectionContext.GUARD))
     };
 
-    abstract fun firstNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction
-    abstract fun normalNightAction(self: Player, players: List<Player>, io: PlayerIO): NightAction
+    abstract fun firstNightAction(self: Player, players: List<Player>): NightAction
+    abstract fun normalNightAction(self: Player, players: List<Player>): NightAction
 
-    fun nightAction(self: Player, players: List<Player>, io: PlayerIO, isFirstNight: Boolean): NightAction =
-        if (isFirstNight) firstNightAction(self, players, io) else normalNightAction(self, players, io)
+    fun buildNightAction(self: Player, players: List<Player>, isFirstNight: Boolean): NightAction =
+        if (isFirstNight) firstNightAction(self, players) else normalNightAction(self, players)
 }

--- a/src/main/kotlin/SelectionContext.kt
+++ b/src/main/kotlin/SelectionContext.kt
@@ -1,0 +1,10 @@
+package org.example
+
+enum class SelectionContext(val title: String, val description: String) {
+    ATTACK("夜の行動", "襲撃先を選んでください"),
+    DIVINE("夜の行動", "占う対象を選んでください"),
+    GUARD("夜の行動", "護衛する対象を選んでください"),
+    VOTE("投票", "投票先を選んでください");
+
+    fun candidates(self: Player, players: List<Player>): List<Player> = players.filterNot { it === self }
+}


### PR DESCRIPTION
## Summary

- `Role` から `PlayerIO` 依存を除去し、ゲームルールの純粋な計算オブジェクトとして分離
- `Player` インターフェースの `nightAction()` / `vote()` を `selectTarget(players, context)` に統一
- `SelectionContext` enum を新設し、UI ラベルと候補絞り込みルールをコンテキストごとに一元管理

## Test plan

- [ ] ビルドが通ること (`./gradlew build`)
- [ ] ゲームを実行し、夜の行動（人狼の襲撃・占い師の占い・狩人の護衛）が正常に動作すること
- [ ] 投票フェーズが正常に動作すること
- [ ] 動作の変化がないこと（リファクタリングのみ）

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)