### PR TITLE
Add English title placeholder to all issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -2,6 +2,7 @@
 name: バグ報告
 about: 動作がおかしい箇所の報告
 labels: bug
+title: 'Describe in English'
 ---
 
 ## 現象

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -2,6 +2,7 @@
 name: 雑務・環境整備
 about: 設定ファイル追加・ツール導入など開発環境や運用に関する作業
 labels: chore
+title: 'Describe in English'
 ---
 
 ## やること

--- a/.github/ISSUE_TEMPLATE/design.md
+++ b/.github/ISSUE_TEMPLATE/design.md
@@ -2,6 +2,7 @@
 name: 設計・方針決定
 about: 適切な設計や方針を検討し、決定する
 labels: design
+title: 'Describe in English'
 ---
 
 ## 検討したいこと

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -2,6 +2,7 @@
 name: 機能追加
 about: 新機能の追加・既存機能の変更
 labels: feature
+title: 'Describe in English'
 ---
 
 ## やること

--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -2,6 +2,7 @@
 name: リファクタリング
 about: 動作を変えずにコードを整理する
 labels: refactor
+title: 'Describe in English'
 ---
 
 ## 対象


### PR DESCRIPTION
## やること
全issueテンプレートのfrontmatterに `title: 'Describe in English'` を追加し、GitHub UI上でタイトルを英語で記載する慣習を明示する。

Closes #48