### PR TITLE
Redesign SelectionContext as sealed class to enforce candidate filtering

### DIFF
--- a/src/main/kotlin/HumanPlayer.kt
+++ b/src/main/kotlin/HumanPlayer.kt
@@ -5,8 +5,8 @@ class HumanPlayer(override val role: Role, override val name: String, private va
         io.sendMessage(name, "役職通知", "あなたの役職は「${role.displayName}」です。")
     }
 
-    override fun selectTarget(players: List<Player>, context: SelectionContext): Player =
-        io.prompt(name, context.title, context.description, context.candidates(this, players))
+    override fun selectTarget(context: SelectionContext): Player =
+        io.prompt(name, context.title, context.description, context.candidates())
 
     override fun onGameOver(winnerSide: Side) {
         val result = if (role.side == winnerSide) "勝利" else "敗北"

--- a/src/main/kotlin/Player.kt
+++ b/src/main/kotlin/Player.kt
@@ -4,7 +4,7 @@ interface Player {
     val name: String
     val role: Role
     fun notifyRole()
-    fun selectTarget(players: List<Player>, context: SelectionContext): Player
+    fun selectTarget(context: SelectionContext): Player
     fun onPlayerExecuted(player: Player)
     fun onPlayerAttacked(player: Player)
     fun onDivineResult(target: Player, result: DivineResult)

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -67,7 +67,7 @@ class PlayerManager(allPlayers: List<Player>) {
     }
 
     private fun runVoting() {
-        val votes = _alivePlayers.map { it.selectTarget(_alivePlayers, SelectionContext.VOTE) }
+        val votes = _alivePlayers.map { it.selectTarget(SelectionContext.Vote(it, _alivePlayers)) }
         val mostVoted = votes.groupBy { it }.maxBy { it.value.size }.key
         execute(mostVoted)
     }

--- a/src/main/kotlin/Role.kt
+++ b/src/main/kotlin/Role.kt
@@ -4,13 +4,13 @@ enum class Role(val displayName: String, val side: Side, val divineResult: Divin
     WEREWOLF("人狼", Side.WEREWOLF, DivineResult.WEREWOLF, MediumResult.WEREWOLF) {
         override fun firstNightAction(self: Player, players: List<Player>): NightAction = NightAction.None
         override fun normalNightAction(self: Player, players: List<Player>): NightAction =
-            NightAction.Attack(self.selectTarget(players, SelectionContext.ATTACK))
+            NightAction.Attack(self.selectTarget(SelectionContext.Attack(self, players)))
     },
     SEER("占い師", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
         override fun firstNightAction(self: Player, players: List<Player>): NightAction =
             NightAction.Divine(FirstDivineFilter.candidates(self, players).random())
         override fun normalNightAction(self: Player, players: List<Player>): NightAction =
-            NightAction.Divine(self.selectTarget(players, SelectionContext.DIVINE))
+            NightAction.Divine(self.selectTarget(SelectionContext.Divine(self, players)))
     },
     MEDIUM("霊能者", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
         override fun firstNightAction(self: Player, players: List<Player>): NightAction = NightAction.MediumReveal
@@ -23,7 +23,7 @@ enum class Role(val displayName: String, val side: Side, val divineResult: Divin
     HUNTER("狩人", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
         override fun firstNightAction(self: Player, players: List<Player>): NightAction = NightAction.None
         override fun normalNightAction(self: Player, players: List<Player>): NightAction =
-            NightAction.Guard(self.selectTarget(players, SelectionContext.GUARD))
+            NightAction.Guard(self.selectTarget(SelectionContext.Guard(self, players)))
     };
 
     abstract fun firstNightAction(self: Player, players: List<Player>): NightAction

--- a/src/main/kotlin/SelectionContext.kt
+++ b/src/main/kotlin/SelectionContext.kt
@@ -1,17 +1,30 @@
 package org.example
 
-interface CandidateFilter {
-    fun candidates(self: Player, players: List<Player>): List<Player> = players.filterNot { it === self }
+sealed class SelectionContext(val title: String, val description: String) {
+    abstract fun candidates(): List<Player>
+
+    class Attack(private val self: Player, private val players: List<Player>)
+        : SelectionContext("夜の行動", "襲撃先を選んでください") {
+        override fun candidates() = players.filterNot { it === self }
+    }
+
+    class Divine(private val self: Player, private val players: List<Player>)
+        : SelectionContext("夜の行動", "占う対象を選んでください") {
+        override fun candidates() = players.filterNot { it === self }
+    }
+
+    class Guard(private val self: Player, private val players: List<Player>)
+        : SelectionContext("夜の行動", "護衛する対象を選んでください") {
+        override fun candidates() = players.filterNot { it === self }
+    }
+
+    class Vote(private val self: Player, private val players: List<Player>)
+        : SelectionContext("投票", "投票先を選んでください") {
+        override fun candidates() = players.filterNot { it === self }
+    }
 }
 
-enum class SelectionContext(val title: String, val description: String) : CandidateFilter {
-    ATTACK("夜の行動", "襲撃先を選んでください"),
-    DIVINE("夜の行動", "占う対象を選んでください"),
-    GUARD("夜の行動", "護衛する対象を選んでください"),
-    VOTE("投票", "投票先を選んでください"),
-}
-
-object FirstDivineFilter : CandidateFilter {
-    override fun candidates(self: Player, players: List<Player>): List<Player> =
-        super.candidates(self, players).filter { it.role.divineResult == DivineResult.NOT_WEREWOLF }
+object FirstDivineFilter {
+    fun candidates(self: Player, players: List<Player>): List<Player> =
+        players.filterNot { it === self }.filter { it.role.divineResult == DivineResult.NOT_WEREWOLF }
 }


### PR DESCRIPTION
## Summary

- `SelectionContext` を enum から sealed class に変更。`self` と `players` をコンストラクタで受け取り、`candidates()` のみ公開する
- `Player.selectTarget` から `players` パラメータを除去。呼び出し側は `context` だけを渡す
- `CandidateFilter` インターフェースを削除。`FirstDivineFilter` はシンプルな object として残す

## Test plan

- [ ] ビルドが通ること
- [ ] 夜の行動・投票が正常に動作すること
- [ ] 動作の変化がないこと（リファクタリングのみ）

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)