### PR TITLE
Remove werewolf exclusion from SelectionContext.Attack candidates

### DIFF
--- a/src/main/kotlin/SelectionContext.kt
+++ b/src/main/kotlin/SelectionContext.kt
@@ -5,7 +5,7 @@ sealed class SelectionContext(val title: String, val description: String) {
 
     class Attack(private val self: Player, private val players: List<Player>)
         : SelectionContext("夜の行動", "襲撃先を選んでください") {
-        override fun candidates() = players.filterNot { it === self || it.role == Role.WEREWOLF }
+        override fun candidates() = players.filterNot { it === self }
     }
 
     class Divine(private val self: Player, private val players: List<Player>)


### PR DESCRIPTION
## Summary
- `SelectionContext.Attack.candidates()` から `it.role == Role.WEREWOLF` による除外を削除
- 候補リストが自分以外の全生存者になった

人狼が仲間を攻撃対象として選べないようにする仕組みは #61 で対応する。

## Test plan
- [x] ビルド・既存テストがパスすること

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)