### PR TITLE
Introduce Oracle and GameSetup

### DIFF
--- a/src/main/kotlin/AliveCounts.kt
+++ b/src/main/kotlin/AliveCounts.kt
@@ -1,10 +1,6 @@
 package org.example
 
-class AliveCounts(alivePlayers: List<Player>) {
-    private val counts: Map<Side, Int> = Side.entries.associateWith { side ->
-        alivePlayers.count { it.role.side == side }
-    }
-
-    // Side.entriesを使って全陣営のカウントを設定するため、必ずgetできる
+class AliveCounts(private val counts: Map<Side, Int>) {
+    // 全陣営のカウントが揃っていることを呼び出し側が保証するため、必ずgetできる
     operator fun get(side: Side): Int = counts.getValue(side)
 }

--- a/src/main/kotlin/GameSetup.kt
+++ b/src/main/kotlin/GameSetup.kt
@@ -1,0 +1,3 @@
+package org.example
+
+data class GameSetup(val players: List<Player>, val oracle: Oracle)

--- a/src/main/kotlin/Lodge.kt
+++ b/src/main/kotlin/Lodge.kt
@@ -1,5 +1,5 @@
 package org.example
 
 interface Lodge {
-    fun create(): List<Player>
+    fun create(): GameSetup
 }

--- a/src/main/kotlin/Oracle.kt
+++ b/src/main/kotlin/Oracle.kt
@@ -1,14 +1,17 @@
 package org.example
 
 class Oracle(private val roles: Map<Player, Role>) {
+    private fun roleOf(player: Player): Role =
+        requireNotNull(roles[player]) { "Player not in Oracle: ${player.name}" }
+
     fun initiatePlayers() = roles.forEach { (player, role) -> GameEvent.RoleAssigned.send(role, player) }
 
     // Temporary: delegating to Role is Player's responsibility. Will be removed in #60
     // when Player becomes an abstract class with buildNightAction as a final method.
     fun buildNightAction(player: Player, alivePlayers: List<Player>, isFirstNight: Boolean): NightAction =
-        roles[player]!!.buildNightAction(player, alivePlayers, isFirstNight)
+        roleOf(player).buildNightAction(player, alivePlayers, isFirstNight)
 
     fun aliveCounts(alivePlayers: List<Player>): AliveCounts =
-        AliveCounts(Side.entries.associateWith { side -> alivePlayers.count { roles[it]!!.side == side } })
-    fun isWinner(player: Player, winningSide: Side): Boolean = roles[player]!!.side == winningSide
+        AliveCounts(Side.entries.associateWith { side -> alivePlayers.count { roleOf(it).side == side } })
+    fun isWinner(player: Player, winningSide: Side): Boolean = roleOf(player).side == winningSide
 }

--- a/src/main/kotlin/Oracle.kt
+++ b/src/main/kotlin/Oracle.kt
@@ -1,0 +1,14 @@
+package org.example
+
+class Oracle(private val roles: Map<Player, Role>) {
+    fun initiatePlayers() = roles.forEach { (player, role) -> GameEvent.RoleAssigned.send(role, player) }
+
+    // Temporary: delegating to Role is Player's responsibility. Will be removed in #60
+    // when Player becomes an abstract class with buildNightAction as a final method.
+    fun buildNightAction(player: Player, alivePlayers: List<Player>, isFirstNight: Boolean): NightAction =
+        roles[player]!!.buildNightAction(player, alivePlayers, isFirstNight)
+
+    fun aliveCounts(alivePlayers: List<Player>): AliveCounts =
+        AliveCounts(Side.entries.associateWith { side -> alivePlayers.count { roles[it]!!.side == side } })
+    fun isWinner(player: Player, winningSide: Side): Boolean = roles[player]!!.side == winningSide
+}

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -1,8 +1,9 @@
 package org.example
 
-class PlayerManager(allPlayers: List<Player>) {
+class PlayerManager(setup: GameSetup) {
 
-    private val _allPlayers: List<Player> = allPlayers
+    private val oracle = setup.oracle
+    private val _allPlayers: List<Player> = setup.players
     private val _alivePlayers: MutableList<Player> = _allPlayers.toMutableList()
     private val _executedPlayers: MutableList<Player> = mutableListOf()
     private val _attackedPlayers: MutableList<Player> = mutableListOf()
@@ -11,7 +12,7 @@ class PlayerManager(allPlayers: List<Player>) {
     private val allPlayers get() = AllPlayers(_allPlayers)
 
     private fun checkWinner() {
-        GameOverSignal.throwIfGameOver(AliveCounts(_alivePlayers))
+        GameOverSignal.throwIfGameOver(oracle.aliveCounts(_alivePlayers))
     }
 
     private fun die(player: Player) {
@@ -20,11 +21,11 @@ class PlayerManager(allPlayers: List<Player>) {
     }
 
     fun startGame() {
-        _allPlayers.forEach { GameEvent.RoleAssigned.send(it.role, it) }
+        oracle.initiatePlayers()
     }
 
     private fun runNightActions(nightNumber: Int): Player? {
-        val decisions = _alivePlayers.map { it to it.role.buildNightAction(it, _alivePlayers, nightNumber == 1) }
+        val decisions = _alivePlayers.map { it to oracle.buildNightAction(it, _alivePlayers, nightNumber == 1) }
 
         val attacks = decisions.map { it.second }.filterIsInstance<NightAction.Attack>()
         val guards = decisions.map { it.second }.filterIsInstance<NightAction.Guard>()
@@ -74,7 +75,7 @@ class PlayerManager(allPlayers: List<Player>) {
 
     fun endGame(signal: GameOverSignal) {
         GameEvent.GameOver.send(signal.winningSide, allPlayers)
-        _allPlayers.forEach { GameEvent.GameResult.send(it.role.side == signal.winningSide, it) }
+        _allPlayers.forEach { GameEvent.GameResult.send(oracle.isWinner(it, signal.winningSide), it) }
     }
 
     private fun execute(mostVoted: Player) {

--- a/src/main/kotlin/SmallLodge.kt
+++ b/src/main/kotlin/SmallLodge.kt
@@ -1,13 +1,20 @@
 package org.example
 
 object SmallLodge : Lodge {
-    override fun create(): List<Player> = listOf(
-        HumanPlayer(Role.HUNTER, "1", ConsolePlayerIO()),
-        HumanPlayer(Role.VILLAGER, "2", ConsolePlayerIO()),
-        HumanPlayer(Role.VILLAGER, "3", ConsolePlayerIO()),
-        HumanPlayer(Role.WEREWOLF, "4", ConsolePlayerIO()),
-        HumanPlayer(Role.SEER, "5", ConsolePlayerIO()),
-        HumanPlayer(Role.MEDIUM, "6", ConsolePlayerIO()),
-        HumanPlayer(Role.WEREWOLF, "7", ConsolePlayerIO()),
-    )
+    override fun create(): GameSetup {
+        val assignments: List<Pair<Role, (Role) -> Player>> = listOf(
+            Role.HUNTER  to { HumanPlayer(it, "1", ConsolePlayerIO()) },
+            Role.VILLAGER to { HumanPlayer(it, "2", ConsolePlayerIO()) },
+            Role.VILLAGER to { HumanPlayer(it, "3", ConsolePlayerIO()) },
+            Role.WEREWOLF to { HumanPlayer(it, "4", ConsolePlayerIO()) },
+            Role.SEER    to { HumanPlayer(it, "5", ConsolePlayerIO()) },
+            Role.MEDIUM  to { HumanPlayer(it, "6", ConsolePlayerIO()) },
+            Role.WEREWOLF to { HumanPlayer(it, "7", ConsolePlayerIO()) },
+        )
+        val playerRoles = assignments.map { (role, factory) -> factory(role) to role }
+        return GameSetup(
+            players = playerRoles.map { it.first },
+            oracle = Oracle(playerRoles.toMap()),
+        )
+    }
 }

--- a/src/test/kotlin/GameEventRoleAssignedTest.kt
+++ b/src/test/kotlin/GameEventRoleAssignedTest.kt
@@ -16,7 +16,11 @@ class GameEventRoleAssignedTest {
     fun `startGame notifies each player of their assigned role`() {
         val villager = RecordingPlayer(Role.VILLAGER, "Alice")
         val werewolf = RecordingPlayer(Role.WEREWOLF, "Bob")
-        PlayerManager(listOf(villager, werewolf)).startGame()
+        val setup = GameSetup(
+            players = listOf(villager, werewolf),
+            oracle = Oracle(mapOf(villager to Role.VILLAGER, werewolf to Role.WEREWOLF)),
+        )
+        PlayerManager(setup).startGame()
 
         val villagerEvent = villager.received.single() as GameEvent.RoleAssigned
         assertEquals(Role.VILLAGER, villagerEvent.role)


### PR DESCRIPTION
## Summary
- `Oracle` クラスを新設し、役職情報へのアクセスを集約
  - `initiatePlayers()`: 全プレイヤーに RoleAssigned を送信
  - `buildNightAction()`: Role に委譲（#60 で削除予定の暫定実装）
  - `aliveCounts()`: 陣営別生存者数を算出
  - `isWinner()`: プレイヤーの勝敗を判定
- `GameSetup` データクラスを新設（players + oracle）
- `Lodge.create()` の戻り値を `GameSetup` に変更
- `SmallLodge` を `(Role, factory)` ペアで構築するよう変更
- `AliveCounts` のコンストラクタを `Map<Side, Int>` 受け取りに変更
- `PlayerManager` が `GameSetup` を受け取り、Oracle 経由で役職を参照するよう更新
- `GameEventRoleAssignedTest` を `GameSetup` 構築に合わせて更新

## Test plan
- [ ] ビルド・既存テストがパスすること

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)