### PR TITLE
Split GameEvent.GameOver into GameOver and GameResult

### DIFF
--- a/src/main/kotlin/GameEvent.kt
+++ b/src/main/kotlin/GameEvent.kt
@@ -96,13 +96,20 @@ sealed class GameEvent {
     @ConsistentCopyVisibility
     data class GameOver private constructor(val winnerSide: Side, private val allPlayers: AllPlayers) : GameEvent() {
         override val title = "ゲーム終了"
-        override fun body(self: Player): String {
-            val result = if (self.role.side == winnerSide) "勝利" else "敗北"
-            return "${winnerSide.displayName}陣営の勝利です！あなたは${result}しました。"
-        }
+        override fun body(self: Player) = "${winnerSide.displayName}陣営の勝利です！"
         override val recipients: Notifiable = allPlayers
         companion object {
             fun send(winnerSide: Side, allPlayers: AllPlayers) = GameOver(winnerSide, allPlayers).dispatch()
+        }
+    }
+
+    @ConsistentCopyVisibility
+    data class GameResult private constructor(val isWinner: Boolean, private val recipient: Player) : GameEvent() {
+        override val title = "勝敗結果"
+        override fun body(self: Player) = if (isWinner) "あなたは勝利しました。" else "あなたは敗北しました。"
+        override val recipients: Notifiable = recipient
+        companion object {
+            fun send(isWinner: Boolean, recipient: Player) = GameResult(isWinner, recipient).dispatch()
         }
     }
 }

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -74,6 +74,7 @@ class PlayerManager(allPlayers: List<Player>) {
 
     fun endGame(signal: GameOverSignal) {
         GameEvent.GameOver.send(signal.winningSide, allPlayers)
+        _allPlayers.forEach { GameEvent.GameResult.send(it.role.side == signal.winningSide, it) }
     }
 
     private fun execute(mostVoted: Player) {


### PR DESCRIPTION
## Summary
- `GameEvent.GameOver` を全員向けの陣営告知のみに変更（`self.role` 参照を除去）
- `GameEvent.GameResult` を新設し、個人向けに勝敗を通知
- `PlayerManager.endGame()` で両イベントを送信するよう更新

## Test plan
- [x] ビルド・既存テストがパスすること

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)