### PR TITLE
Replace notifyRole() with GameEvent.RoleAssigned in startGame()

### DIFF
--- a/src/main/kotlin/GameEvent.kt
+++ b/src/main/kotlin/GameEvent.kt
@@ -4,6 +4,11 @@ sealed class GameEvent {
     abstract val title: String
     abstract fun body(self: Player): String
 
+    data class RoleAssigned(val role: Role) : GameEvent() {
+        override val title = "役職通知"
+        override fun body(self: Player) = "あなたの役職は「${role.displayName}」です。"
+    }
+
     data class PlayerExecuted(val executed: Player) : GameEvent() {
         override val title = "処刑通知"
         override fun body(self: Player) =

--- a/src/main/kotlin/HumanPlayer.kt
+++ b/src/main/kotlin/HumanPlayer.kt
@@ -1,10 +1,6 @@
 package org.example
 
 class HumanPlayer(override val role: Role, override val name: String, private val io: PlayerIO) : Player {
-    override fun notifyRole() {
-        io.sendMessage(name, "役職通知", "あなたの役職は「${role.displayName}」です。")
-    }
-
     override fun selectTarget(context: SelectionContext): Player =
         io.prompt(name, context.title, context.description, context.candidates())
 

--- a/src/main/kotlin/Player.kt
+++ b/src/main/kotlin/Player.kt
@@ -3,7 +3,6 @@ package org.example
 interface Player {
     val name: String
     val role: Role
-    fun notifyRole()
     fun selectTarget(context: SelectionContext): Player
     fun receive(event: GameEvent)
     fun discuss(players: List<Player>): String

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -21,7 +21,7 @@ class PlayerManager(allPlayers: List<Player>) {
     }
 
     fun startGame() {
-        _allPlayers.forEach { it.notifyRole() }
+        _allPlayers.forEach { it.receive(GameEvent.RoleAssigned(it.role)) }
     }
 
     private fun runNightActions(nightNumber: Int) {

--- a/src/test/kotlin/GameEventRoleAssignedTest.kt
+++ b/src/test/kotlin/GameEventRoleAssignedTest.kt
@@ -1,0 +1,28 @@
+package org.example
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GameEventRoleAssignedTest {
+
+    private val anyPlayer = object : Player {
+        override val name = "test"
+        override val role = Role.VILLAGER
+        override fun selectTarget(context: SelectionContext) = this
+        override fun receive(event: GameEvent) {}
+        override fun discuss(players: List<Player>) = ""
+    }
+
+    @Test
+    fun `title is 役職通知`() {
+        assertEquals("役職通知", GameEvent.RoleAssigned(Role.WEREWOLF).title)
+    }
+
+    @Test
+    fun `body shows role display name`() {
+        assertEquals(
+            "あなたの役職は「人狼」です。",
+            GameEvent.RoleAssigned(Role.WEREWOLF).body(anyPlayer)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- `GameEvent.RoleAssigned(val role: Role)` を追加
- `PlayerManager.startGame()` で `notifyRole()` の代わりに `receive(GameEvent.RoleAssigned(role))` を呼ぶよう変更
- `notifyRole()` を `Player` インターフェース・`HumanPlayer` から削除
- `GameEventRoleAssignedTest` でテストを追加

## Test plan
- [x] `./gradlew test` 通過確認済み
- [x] CIが通ることを確認

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)