### PR TITLE
Allow dead players to observe discussion

### DIFF
--- a/src/main/kotlin/Discussion.kt
+++ b/src/main/kotlin/Discussion.kt
@@ -1,6 +1,6 @@
 package org.example
 
-abstract class Discussion(private val players: List<Player>) {
+abstract class Discussion(private val alivePlayers: List<Player>, private val allPlayers: List<Player>) {
     companion object {
         private const val ROUNDS = 3
     }
@@ -8,16 +8,16 @@ abstract class Discussion(private val players: List<Player>) {
     protected abstract fun speakingOrder(players: List<Player>): List<Player>
 
     fun conduct() {
-        val order = speakingOrder(players)
+        val order = speakingOrder(alivePlayers)
         repeat(ROUNDS) { index ->
             order.forEach { speaker ->
-                val statement = speaker.discuss(players)
-                players.forEach { it.receive(GameEvent.StatementMade(index + 1, speaker.name, statement)) }
+                val statement = speaker.discuss(alivePlayers)
+                allPlayers.forEach { it.receive(GameEvent.StatementMade(index + 1, speaker.name, statement)) }
             }
         }
     }
 }
 
-class RandomOrderDiscussion(players: List<Player>) : Discussion(players) {
+class RandomOrderDiscussion(alivePlayers: List<Player>, allPlayers: List<Player>) : Discussion(alivePlayers, allPlayers) {
     override fun speakingOrder(players: List<Player>) = players.shuffled()
 }

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -61,7 +61,7 @@ class PlayerManager(allPlayers: List<Player>) {
     }
 
     private fun runDiscussion() {
-        RandomOrderDiscussion(_alivePlayers).conduct()
+        RandomOrderDiscussion(_alivePlayers, _allPlayers).conduct()
     }
 
     private fun runVoting() {

--- a/src/test/kotlin/DiscussionTest.kt
+++ b/src/test/kotlin/DiscussionTest.kt
@@ -30,9 +30,10 @@ class DiscussionTest {
         override fun selectTarget(context: SelectionContext): Player = error("not expected in discussion test")
     }
 
-    private fun fixedOrderDiscussion(players: List<Player>) = object : Discussion(players) {
-        override fun speakingOrder(players: List<Player>) = players
-    }
+    private fun fixedOrderDiscussion(alivePlayers: List<Player>, allPlayers: List<Player>) =
+        object : Discussion(alivePlayers, allPlayers) {
+            override fun speakingOrder(players: List<Player>) = players
+        }
 
     @Test
     fun `statements are delivered immediately in order`() {
@@ -48,7 +49,7 @@ class DiscussionTest {
         ))
         val players = listOf(alice, bob)
 
-        fixedOrderDiscussion(players).conduct()
+        fixedOrderDiscussion(players, players).conduct()
 
         assertEquals(listOf(
             "Alice:said:私はBobが怪しいと思う",
@@ -73,5 +74,25 @@ class DiscussionTest {
             "Bob:said:Aliceに投票します",
             "Bob:heard:Bob:Aliceに投票します",
         ), bob.log)
+    }
+
+    @Test
+    fun `dead players receive all statements without speaking`() {
+        val alice = TestPlayer("Alice", Role.VILLAGER, listOf("村人として発言します", "続けて発言します", "最終発言です"))
+        val bob = TestPlayer("Bob", Role.WEREWOLF, listOf("人狼として発言します", "続けて発言します", "最終発言です"))
+        val charlie = TestPlayer("Charlie", Role.VILLAGER, emptyList())
+        val alivePlayers = listOf(alice, bob)
+        val allPlayers = listOf(alice, bob, charlie)
+
+        fixedOrderDiscussion(alivePlayers, allPlayers).conduct()
+
+        assertEquals(listOf(
+            "Charlie:heard:Alice:村人として発言します",
+            "Charlie:heard:Bob:人狼として発言します",
+            "Charlie:heard:Alice:続けて発言します",
+            "Charlie:heard:Bob:続けて発言します",
+            "Charlie:heard:Alice:最終発言です",
+            "Charlie:heard:Bob:最終発言です",
+        ), charlie.log)
     }
 }


### PR DESCRIPTION
## やること
`Discussion` が「発言者リスト（生存者）」と「通知先（全プレイヤー）」を別々に保持するよう変更し、死者も議論を観戦できるようにする。

## 変更内容
- `Discussion` / `RandomOrderDiscussion` のコンストラクタに `alivePlayers` と `allPlayers` を分けて渡すよう変更
- `speakingOrder` / `discuss` の入力は `alivePlayers`、`StatementMade` の通知先は `allPlayers`
- `PlayerManager.runDiscussion()` で両リストを渡すよう更新
- `DiscussionTest` に死者が全発言を受け取ることを検証するテストを追加

Closes #47