### PR TITLE
Resolve attack and vote targets by majority vote with random tiebreaking

### DIFF
--- a/src/main/kotlin/MajorityVoteResolver.kt
+++ b/src/main/kotlin/MajorityVoteResolver.kt
@@ -1,0 +1,10 @@
+package org.example
+
+object MajorityVoteResolver {
+    fun <T> resolve(votes: List<T>): T? {
+        if (votes.isEmpty()) return null
+        val countByCandidate = votes.groupingBy { it }.eachCount()
+        val maxCount = countByCandidate.values.max()
+        return countByCandidate.filter { it.value == maxCount }.keys.random()
+    }
+}

--- a/src/main/kotlin/MajorityVoteResolver.kt
+++ b/src/main/kotlin/MajorityVoteResolver.kt
@@ -3,6 +3,15 @@ package org.example
 object MajorityVoteResolver {
     fun <T> resolve(votes: List<T>): T? {
         if (votes.isEmpty()) return null
+        return majority(votes)
+    }
+
+    fun <T> resolveNonEmpty(votes: List<T>): T {
+        require(votes.isNotEmpty()) { "votes must not be empty" }
+        return majority(votes)
+    }
+
+    private fun <T> majority(votes: List<T>): T {
         val countByCandidate = votes.groupingBy { it }.eachCount()
         val maxCount = countByCandidate.values.max()
         return countByCandidate.filter { it.value == maxCount }.keys.random()

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -68,7 +68,7 @@ class PlayerManager(allPlayers: List<Player>) {
 
     private fun runVoting() {
         val votes = _alivePlayers.map { it.selectTarget(SelectionContext.Vote(it, _alivePlayers)) }
-        val mostVoted = MajorityVoteResolver.resolve(votes) ?: return
+        val mostVoted = MajorityVoteResolver.resolveNonEmpty(votes)
         execute(mostVoted)
     }
 

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -49,7 +49,7 @@ class PlayerManager(allPlayers: List<Player>) {
     }
 
     private fun attackIfNotGuarded(attacks: List<NightAction.Attack>, guards: List<NightAction.Guard>) {
-        val target = attacks.firstOrNull()?.target ?: return
+        val target = MajorityVoteResolver.resolve(attacks.map { it.target }) ?: return
         if (guards.none { it.target === target }) attack(target)
     }
 
@@ -68,7 +68,7 @@ class PlayerManager(allPlayers: List<Player>) {
 
     private fun runVoting() {
         val votes = _alivePlayers.map { it.selectTarget(SelectionContext.Vote(it, _alivePlayers)) }
-        val mostVoted = votes.groupBy { it }.maxBy { it.value.size }.key
+        val mostVoted = MajorityVoteResolver.resolve(votes) ?: return
         execute(mostVoted)
     }
 

--- a/src/test/kotlin/MajorityVoteResolverTest.kt
+++ b/src/test/kotlin/MajorityVoteResolverTest.kt
@@ -1,0 +1,38 @@
+package org.example
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertContains
+
+class MajorityVoteResolverTest {
+
+    @Test
+    fun `returns null for empty votes`() {
+        assertNull(MajorityVoteResolver.resolve(emptyList<String>()))
+    }
+
+    @Test
+    fun `returns the only candidate when all votes are the same`() {
+        assertEquals("A", MajorityVoteResolver.resolve(listOf("A", "A", "A")))
+    }
+
+    @Test
+    fun `returns the majority candidate`() {
+        assertEquals("B", MajorityVoteResolver.resolve(listOf("A", "B", "B")))
+    }
+
+    @Test
+    fun `returns one of the tied candidates when votes are split evenly`() {
+        val tied = setOf("A", "B")
+        val results = (1..100).map { MajorityVoteResolver.resolve(listOf("A", "B")) }.toSet()
+        assertEquals(tied, results)
+    }
+
+    @Test
+    fun `returns one of the top tied candidates ignoring lower-voted ones`() {
+        val tied = setOf("A", "B")
+        val results = (1..100).map { MajorityVoteResolver.resolve(listOf("A", "A", "B", "B", "C")) }.toSet()
+        assertEquals(tied, results)
+    }
+}

--- a/src/test/kotlin/MajorityVoteResolverTest.kt
+++ b/src/test/kotlin/MajorityVoteResolverTest.kt
@@ -4,6 +4,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertContains
+import kotlin.test.assertFailsWith
 
 class MajorityVoteResolverTest {
 
@@ -34,5 +35,17 @@ class MajorityVoteResolverTest {
         val tied = setOf("A", "B")
         val results = (1..100).map { MajorityVoteResolver.resolve(listOf("A", "A", "B", "B", "C")) }.toSet()
         assertEquals(tied, results)
+    }
+
+    @Test
+    fun `resolveNonEmpty throws for empty votes`() {
+        assertFailsWith<IllegalArgumentException> {
+            MajorityVoteResolver.resolveNonEmpty(emptyList<String>())
+        }
+    }
+
+    @Test
+    fun `resolveNonEmpty returns the majority candidate`() {
+        assertEquals("B", MajorityVoteResolver.resolveNonEmpty(listOf("A", "B", "B")))
     }
 }


### PR DESCRIPTION
## Summary
- `MajorityVoteResolver` を追加し、多数決＋同数タイ時のランダム選択ロジックを実装
  - `resolve()`: 空リストはnullを返す（初日夜の無攻撃など正常な空を扱う場合）
  - `resolveNonEmpty()`: 空リストはエラー（投票など空になり得ない場合）
- `attackIfNotGuarded()` で `resolve()` を使用（従来は先頭の人狼の選択が常に優先されていた）
- `runVoting()` で `resolveNonEmpty()` を使用（従来は `maxBy` でタイを正しく処理できていなかった）
- `MajorityVoteResolverTest` でテストを追加

## Test plan
- [x] `./gradlew test` 通過確認済み
- [x] CIが通ることを確認

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)