### PR TITLE
Simplify Divined and MediumRevealed send() by resolving role result internally

### DIFF
--- a/src/main/kotlin/GameEvent.kt
+++ b/src/main/kotlin/GameEvent.kt
@@ -47,7 +47,7 @@ sealed class GameEvent {
         override fun body(self: Player) = "${target.name} は「${result.displayName}」です。"
         override val recipients: Notifiable = recipient
         companion object {
-            fun send(target: Player, result: DivineResult, recipient: Player) = Divined(target, result, recipient).dispatch()
+            fun send(target: Player, recipient: Player) = Divined(target, target.role.divineResult, recipient).dispatch()
         }
     }
 
@@ -57,7 +57,7 @@ sealed class GameEvent {
         override fun body(self: Player) = "${target.name} は「${result.displayName}」です。"
         override val recipients: Notifiable = recipient
         companion object {
-            fun send(target: Player, result: MediumResult, recipient: Player) = MediumRevealed(target, result, recipient).dispatch()
+            fun send(target: Player, recipient: Player) = MediumRevealed(target, target.role.mediumResult, recipient).dispatch()
         }
     }
 

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -40,9 +40,9 @@ class PlayerManager(allPlayers: List<Player>) {
                 is NightAction.None -> Unit
                 is NightAction.Attack -> Unit
                 is NightAction.Guard -> Unit
-                is NightAction.Divine -> GameEvent.Divined.send(decision.target, decision.target.role.divineResult, player)
+                is NightAction.Divine -> GameEvent.Divined.send(decision.target, player)
                 is NightAction.MediumReveal -> _executedPlayers.lastOrNull()?.let { target ->
-                    GameEvent.MediumRevealed.send(target, target.role.mediumResult, player)
+                    GameEvent.MediumRevealed.send(target, player)
                 }
             }
         }


### PR DESCRIPTION
## Summary

- `GameEvent.Divined.send()` の引数から `DivineResult` を削除し、内部で `target.role.divineResult` を取得するように変更
- `GameEvent.MediumRevealed.send()` の引数から `MediumResult` を削除し、内部で `target.role.mediumResult` を取得するように変更
- `PlayerManager` の呼び出しが `send(target, player)` に簡略化された

Closes #53

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)