### PR TITLE
Seer always divines a non-werewolf on the first night

### DIFF
--- a/src/main/kotlin/Role.kt
+++ b/src/main/kotlin/Role.kt
@@ -8,7 +8,7 @@ enum class Role(val displayName: String, val side: Side, val divineResult: Divin
     },
     SEER("占い師", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
         override fun firstNightAction(self: Player, players: List<Player>): NightAction =
-            NightAction.Divine(SelectionContext.DIVINE.candidates(self, players).random())
+            NightAction.Divine(SelectionContext.FIRST_DIVINE.candidates(self, players).random())
         override fun normalNightAction(self: Player, players: List<Player>): NightAction =
             NightAction.Divine(self.selectTarget(players, SelectionContext.DIVINE))
     },

--- a/src/main/kotlin/Role.kt
+++ b/src/main/kotlin/Role.kt
@@ -8,7 +8,7 @@ enum class Role(val displayName: String, val side: Side, val divineResult: Divin
     },
     SEER("占い師", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
         override fun firstNightAction(self: Player, players: List<Player>): NightAction =
-            NightAction.Divine(SelectionContext.FIRST_DIVINE.candidates(self, players).random())
+            NightAction.Divine(FirstDivineFilter.candidates(self, players).random())
         override fun normalNightAction(self: Player, players: List<Player>): NightAction =
             NightAction.Divine(self.selectTarget(players, SelectionContext.DIVINE))
     },

--- a/src/main/kotlin/SelectionContext.kt
+++ b/src/main/kotlin/SelectionContext.kt
@@ -1,14 +1,17 @@
 package org.example
 
-enum class SelectionContext(val title: String, val description: String) {
+interface CandidateFilter {
+    fun candidates(self: Player, players: List<Player>): List<Player> = players.filterNot { it === self }
+}
+
+enum class SelectionContext(val title: String, val description: String) : CandidateFilter {
     ATTACK("夜の行動", "襲撃先を選んでください"),
     DIVINE("夜の行動", "占う対象を選んでください"),
-    FIRST_DIVINE("夜の行動", "占う対象を選んでください") {
-        override fun candidates(self: Player, players: List<Player>): List<Player> =
-            super.candidates(self, players).filter { it.role.divineResult == DivineResult.NOT_WEREWOLF }
-    },
     GUARD("夜の行動", "護衛する対象を選んでください"),
-    VOTE("投票", "投票先を選んでください");
+    VOTE("投票", "投票先を選んでください"),
+}
 
-    open fun candidates(self: Player, players: List<Player>): List<Player> = players.filterNot { it === self }
+object FirstDivineFilter : CandidateFilter {
+    override fun candidates(self: Player, players: List<Player>): List<Player> =
+        super.candidates(self, players).filter { it.role.divineResult == DivineResult.NOT_WEREWOLF }
 }

--- a/src/main/kotlin/SelectionContext.kt
+++ b/src/main/kotlin/SelectionContext.kt
@@ -3,8 +3,12 @@ package org.example
 enum class SelectionContext(val title: String, val description: String) {
     ATTACK("夜の行動", "襲撃先を選んでください"),
     DIVINE("夜の行動", "占う対象を選んでください"),
+    FIRST_DIVINE("夜の行動", "占う対象を選んでください") {
+        override fun candidates(self: Player, players: List<Player>): List<Player> =
+            super.candidates(self, players).filter { it.role.divineResult == DivineResult.NOT_WEREWOLF }
+    },
     GUARD("夜の行動", "護衛する対象を選んでください"),
     VOTE("投票", "投票先を選んでください");
 
-    fun candidates(self: Player, players: List<Player>): List<Player> = players.filterNot { it === self }
+    open fun candidates(self: Player, players: List<Player>): List<Player> = players.filterNot { it === self }
 }


### PR DESCRIPTION
## Summary

- `SelectionContext.FIRST_DIVINE` を追加。`candidates()` を override し、人狼（`divineResult == DivineResult.WEREWOLF`）を候補から除外
- `Role.SEER.firstNightAction` で `FIRST_DIVINE` を使用するよう変更

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)