### PR TITLE
Exclude werewolves from attack candidates

### DIFF
--- a/src/main/kotlin/SelectionContext.kt
+++ b/src/main/kotlin/SelectionContext.kt
@@ -5,7 +5,7 @@ sealed class SelectionContext(val title: String, val description: String) {
 
     class Attack(private val self: Player, private val players: List<Player>)
         : SelectionContext("夜の行動", "襲撃先を選んでください") {
-        override fun candidates() = players.filterNot { it === self }
+        override fun candidates() = players.filterNot { it === self || it.role == Role.WEREWOLF }
     }
 
     class Divine(private val self: Player, private val players: List<Player>)

--- a/src/main/kotlin/SmallLodge.kt
+++ b/src/main/kotlin/SmallLodge.kt
@@ -8,5 +8,6 @@ object SmallLodge : Lodge {
         HumanPlayer(Role.WEREWOLF, "4", ConsolePlayerIO()),
         HumanPlayer(Role.SEER, "5", ConsolePlayerIO()),
         HumanPlayer(Role.MEDIUM, "6", ConsolePlayerIO()),
+        HumanPlayer(Role.WEREWOLF, "7", ConsolePlayerIO()),
     )
 }


### PR DESCRIPTION
## Summary

- `SelectionContext.Attack.candidates()` で `Role.WEREWOLF` を除外し、人狼が他の人狼を襲撃できないようにした
- `SmallLodge` に2人目の人狼（プレイヤー7）を追加し、複数人狼構成に近づけた

Closes #18