### PR TITLE
Add TimeOfDay and notify all players when day/night begins

### DIFF
--- a/src/main/kotlin/GameEvent.kt
+++ b/src/main/kotlin/GameEvent.kt
@@ -36,6 +36,11 @@ sealed class GameEvent {
         override fun body(self: Player) = "$speakerName: $statement"
     }
 
+    data class TimeChanged(val timeOfDay: TimeOfDay) : GameEvent() {
+        override val title = "${timeOfDay.name}の訪れ"
+        override fun body(self: Player) = "${timeOfDay.displayName}になりました。"
+    }
+
     data class MorningReport(val victim: Player?) : GameEvent() {
         override val title = "朝の報告"
         override fun body(self: Player) =

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -52,7 +52,9 @@ class PlayerManager(allPlayers: List<Player>) {
     }
 
     fun runTurn(nightNumber: Int) {
+        _allPlayers.forEach { it.receive(GameEvent.TimeChanged(TimeOfDay.Night(nightNumber))) }
         val killed = runNightActions(nightNumber)
+        _allPlayers.forEach { it.receive(GameEvent.TimeChanged(TimeOfDay.Morning)) }
         _allPlayers.forEach { it.receive(GameEvent.MorningReport(killed)) }
         runDiscussion()
         runVoting()

--- a/src/main/kotlin/TimeOfDay.kt
+++ b/src/main/kotlin/TimeOfDay.kt
@@ -1,0 +1,21 @@
+package org.example
+
+sealed class TimeOfDay {
+    abstract val name: String
+    abstract val displayName: String
+
+    data class Night(val nightNumber: Int) : TimeOfDay() {
+        override val name = "夜"
+        override val displayName = "${nightNumber}日目の夜"
+    }
+
+    data object Morning : TimeOfDay() {
+        override val name = "朝"
+        override val displayName = "朝"
+    }
+
+    data class Midnight(val nightNumber: Int) : TimeOfDay() {
+        override val name = "深夜"
+        override val displayName = "${nightNumber}日目の深夜"
+    }
+}

--- a/src/main/kotlin/TimeOfDay.kt
+++ b/src/main/kotlin/TimeOfDay.kt
@@ -16,6 +16,6 @@ sealed class TimeOfDay {
 
     data class Midnight(val nightNumber: Int) : TimeOfDay() {
         override val name = "深夜"
-        override val displayName = "${nightNumber}日目の深夜"
+        override val displayName = "深夜"
     }
 }


### PR DESCRIPTION
## Summary
- `TimeOfDay` sealed class を新設（`Night` / `Morning` / `Midnight`）
- `GameEvent.TimeChanged(timeOfDay)` を追加。title は「〇〇の訪れ」、body は「〇〇になりました。」
- `PlayerManager.runTurn` で夜と朝の開始時に `_allPlayers` 全員へ通知

## Test plan
- [x] `TimeOfDay` / `GameEvent.TimeChanged` は定数返却のみで単独テストの価値がなく、`PlayerManager` はオーケストレーター層のためテストなし

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)