### PR TITLE
Change Player to abstract class and make role private

### DIFF
--- a/src/main/kotlin/HumanPlayer.kt
+++ b/src/main/kotlin/HumanPlayer.kt
@@ -1,6 +1,6 @@
 package org.example
 
-class HumanPlayer(override val role: Role, override val name: String, private val io: PlayerIO) : Player {
+class HumanPlayer(role: Role, override val name: String, private val io: PlayerIO) : Player(role) {
     override fun selectTarget(context: SelectionContext): Player =
         io.prompt(name, context.title, context.description, context.candidates())
 

--- a/src/main/kotlin/Oracle.kt
+++ b/src/main/kotlin/Oracle.kt
@@ -6,11 +6,6 @@ class Oracle(private val roles: Map<Player, Role>) {
 
     fun initiatePlayers() = roles.forEach { (player, role) -> GameEvent.RoleAssigned.send(role, player) }
 
-    // Temporary: delegating to Role is Player's responsibility. Will be removed in #60
-    // when Player becomes an abstract class with buildNightAction as a final method.
-    fun buildNightAction(player: Player, alivePlayers: List<Player>, isFirstNight: Boolean): NightAction =
-        roleOf(player).buildNightAction(player, alivePlayers, isFirstNight)
-
     fun divine(seer: Player, target: Player) =
         GameEvent.Divined.send(target, roleOf(target).divineResult, seer)
 

--- a/src/main/kotlin/Player.kt
+++ b/src/main/kotlin/Player.kt
@@ -1,9 +1,11 @@
 package org.example
 
-interface Player : Notifiable {
-    val name: String
-    val role: Role
-    fun selectTarget(context: SelectionContext): Player
-    override fun receive(event: GameEvent)
-    fun discuss(players: List<Player>): String
+abstract class Player(private val role: Role) : Notifiable {
+    abstract val name: String
+    abstract fun selectTarget(context: SelectionContext): Player
+    abstract override fun receive(event: GameEvent)
+    abstract fun discuss(players: List<Player>): String
+
+    fun buildNightAction(players: List<Player>, isFirstNight: Boolean): NightAction =
+        role.buildNightAction(this, players, isFirstNight)
 }

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -25,7 +25,7 @@ class PlayerManager(setup: GameSetup) {
     }
 
     private fun runNightActions(nightNumber: Int): Player? {
-        val decisions = _alivePlayers.map { it to oracle.buildNightAction(it, _alivePlayers, nightNumber == 1) }
+        val decisions = _alivePlayers.map { it to it.buildNightAction(_alivePlayers, nightNumber == 1) }
 
         val attacks = decisions.map { it.second }.filterIsInstance<NightAction.Attack>()
         val guards = decisions.map { it.second }.filterIsInstance<NightAction.Guard>()

--- a/src/test/kotlin/DiscussionTest.kt
+++ b/src/test/kotlin/DiscussionTest.kt
@@ -7,9 +7,9 @@ class DiscussionTest {
 
     private class TestPlayer(
         override val name: String,
-        override val role: Role,
+        role: Role,
         private val statements: List<String>
-    ) : Player {
+    ) : Player(role) {
         private val _log = mutableListOf<String>()
         val log: List<String> get() = _log
         private var statementIndex = 0

--- a/src/test/kotlin/GameEventRoleAssignedTest.kt
+++ b/src/test/kotlin/GameEventRoleAssignedTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.assertEquals
 
 class GameEventRoleAssignedTest {
 
-    private class RecordingPlayer(override val role: Role, override val name: String) : Player {
+    private class RecordingPlayer(role: Role, override val name: String) : Player(role) {
         val received = mutableListOf<GameEvent>()
         override fun selectTarget(context: SelectionContext) = this
         override fun receive(event: GameEvent) { received.add(event) }

--- a/src/test/kotlin/OracleFirstNightDivineTest.kt
+++ b/src/test/kotlin/OracleFirstNightDivineTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.assertFalse
 
 class OracleFirstNightDivineTest {
 
-    private class RecordingPlayer(override val role: Role, override val name: String) : Player {
+    private class RecordingPlayer(role: Role, override val name: String) : Player(role) {
         val divinedTargets = mutableListOf<Player>()
         override fun selectTarget(context: SelectionContext) = this
         override fun receive(event: GameEvent) { divinedTargets.add((event as GameEvent.Divined).target) }


### PR DESCRIPTION
## Summary

- `Player` を `interface` から `abstract class(private val role: Role)` に変更し、`role` を private 化
- `buildNightAction()` を `Player` の final メソッドとして定義し、`role.buildNightAction()` に委譲
- `Oracle.buildNightAction()` を削除し、`PlayerManager` が `player.buildNightAction()` を直接呼ぶように変更
- `HumanPlayer`・テストの `RecordingPlayer` / `TestPlayer` を abstract class 継承に更新

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)