### PR TITLE
Remove Player.role references from GameEvent.Divined and GameEvent.MediumRevealed

### DIFF
--- a/src/main/kotlin/GameEvent.kt
+++ b/src/main/kotlin/GameEvent.kt
@@ -47,7 +47,7 @@ sealed class GameEvent {
         override fun body(self: Player) = "${target.name} は「${result.displayName}」です。"
         override val recipients: Notifiable = recipient
         companion object {
-            fun send(target: Player, recipient: Player) = Divined(target, target.role.divineResult, recipient).dispatch()
+            fun send(target: Player, result: DivineResult, recipient: Player) = Divined(target, result, recipient).dispatch()
         }
     }
 
@@ -57,7 +57,7 @@ sealed class GameEvent {
         override fun body(self: Player) = "${target.name} は「${result.displayName}」です。"
         override val recipients: Notifiable = recipient
         companion object {
-            fun send(target: Player, recipient: Player) = MediumRevealed(target, target.role.mediumResult, recipient).dispatch()
+            fun send(target: Player, result: MediumResult, recipient: Player) = MediumRevealed(target, result, recipient).dispatch()
         }
     }
 

--- a/src/main/kotlin/Oracle.kt
+++ b/src/main/kotlin/Oracle.kt
@@ -11,11 +11,17 @@ class Oracle(private val roles: Map<Player, Role>) {
     fun buildNightAction(player: Player, alivePlayers: List<Player>, isFirstNight: Boolean): NightAction =
         roleOf(player).buildNightAction(player, alivePlayers, isFirstNight)
 
+    fun divine(seer: Player, target: Player) =
+        GameEvent.Divined.send(target, roleOf(target).divineResult, seer)
+
+    fun mediumReveal(medium: Player, target: Player) =
+        GameEvent.MediumRevealed.send(target, roleOf(target).mediumResult, medium)
+
     fun firstNightDivine(seer: Player, alivePlayers: List<Player>) {
         val target = alivePlayers.filterNot { it === seer }
             .filter { roleOf(it).divineResult == DivineResult.NOT_WEREWOLF }
             .random()
-        GameEvent.Divined.send(target, seer)
+        divine(seer, target)
     }
 
     fun aliveCounts(alivePlayers: List<Player>): AliveCounts =

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -42,9 +42,9 @@ class PlayerManager(setup: GameSetup) {
                 is NightAction.Attack -> Unit
                 is NightAction.Guard -> Unit
                 is NightAction.FirstNightDivine -> oracle.firstNightDivine(player, _alivePlayers)
-                is NightAction.Divine -> GameEvent.Divined.send(decision.target, player)
+                is NightAction.Divine -> oracle.divine(player, decision.target)
                 is NightAction.MediumReveal -> _executedPlayers.lastOrNull()?.let { target ->
-                    GameEvent.MediumRevealed.send(target, player)
+                    oracle.mediumReveal(player, target)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- `GameEvent.Divined.send()` のシグネチャを変更し、`DivineResult` を直接受け取るよう修正（`Player.role` 参照を除去）
- `GameEvent.MediumRevealed.send()` のシグネチャを変更し、`MediumResult` を直接受け取るよう修正（`Player.role` 参照を除去）
- `Oracle` に `divine()` と `mediumReveal()` を追加し、役職情報の解決とイベント送信を集約
- `Oracle.firstNightDivine()` が `divine()` を再利用するよう整理
- `PlayerManager` が `GameEvent.Divined` / `GameEvent.MediumRevealed` を直接扱わず Oracle に委譲

## Test plan
- [x] 既存テストがすべてパスすること

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)