### PR TITLE
Notify all players when no werewolf attack occurred

### DIFF
--- a/src/main/kotlin/GameEvent.kt
+++ b/src/main/kotlin/GameEvent.kt
@@ -36,6 +36,12 @@ sealed class GameEvent {
         override fun body(self: Player) = "$speakerName: $statement"
     }
 
+    data class MorningReport(val victim: Player?) : GameEvent() {
+        override val title = "朝の報告"
+        override fun body(self: Player) =
+            if (victim != null) "昨夜は ${victim.name} が襲撃されました。" else "昨夜は犠牲者がいませんでした。"
+    }
+
     data class GameOver(val winnerSide: Side) : GameEvent() {
         override val title = "ゲーム終了"
         override fun body(self: Player): String {

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -21,14 +21,15 @@ class PlayerManager(allPlayers: List<Player>) {
         _allPlayers.forEach { it.receive(GameEvent.RoleAssigned(it.role)) }
     }
 
-    private fun runNightActions(nightNumber: Int) {
+    private fun runNightActions(nightNumber: Int): Player? {
         val decisions = _alivePlayers.map { it to it.role.buildNightAction(it, _alivePlayers, nightNumber == 1) }
 
         val attacks = decisions.map { it.second }.filterIsInstance<NightAction.Attack>()
         val guards = decisions.map { it.second }.filterIsInstance<NightAction.Guard>()
-        attackIfNotGuarded(attacks, guards)
+        val killed = attackIfNotGuarded(attacks, guards)
 
         revealNightSecrets(decisions)
+        return killed
     }
 
     private fun revealNightSecrets(decisions: List<Pair<Player, NightAction>>) {
@@ -45,13 +46,14 @@ class PlayerManager(allPlayers: List<Player>) {
         }
     }
 
-    private fun attackIfNotGuarded(attacks: List<NightAction.Attack>, guards: List<NightAction.Guard>) {
-        val target = MajorityVoteResolver.resolve(attacks.map { it.target }) ?: return
-        if (guards.none { it.target === target }) attack(target)
+    private fun attackIfNotGuarded(attacks: List<NightAction.Attack>, guards: List<NightAction.Guard>): Player? {
+        val target = MajorityVoteResolver.resolve(attacks.map { it.target }) ?: return null
+        return if (guards.none { it.target === target }) attack(target) else null
     }
 
     fun runTurn(nightNumber: Int) {
-        runNightActions(nightNumber)
+        val killed = runNightActions(nightNumber)
+        _allPlayers.forEach { it.receive(GameEvent.MorningReport(killed)) }
         runDiscussion()
         runVoting()
     }
@@ -76,9 +78,10 @@ class PlayerManager(allPlayers: List<Player>) {
         die(mostVoted)
     }
 
-    private fun attack(target: Player) {
+    private fun attack(target: Player): Player {
         _allPlayers.forEach { it.receive(GameEvent.PlayerAttacked(attacked = target)) }
         _attackedPlayers.add(target)
         die(target)
+        return target
     }
 }


### PR DESCRIPTION
## Summary
- 夜フェーズ終了後、犠牲者の有無にかかわらず全プレイヤーへ朝の報告（`GameEvent.MorningReport`）を送信するようにした
- 犠牲者なしの場合も「昨夜は犠牲者がいませんでした」と明示的に通知される

## Test plan
- [x] 犠牲者が出た場合に既存の死亡通知が正常に表示されることを確認
- [x] 犠牲者が出なかった場合に「昨夜は犠牲者がいませんでした」が全プレイヤーに通知されることを確認

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)