### PR TITLE
Unify player notification methods into GameEvent sealed class

### DIFF
--- a/src/main/kotlin/GameEvent.kt
+++ b/src/main/kotlin/GameEvent.kt
@@ -1,0 +1,42 @@
+package org.example
+
+sealed class GameEvent {
+    abstract val title: String
+    abstract fun body(self: Player): String
+
+    data class PlayerExecuted(val executed: Player) : GameEvent() {
+        override val title = "処刑通知"
+        override fun body(self: Player) =
+            if (executed === self) "あなたは処刑されました。" else "${executed.name} が処刑されました。"
+    }
+
+    data class PlayerAttacked(val attacked: Player) : GameEvent() {
+        override val title = "襲撃通知"
+        override fun body(self: Player) =
+            if (attacked === self) "あなたは襲撃されました。" else "${attacked.name} が襲撃されました。"
+    }
+
+    data class Divined(val target: Player, val result: DivineResult) : GameEvent() {
+        override val title = "占い結果"
+        override fun body(self: Player) = "${target.name} は「${result.displayName}」です。"
+    }
+
+    data class MediumRevealed(val target: Player, val result: MediumResult) : GameEvent() {
+        override val title = "霊視結果"
+        override fun body(self: Player) = "${target.name} は「${result.displayName}」です。"
+    }
+
+    data class DiscussionRound(val round: Int, val statements: List<Pair<String, String>>) : GameEvent() {
+        override val title = "議論（${round}ラウンド目）結果"
+        override fun body(self: Player) =
+            statements.joinToString("\n") { (speaker, statement) -> "$speaker: $statement" }
+    }
+
+    data class GameOver(val winnerSide: Side) : GameEvent() {
+        override val title = "ゲーム終了"
+        override fun body(self: Player): String {
+            val result = if (self.role.side == winnerSide) "勝利" else "敗北"
+            return "${winnerSide.displayName}陣営の勝利です！あなたは${result}しました。"
+        }
+    }
+}

--- a/src/main/kotlin/HumanPlayer.kt
+++ b/src/main/kotlin/HumanPlayer.kt
@@ -8,40 +8,10 @@ class HumanPlayer(override val role: Role, override val name: String, private va
     override fun selectTarget(context: SelectionContext): Player =
         io.prompt(name, context.title, context.description, context.candidates())
 
-    override fun onGameOver(winnerSide: Side) {
-        val result = if (role.side == winnerSide) "勝利" else "敗北"
-        io.sendMessage(name, "ゲーム終了", "${winnerSide.displayName}陣営の勝利です！あなたは${result}しました。")
-    }
-
-    override fun onPlayerExecuted(player: Player) {
-        if (player === this) {
-            io.sendMessage(name, "処刑通知", "あなたは処刑されました。")
-        } else {
-            io.sendMessage(name, "処刑通知", "${player.name} が処刑されました。")
-        }
-    }
-
-    override fun onDivineResult(target: Player, result: DivineResult) {
-        io.sendMessage(name, "占い結果", "${target.name} は「${result.displayName}」です。")
-    }
-
-    override fun onMediumReveal(target: Player, result: MediumResult) {
-        io.sendMessage(name, "霊視結果", "${target.name} は「${result.displayName}」です。")
+    override fun receive(event: GameEvent) {
+        io.sendMessage(name, event.title, event.body(this))
     }
 
     override fun discuss(players: List<Player>): String =
         io.promptFreeText(name, "議論", "発言してください")
-
-    override fun onDiscussionRound(round: Int, statements: List<Pair<String, String>>) {
-        val content = statements.joinToString("\n") { (speaker, statement) -> "$speaker: $statement" }
-        io.sendMessage(name, "議論（${round}ラウンド目）結果", content)
-    }
-
-    override fun onPlayerAttacked(player: Player) {
-        if (player === this) {
-            io.sendMessage(name, "襲撃通知", "あなたは襲撃されました。")
-        } else {
-            io.sendMessage(name, "襲撃通知", "${player.name} が襲撃されました。")
-        }
-    }
 }

--- a/src/main/kotlin/Player.kt
+++ b/src/main/kotlin/Player.kt
@@ -5,11 +5,6 @@ interface Player {
     val role: Role
     fun notifyRole()
     fun selectTarget(context: SelectionContext): Player
-    fun onPlayerExecuted(player: Player)
-    fun onPlayerAttacked(player: Player)
-    fun onDivineResult(target: Player, result: DivineResult)
-    fun onMediumReveal(target: Player, result: MediumResult)
+    fun receive(event: GameEvent)
     fun discuss(players: List<Player>): String
-    fun onDiscussionRound(round: Int, statements: List<Pair<String, String>>)
-    fun onGameOver(winnerSide: Side)
 }

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -40,9 +40,9 @@ class PlayerManager(allPlayers: List<Player>) {
                 is NightAction.None -> Unit
                 is NightAction.Attack -> Unit
                 is NightAction.Guard -> Unit
-                is NightAction.Divine -> player.onDivineResult(decision.target, decision.target.role.divineResult)
+                is NightAction.Divine -> player.receive(GameEvent.Divined(decision.target, decision.target.role.divineResult))
                 is NightAction.MediumReveal -> _executedPlayers.lastOrNull()?.let { target ->
-                    player.onMediumReveal(target, target.role.mediumResult)
+                    player.receive(GameEvent.MediumRevealed(target, target.role.mediumResult))
                 }
             }
         }
@@ -62,7 +62,7 @@ class PlayerManager(allPlayers: List<Player>) {
     private fun runDiscussion() {
         repeat(DISCUSSION_ROUNDS) { index ->
             val statements = _alivePlayers.map { it.name to it.discuss(_alivePlayers) }
-            _alivePlayers.forEach { it.onDiscussionRound(index + 1, statements) }
+            _alivePlayers.forEach { it.receive(GameEvent.DiscussionRound(index + 1, statements)) }
         }
     }
 
@@ -73,17 +73,17 @@ class PlayerManager(allPlayers: List<Player>) {
     }
 
     fun endGame(signal: GameOverSignal) {
-        _allPlayers.forEach { it.onGameOver(signal.winningSide) }
+        _allPlayers.forEach { it.receive(GameEvent.GameOver(signal.winningSide)) }
     }
 
     private fun execute(mostVoted: Player) {
-        _allPlayers.forEach { it.onPlayerExecuted(mostVoted) }
+        _allPlayers.forEach { it.receive(GameEvent.PlayerExecuted(executed = mostVoted)) }
         _executedPlayers.add(mostVoted)
         die(mostVoted)
     }
 
     private fun attack(target: Player) {
-        _allPlayers.forEach { it.onPlayerAttacked(target) }
+        _allPlayers.forEach { it.receive(GameEvent.PlayerAttacked(attacked = target)) }
         _attackedPlayers.add(target)
         die(target)
     }


### PR DESCRIPTION
## Summary

- `GameEvent` sealed class を新規追加し、全イベントを集約
- `Player` インターフェースの `onXxx` メソッド群を `receive(event: GameEvent)` に統一
- メッセージのタイトル・本文は `GameEvent` が `title` / `body(self)` として保持し、`HumanPlayer.receive` は `io.sendMessage` の1行のみ
- `GameEvent.Divined` / `GameEvent.MediumRevealed` と enum `DivineResult` / `MediumResult` の名前衝突を回避

Closes #20