### PR TITLE
Replace FirstDivineFilter with NightAction.FirstNightDivine

### DIFF
--- a/src/main/kotlin/NightAction.kt
+++ b/src/main/kotlin/NightAction.kt
@@ -3,6 +3,7 @@ package org.example
 sealed interface NightAction {
     data object None : NightAction
     data class Attack(val target: Player) : NightAction
+    data object FirstNightDivine : NightAction
     data class Divine(val target: Player) : NightAction
     data object MediumReveal : NightAction
     data class Guard(val target: Player) : NightAction

--- a/src/main/kotlin/Oracle.kt
+++ b/src/main/kotlin/Oracle.kt
@@ -11,6 +11,13 @@ class Oracle(private val roles: Map<Player, Role>) {
     fun buildNightAction(player: Player, alivePlayers: List<Player>, isFirstNight: Boolean): NightAction =
         roleOf(player).buildNightAction(player, alivePlayers, isFirstNight)
 
+    fun firstNightDivine(seer: Player, alivePlayers: List<Player>) {
+        val target = alivePlayers.filterNot { it === seer }
+            .filter { roleOf(it).divineResult == DivineResult.NOT_WEREWOLF }
+            .random()
+        GameEvent.Divined.send(target, seer)
+    }
+
     fun aliveCounts(alivePlayers: List<Player>): AliveCounts =
         AliveCounts(Side.entries.associateWith { side -> alivePlayers.count { roleOf(it).side == side } })
     fun isWinner(player: Player, winningSide: Side): Boolean = roleOf(player).side == winningSide

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -41,6 +41,7 @@ class PlayerManager(setup: GameSetup) {
                 is NightAction.None -> Unit
                 is NightAction.Attack -> Unit
                 is NightAction.Guard -> Unit
+                is NightAction.FirstNightDivine -> oracle.firstNightDivine(player, _alivePlayers)
                 is NightAction.Divine -> GameEvent.Divined.send(decision.target, player)
                 is NightAction.MediumReveal -> _executedPlayers.lastOrNull()?.let { target ->
                     GameEvent.MediumRevealed.send(target, player)

--- a/src/main/kotlin/Role.kt
+++ b/src/main/kotlin/Role.kt
@@ -8,7 +8,7 @@ enum class Role(val displayName: String, val side: Side, val divineResult: Divin
     },
     SEER("占い師", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
         override fun firstNightAction(self: Player, players: List<Player>): NightAction =
-            NightAction.Divine(FirstDivineFilter.candidates(self, players).random())
+            NightAction.FirstNightDivine
         override fun normalNightAction(self: Player, players: List<Player>): NightAction =
             NightAction.Divine(self.selectTarget(SelectionContext.Divine(self, players)))
     },

--- a/src/main/kotlin/SelectionContext.kt
+++ b/src/main/kotlin/SelectionContext.kt
@@ -23,8 +23,3 @@ sealed class SelectionContext(val title: String, val description: String) {
         override fun candidates() = players.filterNot { it === self }
     }
 }
-
-object FirstDivineFilter {
-    fun candidates(self: Player, players: List<Player>): List<Player> =
-        players.filterNot { it === self }.filter { it.role.divineResult == DivineResult.NOT_WEREWOLF }
-}

--- a/src/test/kotlin/OracleFirstNightDivineTest.kt
+++ b/src/test/kotlin/OracleFirstNightDivineTest.kt
@@ -1,0 +1,38 @@
+package org.example
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+
+class OracleFirstNightDivineTest {
+
+    private class RecordingPlayer(override val role: Role, override val name: String) : Player {
+        val divinedTargets = mutableListOf<Player>()
+        override fun selectTarget(context: SelectionContext) = this
+        override fun receive(event: GameEvent) { divinedTargets.add((event as GameEvent.Divined).target) }
+        override fun discuss(players: List<Player>) = ""
+    }
+
+    @Test
+    fun `never selects seer as divine target`() {
+        val seer = RecordingPlayer(Role.SEER, "Seer")
+        val villager1 = RecordingPlayer(Role.VILLAGER, "V1")
+        val villager2 = RecordingPlayer(Role.VILLAGER, "V2")
+        val oracle = Oracle(mapOf(seer to Role.SEER, villager1 to Role.VILLAGER, villager2 to Role.VILLAGER))
+
+        repeat(100) { oracle.firstNightDivine(seer, listOf(seer, villager1, villager2)) }
+
+        assertFalse(seer in seer.divinedTargets)
+    }
+
+    @Test
+    fun `never selects werewolf as divine target`() {
+        val seer = RecordingPlayer(Role.SEER, "Seer")
+        val werewolf = RecordingPlayer(Role.WEREWOLF, "Wolf")
+        val villager = RecordingPlayer(Role.VILLAGER, "Villager")
+        val oracle = Oracle(mapOf(seer to Role.SEER, werewolf to Role.WEREWOLF, villager to Role.VILLAGER))
+
+        repeat(100) { oracle.firstNightDivine(seer, listOf(seer, werewolf, villager)) }
+
+        assertFalse(werewolf in seer.divinedTargets)
+    }
+}


### PR DESCRIPTION
## Summary
- `NightAction.FirstNightDivine`（target フィールドなし）を追加
- `Role.SEER.firstNightAction` が `FirstNightDivine` を返すよう変更
- `Oracle.firstNightDivine()` を追加し、候補の絞り込みとイベント送信を Oracle に集約
- `PlayerManager` が `FirstNightDivine` を Oracle に委譲するよう更新
- `FirstDivineFilter` を削除し、`SelectionContext` から `Player.role` 参照を除去
- `OracleFirstNightDivineTest` を追加（自分・人狼が選ばれないことを検証）

## Test plan
- [x] `OracleFirstNightDivineTest` — 自分・人狼が選ばれないことを100回繰り返しで検証
- [x] 既存テストがすべてパスすること

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)