### PR TITLE
Centralize notification policy in GameEvent with Notifiable interface

### DIFF
--- a/src/main/kotlin/Discussion.kt
+++ b/src/main/kotlin/Discussion.kt
@@ -13,7 +13,7 @@ abstract class Discussion(private val alivePlayers: List<Player>, private val al
         repeat(ROUNDS) { index ->
             order.forEach { speaker ->
                 val statement = speaker.discuss(alivePlayers)
-                GameEvent.StatementMade(index + 1, speaker.name, statement, recipients).dispatch()
+                GameEvent.StatementMade.send(index + 1, speaker.name, statement, recipients)
             }
         }
     }

--- a/src/main/kotlin/Discussion.kt
+++ b/src/main/kotlin/Discussion.kt
@@ -9,10 +9,11 @@ abstract class Discussion(private val alivePlayers: List<Player>, private val al
 
     fun conduct() {
         val order = speakingOrder(alivePlayers)
+        val recipients = AllPlayers(allPlayers)
         repeat(ROUNDS) { index ->
             order.forEach { speaker ->
                 val statement = speaker.discuss(alivePlayers)
-                allPlayers.forEach { it.receive(GameEvent.StatementMade(index + 1, speaker.name, statement)) }
+                GameEvent.StatementMade(index + 1, speaker.name, statement, recipients).dispatch()
             }
         }
     }

--- a/src/main/kotlin/GameEvent.kt
+++ b/src/main/kotlin/GameEvent.kt
@@ -7,7 +7,7 @@ sealed class GameEvent {
     abstract val title: String
     abstract fun body(self: Player): String
     protected abstract val recipients: Notifiable
-    fun dispatch() = recipients.receive(this)
+    protected fun dispatch() = recipients.receive(this)
 
     @ConsistentCopyVisibility
     data class RoleAssigned private constructor(val role: Role, private val recipient: Player) : GameEvent() {

--- a/src/main/kotlin/GameEvent.kt
+++ b/src/main/kotlin/GameEvent.kt
@@ -3,55 +3,66 @@ package org.example
 sealed class GameEvent {
     abstract val title: String
     abstract fun body(self: Player): String
+    protected abstract val recipients: Notifiable
+    fun dispatch() = recipients.receive(this)
 
-    data class RoleAssigned(val role: Role) : GameEvent() {
+    data class RoleAssigned(val role: Role, private val recipient: Player) : GameEvent() {
         override val title = "役職通知"
         override fun body(self: Player) = "あなたの役職は「${role.displayName}」です。"
+        override val recipients: Notifiable = recipient
     }
 
-    data class PlayerExecuted(val executed: Player) : GameEvent() {
+    data class PlayerExecuted(val executed: Player, private val allPlayers: AllPlayers) : GameEvent() {
         override val title = "処刑通知"
         override fun body(self: Player) =
             if (executed === self) "あなたは処刑されました。" else "${executed.name} が処刑されました。"
+        override val recipients: Notifiable = allPlayers
     }
 
-    data class PlayerAttacked(val attacked: Player) : GameEvent() {
+    data class PlayerAttacked(val attacked: Player, private val allPlayers: AllPlayers) : GameEvent() {
         override val title = "襲撃通知"
         override fun body(self: Player) =
             if (attacked === self) "あなたは襲撃されました。" else "${attacked.name} が襲撃されました。"
+        override val recipients: Notifiable = allPlayers
     }
 
-    data class Divined(val target: Player, val result: DivineResult) : GameEvent() {
+    data class Divined(val target: Player, val result: DivineResult, private val recipient: Player) : GameEvent() {
         override val title = "占い結果"
         override fun body(self: Player) = "${target.name} は「${result.displayName}」です。"
+        override val recipients: Notifiable = recipient
     }
 
-    data class MediumRevealed(val target: Player, val result: MediumResult) : GameEvent() {
+    data class MediumRevealed(val target: Player, val result: MediumResult, private val recipient: Player) : GameEvent() {
         override val title = "霊視結果"
         override fun body(self: Player) = "${target.name} は「${result.displayName}」です。"
+        override val recipients: Notifiable = recipient
     }
 
-    data class StatementMade(val round: Int, val speakerName: String, val statement: String) : GameEvent() {
+    data class StatementMade(val round: Int, val speakerName: String, val statement: String, private val allPlayers: AllPlayers) : GameEvent() {
         override val title = "発言（${round}ラウンド目）"
         override fun body(self: Player) = "$speakerName: $statement"
+        override val recipients: Notifiable = allPlayers
     }
 
-    data class TimeChanged(val timeOfDay: TimeOfDay) : GameEvent() {
+    data class TimeChanged(val timeOfDay: TimeOfDay, private val allPlayers: AllPlayers) : GameEvent() {
         override val title = "${timeOfDay.name}の訪れ"
         override fun body(self: Player) = "${timeOfDay.displayName}になりました。"
+        override val recipients: Notifiable = allPlayers
     }
 
-    data class MorningReport(val victim: Player?) : GameEvent() {
+    data class MorningReport(val victim: Player?, private val allPlayers: AllPlayers) : GameEvent() {
         override val title = "朝の報告"
         override fun body(self: Player) =
             if (victim != null) "昨夜は ${victim.name} が襲撃されました。" else "昨夜は犠牲者がいませんでした。"
+        override val recipients: Notifiable = allPlayers
     }
 
-    data class GameOver(val winnerSide: Side) : GameEvent() {
+    data class GameOver(val winnerSide: Side, private val allPlayers: AllPlayers) : GameEvent() {
         override val title = "ゲーム終了"
         override fun body(self: Player): String {
             val result = if (self.role.side == winnerSide) "勝利" else "敗北"
             return "${winnerSide.displayName}陣営の勝利です！あなたは${result}しました。"
         }
+        override val recipients: Notifiable = allPlayers
     }
 }

--- a/src/main/kotlin/GameEvent.kt
+++ b/src/main/kotlin/GameEvent.kt
@@ -1,68 +1,108 @@
 package org.example
 
+// Each subclass must have a private constructor and a companion send() function
+// that creates and dispatches atomically. This ensures notification targets are
+// always defined explicitly at the point of creation.
 sealed class GameEvent {
     abstract val title: String
     abstract fun body(self: Player): String
     protected abstract val recipients: Notifiable
     fun dispatch() = recipients.receive(this)
 
-    data class RoleAssigned(val role: Role, private val recipient: Player) : GameEvent() {
+    @ConsistentCopyVisibility
+    data class RoleAssigned private constructor(val role: Role, private val recipient: Player) : GameEvent() {
         override val title = "役職通知"
         override fun body(self: Player) = "あなたの役職は「${role.displayName}」です。"
         override val recipients: Notifiable = recipient
+        companion object {
+            fun send(role: Role, recipient: Player) = RoleAssigned(role, recipient).dispatch()
+        }
     }
 
-    data class PlayerExecuted(val executed: Player, private val allPlayers: AllPlayers) : GameEvent() {
+    @ConsistentCopyVisibility
+    data class PlayerExecuted private constructor(val executed: Player, private val allPlayers: AllPlayers) : GameEvent() {
         override val title = "処刑通知"
         override fun body(self: Player) =
             if (executed === self) "あなたは処刑されました。" else "${executed.name} が処刑されました。"
         override val recipients: Notifiable = allPlayers
+        companion object {
+            fun send(executed: Player, allPlayers: AllPlayers) = PlayerExecuted(executed, allPlayers).dispatch()
+        }
     }
 
-    data class PlayerAttacked(val attacked: Player, private val allPlayers: AllPlayers) : GameEvent() {
+    @ConsistentCopyVisibility
+    data class PlayerAttacked private constructor(val attacked: Player, private val allPlayers: AllPlayers) : GameEvent() {
         override val title = "襲撃通知"
         override fun body(self: Player) =
             if (attacked === self) "あなたは襲撃されました。" else "${attacked.name} が襲撃されました。"
         override val recipients: Notifiable = allPlayers
+        companion object {
+            fun send(attacked: Player, allPlayers: AllPlayers) = PlayerAttacked(attacked, allPlayers).dispatch()
+        }
     }
 
-    data class Divined(val target: Player, val result: DivineResult, private val recipient: Player) : GameEvent() {
+    @ConsistentCopyVisibility
+    data class Divined private constructor(val target: Player, val result: DivineResult, private val recipient: Player) : GameEvent() {
         override val title = "占い結果"
         override fun body(self: Player) = "${target.name} は「${result.displayName}」です。"
         override val recipients: Notifiable = recipient
+        companion object {
+            fun send(target: Player, result: DivineResult, recipient: Player) = Divined(target, result, recipient).dispatch()
+        }
     }
 
-    data class MediumRevealed(val target: Player, val result: MediumResult, private val recipient: Player) : GameEvent() {
+    @ConsistentCopyVisibility
+    data class MediumRevealed private constructor(val target: Player, val result: MediumResult, private val recipient: Player) : GameEvent() {
         override val title = "霊視結果"
         override fun body(self: Player) = "${target.name} は「${result.displayName}」です。"
         override val recipients: Notifiable = recipient
+        companion object {
+            fun send(target: Player, result: MediumResult, recipient: Player) = MediumRevealed(target, result, recipient).dispatch()
+        }
     }
 
-    data class StatementMade(val round: Int, val speakerName: String, val statement: String, private val allPlayers: AllPlayers) : GameEvent() {
+    @ConsistentCopyVisibility
+    data class StatementMade private constructor(val round: Int, val speakerName: String, val statement: String, private val allPlayers: AllPlayers) : GameEvent() {
         override val title = "発言（${round}ラウンド目）"
         override fun body(self: Player) = "$speakerName: $statement"
         override val recipients: Notifiable = allPlayers
+        companion object {
+            fun send(round: Int, speakerName: String, statement: String, allPlayers: AllPlayers) =
+                StatementMade(round, speakerName, statement, allPlayers).dispatch()
+        }
     }
 
-    data class TimeChanged(val timeOfDay: TimeOfDay, private val allPlayers: AllPlayers) : GameEvent() {
+    @ConsistentCopyVisibility
+    data class TimeChanged private constructor(val timeOfDay: TimeOfDay, private val allPlayers: AllPlayers) : GameEvent() {
         override val title = "${timeOfDay.name}の訪れ"
         override fun body(self: Player) = "${timeOfDay.displayName}になりました。"
         override val recipients: Notifiable = allPlayers
+        companion object {
+            fun send(timeOfDay: TimeOfDay, allPlayers: AllPlayers) = TimeChanged(timeOfDay, allPlayers).dispatch()
+        }
     }
 
-    data class MorningReport(val victim: Player?, private val allPlayers: AllPlayers) : GameEvent() {
+    @ConsistentCopyVisibility
+    data class MorningReport private constructor(val victim: Player?, private val allPlayers: AllPlayers) : GameEvent() {
         override val title = "朝の報告"
         override fun body(self: Player) =
             if (victim != null) "昨夜は ${victim.name} が襲撃されました。" else "昨夜は犠牲者がいませんでした。"
         override val recipients: Notifiable = allPlayers
+        companion object {
+            fun send(victim: Player?, allPlayers: AllPlayers) = MorningReport(victim, allPlayers).dispatch()
+        }
     }
 
-    data class GameOver(val winnerSide: Side, private val allPlayers: AllPlayers) : GameEvent() {
+    @ConsistentCopyVisibility
+    data class GameOver private constructor(val winnerSide: Side, private val allPlayers: AllPlayers) : GameEvent() {
         override val title = "ゲーム終了"
         override fun body(self: Player): String {
             val result = if (self.role.side == winnerSide) "勝利" else "敗北"
             return "${winnerSide.displayName}陣営の勝利です！あなたは${result}しました。"
         }
         override val recipients: Notifiable = allPlayers
+        companion object {
+            fun send(winnerSide: Side, allPlayers: AllPlayers) = GameOver(winnerSide, allPlayers).dispatch()
+        }
     }
 }

--- a/src/main/kotlin/Notifiable.kt
+++ b/src/main/kotlin/Notifiable.kt
@@ -1,0 +1,9 @@
+package org.example
+
+interface Notifiable {
+    fun receive(event: GameEvent)
+}
+
+class AllPlayers(private val players: List<Player>) : Notifiable {
+    override fun receive(event: GameEvent) = players.forEach { it.receive(event) }
+}

--- a/src/main/kotlin/Player.kt
+++ b/src/main/kotlin/Player.kt
@@ -1,9 +1,9 @@
 package org.example
 
-interface Player {
+interface Player : Notifiable {
     val name: String
     val role: Role
     fun selectTarget(context: SelectionContext): Player
-    fun receive(event: GameEvent)
+    override fun receive(event: GameEvent)
     fun discuss(players: List<Player>): String
 }

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -8,6 +8,8 @@ class PlayerManager(allPlayers: List<Player>) {
     private val _attackedPlayers: MutableList<Player> = mutableListOf()
     val players: List<Player> get() = _alivePlayers
 
+    private val allPlayers get() = AllPlayers(_allPlayers)
+
     private fun checkWinner() {
         GameOverSignal.throwIfGameOver(AliveCounts(_alivePlayers))
     }
@@ -18,7 +20,7 @@ class PlayerManager(allPlayers: List<Player>) {
     }
 
     fun startGame() {
-        _allPlayers.forEach { it.receive(GameEvent.RoleAssigned(it.role)) }
+        _allPlayers.forEach { GameEvent.RoleAssigned(it.role, it).dispatch() }
     }
 
     private fun runNightActions(nightNumber: Int): Player? {
@@ -38,9 +40,9 @@ class PlayerManager(allPlayers: List<Player>) {
                 is NightAction.None -> Unit
                 is NightAction.Attack -> Unit
                 is NightAction.Guard -> Unit
-                is NightAction.Divine -> player.receive(GameEvent.Divined(decision.target, decision.target.role.divineResult))
+                is NightAction.Divine -> GameEvent.Divined(decision.target, decision.target.role.divineResult, player).dispatch()
                 is NightAction.MediumReveal -> _executedPlayers.lastOrNull()?.let { target ->
-                    player.receive(GameEvent.MediumRevealed(target, target.role.mediumResult))
+                    GameEvent.MediumRevealed(target, target.role.mediumResult, player).dispatch()
                 }
             }
         }
@@ -52,10 +54,10 @@ class PlayerManager(allPlayers: List<Player>) {
     }
 
     fun runTurn(nightNumber: Int) {
-        _allPlayers.forEach { it.receive(GameEvent.TimeChanged(TimeOfDay.Night(nightNumber))) }
+        GameEvent.TimeChanged(TimeOfDay.Night(nightNumber), allPlayers).dispatch()
         val killed = runNightActions(nightNumber)
-        _allPlayers.forEach { it.receive(GameEvent.TimeChanged(TimeOfDay.Morning)) }
-        _allPlayers.forEach { it.receive(GameEvent.MorningReport(killed)) }
+        GameEvent.TimeChanged(TimeOfDay.Morning, allPlayers).dispatch()
+        GameEvent.MorningReport(killed, allPlayers).dispatch()
         runDiscussion()
         runVoting()
     }
@@ -71,17 +73,17 @@ class PlayerManager(allPlayers: List<Player>) {
     }
 
     fun endGame(signal: GameOverSignal) {
-        _allPlayers.forEach { it.receive(GameEvent.GameOver(signal.winningSide)) }
+        GameEvent.GameOver(signal.winningSide, allPlayers).dispatch()
     }
 
     private fun execute(mostVoted: Player) {
-        _allPlayers.forEach { it.receive(GameEvent.PlayerExecuted(executed = mostVoted)) }
+        GameEvent.PlayerExecuted(mostVoted, allPlayers).dispatch()
         _executedPlayers.add(mostVoted)
         die(mostVoted)
     }
 
     private fun attack(target: Player): Player {
-        _allPlayers.forEach { it.receive(GameEvent.PlayerAttacked(attacked = target)) }
+        GameEvent.PlayerAttacked(target, allPlayers).dispatch()
         _attackedPlayers.add(target)
         die(target)
         return target

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -20,7 +20,7 @@ class PlayerManager(allPlayers: List<Player>) {
     }
 
     fun startGame() {
-        _allPlayers.forEach { GameEvent.RoleAssigned(it.role, it).dispatch() }
+        _allPlayers.forEach { GameEvent.RoleAssigned.send(it.role, it) }
     }
 
     private fun runNightActions(nightNumber: Int): Player? {
@@ -40,9 +40,9 @@ class PlayerManager(allPlayers: List<Player>) {
                 is NightAction.None -> Unit
                 is NightAction.Attack -> Unit
                 is NightAction.Guard -> Unit
-                is NightAction.Divine -> GameEvent.Divined(decision.target, decision.target.role.divineResult, player).dispatch()
+                is NightAction.Divine -> GameEvent.Divined.send(decision.target, decision.target.role.divineResult, player)
                 is NightAction.MediumReveal -> _executedPlayers.lastOrNull()?.let { target ->
-                    GameEvent.MediumRevealed(target, target.role.mediumResult, player).dispatch()
+                    GameEvent.MediumRevealed.send(target, target.role.mediumResult, player)
                 }
             }
         }
@@ -54,10 +54,10 @@ class PlayerManager(allPlayers: List<Player>) {
     }
 
     fun runTurn(nightNumber: Int) {
-        GameEvent.TimeChanged(TimeOfDay.Night(nightNumber), allPlayers).dispatch()
+        GameEvent.TimeChanged.send(TimeOfDay.Night(nightNumber), allPlayers)
         val killed = runNightActions(nightNumber)
-        GameEvent.TimeChanged(TimeOfDay.Morning, allPlayers).dispatch()
-        GameEvent.MorningReport(killed, allPlayers).dispatch()
+        GameEvent.TimeChanged.send(TimeOfDay.Morning, allPlayers)
+        GameEvent.MorningReport.send(killed, allPlayers)
         runDiscussion()
         runVoting()
     }
@@ -73,17 +73,17 @@ class PlayerManager(allPlayers: List<Player>) {
     }
 
     fun endGame(signal: GameOverSignal) {
-        GameEvent.GameOver(signal.winningSide, allPlayers).dispatch()
+        GameEvent.GameOver.send(signal.winningSide, allPlayers)
     }
 
     private fun execute(mostVoted: Player) {
-        GameEvent.PlayerExecuted(mostVoted, allPlayers).dispatch()
+        GameEvent.PlayerExecuted.send(mostVoted, allPlayers)
         _executedPlayers.add(mostVoted)
         die(mostVoted)
     }
 
     private fun attack(target: Player): Player {
-        GameEvent.PlayerAttacked(target, allPlayers).dispatch()
+        GameEvent.PlayerAttacked.send(target, allPlayers)
         _attackedPlayers.add(target)
         die(target)
         return target

--- a/src/test/kotlin/GameEventRoleAssignedTest.kt
+++ b/src/test/kotlin/GameEventRoleAssignedTest.kt
@@ -5,24 +5,25 @@ import kotlin.test.assertEquals
 
 class GameEventRoleAssignedTest {
 
-    private val anyPlayer = object : Player {
-        override val name = "test"
-        override val role = Role.VILLAGER
+    private class RecordingPlayer(override val role: Role, override val name: String) : Player {
+        val received = mutableListOf<GameEvent>()
         override fun selectTarget(context: SelectionContext) = this
-        override fun receive(event: GameEvent) {}
+        override fun receive(event: GameEvent) { received.add(event) }
         override fun discuss(players: List<Player>) = ""
     }
 
     @Test
-    fun `title is 役職通知`() {
-        assertEquals("役職通知", GameEvent.RoleAssigned(Role.WEREWOLF, anyPlayer).title)
-    }
+    fun `startGame notifies each player of their assigned role`() {
+        val villager = RecordingPlayer(Role.VILLAGER, "Alice")
+        val werewolf = RecordingPlayer(Role.WEREWOLF, "Bob")
+        PlayerManager(listOf(villager, werewolf)).startGame()
 
-    @Test
-    fun `body shows role display name`() {
-        assertEquals(
-            "あなたの役職は「人狼」です。",
-            GameEvent.RoleAssigned(Role.WEREWOLF, anyPlayer).body(anyPlayer)
-        )
+        val villagerEvent = villager.received.single() as GameEvent.RoleAssigned
+        assertEquals(Role.VILLAGER, villagerEvent.role)
+        assertEquals("あなたの役職は「村人」です。", villagerEvent.body(villager))
+
+        val werewolfEvent = werewolf.received.single() as GameEvent.RoleAssigned
+        assertEquals(Role.WEREWOLF, werewolfEvent.role)
+        assertEquals("あなたの役職は「人狼」です。", werewolfEvent.body(werewolf))
     }
 }

--- a/src/test/kotlin/GameEventRoleAssignedTest.kt
+++ b/src/test/kotlin/GameEventRoleAssignedTest.kt
@@ -15,14 +15,14 @@ class GameEventRoleAssignedTest {
 
     @Test
     fun `title is 役職通知`() {
-        assertEquals("役職通知", GameEvent.RoleAssigned(Role.WEREWOLF).title)
+        assertEquals("役職通知", GameEvent.RoleAssigned(Role.WEREWOLF, anyPlayer).title)
     }
 
     @Test
     fun `body shows role display name`() {
         assertEquals(
             "あなたの役職は「人狼」です。",
-            GameEvent.RoleAssigned(Role.WEREWOLF).body(anyPlayer)
+            GameEvent.RoleAssigned(Role.WEREWOLF, anyPlayer).body(anyPlayer)
         )
     }
 }


### PR DESCRIPTION
## 対象
`GameEvent.kt`, `Player.kt`, `PlayerManager.kt`, `Discussion.kt`

## 現状の問題
通知先の判断（誰に `receive()` を呼ぶか）が `PlayerManager` / `Discussion` に散らばっており、統一した方針がない。またイベントを生成しても `dispatch()` を呼び忘れる余地があった。

## 方針
- `Notifiable` インターフェース（`receive(event: GameEvent)`）を導入し、`Player` と `AllPlayers` に実装
- 各 `GameEvent` サブクラスがコンストラクタで通知先（`Notifiable`）を受け取り、`private val recipients` に保持
- 親クラスの `dispatch()` が `recipients.receive(this)` を呼ぶことで配送を完結
- 各サブクラスのコンストラクタを `private` にし、`companion object` の `send()` 経由でのみ生成・送信できるようにすることで、生成と送信を不可分にする
- `@ConsistentCopyVisibility` を付与し、`copy()` も `private` に統一
- `PlayerManager` / `Discussion` の呼び出し側は `send()` に統一

## 完了条件
- [x] `Notifiable` インターフェースと `AllPlayers` クラスが追加されている
- [x] `Player` が `Notifiable` を実装している
- [x] 各 `GameEvent` サブクラスが通知先をコンストラクタで受け取り `send()` で生成・配送する
- [x] コンストラクタが `private` で `send()` 以外からの生成が不可能
- [x] `PlayerManager` / `Discussion` の呼び出しが `send()` に統一されている

Closes #49