### PR TITLE
Prevent werewolves from attacking allies via stored GameEvents

### DIFF
--- a/src/main/kotlin/GameEvent.kt
+++ b/src/main/kotlin/GameEvent.kt
@@ -112,4 +112,14 @@ sealed class GameEvent {
             fun send(isWinner: Boolean, recipient: Player) = GameResult(isWinner, recipient).dispatch()
         }
     }
+
+    @ConsistentCopyVisibility
+    data class WerewolfAllyRevealed private constructor(val ally: Player, private val recipient: Player) : GameEvent() {
+        override val title = "仲間通知"
+        override fun body(self: Player) = "${ally.name} は仲間の人狼です。"
+        override val recipients: Notifiable = recipient
+        companion object {
+            fun send(ally: Player, recipient: Player) = WerewolfAllyRevealed(ally, recipient).dispatch()
+        }
+    }
 }

--- a/src/main/kotlin/HumanPlayer.kt
+++ b/src/main/kotlin/HumanPlayer.kt
@@ -4,7 +4,7 @@ class HumanPlayer(role: Role, override val name: String, private val io: PlayerI
     override fun selectTarget(context: SelectionContext): Player =
         io.prompt(name, context.title, context.description, context.candidates())
 
-    override fun receive(event: GameEvent) {
+    override fun onReceive(event: GameEvent) {
         io.sendMessage(name, event.title, event.body(this))
     }
 

--- a/src/main/kotlin/Oracle.kt
+++ b/src/main/kotlin/Oracle.kt
@@ -4,7 +4,15 @@ class Oracle(private val roles: Map<Player, Role>) {
     private fun roleOf(player: Player): Role =
         requireNotNull(roles[player]) { "Player not in Oracle: ${player.name}" }
 
-    fun initiatePlayers() = roles.forEach { (player, role) -> GameEvent.RoleAssigned.send(role, player) }
+    fun initiatePlayers() {
+        roles.forEach { (player, role) -> GameEvent.RoleAssigned.send(role, player) }
+        val werewolves = roles.filter { it.value == Role.WEREWOLF }.keys.toList()
+        werewolves.forEach { wolf ->
+            werewolves.filterNot { it === wolf }.forEach { ally ->
+                GameEvent.WerewolfAllyRevealed.send(ally, wolf)
+            }
+        }
+    }
 
     fun divine(seer: Player, target: Player) =
         GameEvent.Divined.send(target, roleOf(target).divineResult, seer)

--- a/src/main/kotlin/Player.kt
+++ b/src/main/kotlin/Player.kt
@@ -2,11 +2,10 @@ package org.example
 
 abstract class Player(private val role: Role) : Notifiable {
     abstract val name: String
-    private val _receivedEvents: MutableList<GameEvent> = mutableListOf()
-    val receivedEvents: List<GameEvent> get() = _receivedEvents
+    private val _knowledge: MutableList<GameEvent> = mutableListOf()
 
     final override fun receive(event: GameEvent) {
-        _receivedEvents.add(event)
+        _knowledge.add(event)
         onReceive(event)
     }
 
@@ -15,5 +14,5 @@ abstract class Player(private val role: Role) : Notifiable {
     abstract fun discuss(players: List<Player>): String
 
     fun buildNightAction(players: List<Player>, isFirstNight: Boolean): NightAction =
-        role.buildNightAction(this, players, isFirstNight)
+        role.buildNightAction(this, players, isFirstNight, _knowledge.toList())
 }

--- a/src/main/kotlin/Player.kt
+++ b/src/main/kotlin/Player.kt
@@ -2,8 +2,16 @@ package org.example
 
 abstract class Player(private val role: Role) : Notifiable {
     abstract val name: String
+    private val _receivedEvents: MutableList<GameEvent> = mutableListOf()
+    val receivedEvents: List<GameEvent> get() = _receivedEvents
+
+    final override fun receive(event: GameEvent) {
+        _receivedEvents.add(event)
+        onReceive(event)
+    }
+
+    protected abstract fun onReceive(event: GameEvent)
     abstract fun selectTarget(context: SelectionContext): Player
-    abstract override fun receive(event: GameEvent)
     abstract fun discuss(players: List<Player>): String
 
     fun buildNightAction(players: List<Player>, isFirstNight: Boolean): NightAction =

--- a/src/main/kotlin/Role.kt
+++ b/src/main/kotlin/Role.kt
@@ -3,8 +3,12 @@ package org.example
 enum class Role(val displayName: String, val side: Side, val divineResult: DivineResult, val mediumResult: MediumResult) {
     WEREWOLF("人狼", Side.WEREWOLF, DivineResult.WEREWOLF, MediumResult.WEREWOLF) {
         override fun firstNightAction(self: Player, players: List<Player>): NightAction = NightAction.None
-        override fun normalNightAction(self: Player, players: List<Player>): NightAction =
-            NightAction.Attack(self.selectTarget(SelectionContext.Attack(self, players)))
+        override fun normalNightAction(self: Player, players: List<Player>): NightAction {
+            val allies = self.receivedEvents
+                .filterIsInstance<GameEvent.WerewolfAllyRevealed>()
+                .map { it.ally }
+            return NightAction.Attack(self.selectTarget(SelectionContext.Attack(self, players, allies)))
+        }
     },
     SEER("占い師", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
         override fun firstNightAction(self: Player, players: List<Player>): NightAction =

--- a/src/main/kotlin/Role.kt
+++ b/src/main/kotlin/Role.kt
@@ -3,8 +3,8 @@ package org.example
 enum class Role(val displayName: String, val side: Side, val divineResult: DivineResult, val mediumResult: MediumResult) {
     WEREWOLF("人狼", Side.WEREWOLF, DivineResult.WEREWOLF, MediumResult.WEREWOLF) {
         override fun firstNightAction(self: Player, players: List<Player>): NightAction = NightAction.None
-        override fun normalNightAction(self: Player, players: List<Player>): NightAction {
-            val allies = self.receivedEvents
+        override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction {
+            val allies = knowledge
                 .filterIsInstance<GameEvent.WerewolfAllyRevealed>()
                 .map { it.ally }
             return NightAction.Attack(self.selectTarget(SelectionContext.Attack(self, players, allies)))
@@ -13,26 +13,26 @@ enum class Role(val displayName: String, val side: Side, val divineResult: Divin
     SEER("占い師", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
         override fun firstNightAction(self: Player, players: List<Player>): NightAction =
             NightAction.FirstNightDivine
-        override fun normalNightAction(self: Player, players: List<Player>): NightAction =
+        override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction =
             NightAction.Divine(self.selectTarget(SelectionContext.Divine(self, players)))
     },
     MEDIUM("霊能者", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
         override fun firstNightAction(self: Player, players: List<Player>): NightAction = NightAction.MediumReveal
-        override fun normalNightAction(self: Player, players: List<Player>): NightAction = NightAction.MediumReveal
+        override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction = NightAction.MediumReveal
     },
     VILLAGER("村人", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
         override fun firstNightAction(self: Player, players: List<Player>): NightAction = NightAction.None
-        override fun normalNightAction(self: Player, players: List<Player>): NightAction = NightAction.None
+        override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction = NightAction.None
     },
     HUNTER("狩人", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
         override fun firstNightAction(self: Player, players: List<Player>): NightAction = NightAction.None
-        override fun normalNightAction(self: Player, players: List<Player>): NightAction =
+        override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction =
             NightAction.Guard(self.selectTarget(SelectionContext.Guard(self, players)))
     };
 
     abstract fun firstNightAction(self: Player, players: List<Player>): NightAction
-    abstract fun normalNightAction(self: Player, players: List<Player>): NightAction
+    abstract fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction
 
-    fun buildNightAction(self: Player, players: List<Player>, isFirstNight: Boolean): NightAction =
-        if (isFirstNight) firstNightAction(self, players) else normalNightAction(self, players)
+    fun buildNightAction(self: Player, players: List<Player>, isFirstNight: Boolean, knowledge: List<GameEvent>): NightAction =
+        if (isFirstNight) firstNightAction(self, players) else normalNightAction(self, players, knowledge)
 }

--- a/src/main/kotlin/SelectionContext.kt
+++ b/src/main/kotlin/SelectionContext.kt
@@ -3,7 +3,7 @@ package org.example
 sealed class SelectionContext(val title: String, val description: String) {
     abstract fun candidates(): List<Player>
 
-    class Attack(private val self: Player, private val players: List<Player>, private val allies: List<Player> = emptyList())
+    class Attack(private val self: Player, private val players: List<Player>, private val allies: List<Player>)
         : SelectionContext("夜の行動", "襲撃先を選んでください") {
         override fun candidates() = players.filterNot { it === self || it in allies }
     }

--- a/src/main/kotlin/SelectionContext.kt
+++ b/src/main/kotlin/SelectionContext.kt
@@ -3,9 +3,9 @@ package org.example
 sealed class SelectionContext(val title: String, val description: String) {
     abstract fun candidates(): List<Player>
 
-    class Attack(private val self: Player, private val players: List<Player>)
+    class Attack(private val self: Player, private val players: List<Player>, private val allies: List<Player> = emptyList())
         : SelectionContext("夜の行動", "襲撃先を選んでください") {
-        override fun candidates() = players.filterNot { it === self }
+        override fun candidates() = players.filterNot { it === self || it in allies }
     }
 
     class Divine(private val self: Player, private val players: List<Player>)

--- a/src/test/kotlin/DiscussionTest.kt
+++ b/src/test/kotlin/DiscussionTest.kt
@@ -20,7 +20,7 @@ class DiscussionTest {
             return statement
         }
 
-        override fun receive(event: GameEvent) {
+        override fun onReceive(event: GameEvent) {
             when (event) {
                 is GameEvent.StatementMade -> _log.add("$name:heard:${event.speakerName}:${event.statement}")
                 else -> error("unexpected event in discussion test: $event")

--- a/src/test/kotlin/GameEventRoleAssignedTest.kt
+++ b/src/test/kotlin/GameEventRoleAssignedTest.kt
@@ -6,8 +6,9 @@ import kotlin.test.assertEquals
 class GameEventRoleAssignedTest {
 
     private class RecordingPlayer(role: Role, override val name: String) : Player(role) {
+        val received = mutableListOf<GameEvent>()
         override fun selectTarget(context: SelectionContext) = this
-        override fun onReceive(event: GameEvent) = Unit
+        override fun onReceive(event: GameEvent) { received.add(event) }
         override fun discuss(players: List<Player>) = ""
     }
 
@@ -21,11 +22,11 @@ class GameEventRoleAssignedTest {
         )
         PlayerManager(setup).startGame()
 
-        val villagerEvent = villager.receivedEvents.single() as GameEvent.RoleAssigned
+        val villagerEvent = villager.received.single() as GameEvent.RoleAssigned
         assertEquals(Role.VILLAGER, villagerEvent.role)
         assertEquals("あなたの役職は「村人」です。", villagerEvent.body(villager))
 
-        val werewolfEvent = werewolf.receivedEvents.single() as GameEvent.RoleAssigned
+        val werewolfEvent = werewolf.received.single() as GameEvent.RoleAssigned
         assertEquals(Role.WEREWOLF, werewolfEvent.role)
         assertEquals("あなたの役職は「人狼」です。", werewolfEvent.body(werewolf))
     }

--- a/src/test/kotlin/GameEventRoleAssignedTest.kt
+++ b/src/test/kotlin/GameEventRoleAssignedTest.kt
@@ -6,9 +6,8 @@ import kotlin.test.assertEquals
 class GameEventRoleAssignedTest {
 
     private class RecordingPlayer(role: Role, override val name: String) : Player(role) {
-        val received = mutableListOf<GameEvent>()
         override fun selectTarget(context: SelectionContext) = this
-        override fun receive(event: GameEvent) { received.add(event) }
+        override fun onReceive(event: GameEvent) = Unit
         override fun discuss(players: List<Player>) = ""
     }
 
@@ -22,11 +21,11 @@ class GameEventRoleAssignedTest {
         )
         PlayerManager(setup).startGame()
 
-        val villagerEvent = villager.received.single() as GameEvent.RoleAssigned
+        val villagerEvent = villager.receivedEvents.single() as GameEvent.RoleAssigned
         assertEquals(Role.VILLAGER, villagerEvent.role)
         assertEquals("あなたの役職は「村人」です。", villagerEvent.body(villager))
 
-        val werewolfEvent = werewolf.received.single() as GameEvent.RoleAssigned
+        val werewolfEvent = werewolf.receivedEvents.single() as GameEvent.RoleAssigned
         assertEquals(Role.WEREWOLF, werewolfEvent.role)
         assertEquals("あなたの役職は「人狼」です。", werewolfEvent.body(werewolf))
     }

--- a/src/test/kotlin/OracleFirstNightDivineTest.kt
+++ b/src/test/kotlin/OracleFirstNightDivineTest.kt
@@ -6,13 +6,16 @@ import kotlin.test.assertFalse
 class OracleFirstNightDivineTest {
 
     private class RecordingPlayer(role: Role, override val name: String) : Player(role) {
+        val divinedTargets = mutableListOf<Player>()
         override fun selectTarget(context: SelectionContext) = this
-        override fun onReceive(event: GameEvent) = Unit
+        override fun onReceive(event: GameEvent) {
+            when (event) {
+                is GameEvent.Divined -> divinedTargets.add(event.target)
+                else -> error("unexpected event in oracle first night divine test: $event")
+            }
+        }
         override fun discuss(players: List<Player>) = ""
     }
-
-    private fun RecordingPlayer.divinedTargets() =
-        receivedEvents.filterIsInstance<GameEvent.Divined>().map { it.target }
 
     @Test
     fun `never selects seer as divine target`() {
@@ -23,7 +26,7 @@ class OracleFirstNightDivineTest {
 
         repeat(100) { oracle.firstNightDivine(seer, listOf(seer, villager1, villager2)) }
 
-        assertFalse(seer in seer.divinedTargets())
+        assertFalse(seer in seer.divinedTargets)
     }
 
     @Test
@@ -35,6 +38,6 @@ class OracleFirstNightDivineTest {
 
         repeat(100) { oracle.firstNightDivine(seer, listOf(seer, werewolf, villager)) }
 
-        assertFalse(werewolf in seer.divinedTargets())
+        assertFalse(werewolf in seer.divinedTargets)
     }
 }

--- a/src/test/kotlin/OracleFirstNightDivineTest.kt
+++ b/src/test/kotlin/OracleFirstNightDivineTest.kt
@@ -6,11 +6,13 @@ import kotlin.test.assertFalse
 class OracleFirstNightDivineTest {
 
     private class RecordingPlayer(role: Role, override val name: String) : Player(role) {
-        val divinedTargets = mutableListOf<Player>()
         override fun selectTarget(context: SelectionContext) = this
-        override fun receive(event: GameEvent) { divinedTargets.add((event as GameEvent.Divined).target) }
+        override fun onReceive(event: GameEvent) = Unit
         override fun discuss(players: List<Player>) = ""
     }
+
+    private fun RecordingPlayer.divinedTargets() =
+        receivedEvents.filterIsInstance<GameEvent.Divined>().map { it.target }
 
     @Test
     fun `never selects seer as divine target`() {
@@ -21,7 +23,7 @@ class OracleFirstNightDivineTest {
 
         repeat(100) { oracle.firstNightDivine(seer, listOf(seer, villager1, villager2)) }
 
-        assertFalse(seer in seer.divinedTargets)
+        assertFalse(seer in seer.divinedTargets())
     }
 
     @Test
@@ -33,6 +35,6 @@ class OracleFirstNightDivineTest {
 
         repeat(100) { oracle.firstNightDivine(seer, listOf(seer, werewolf, villager)) }
 
-        assertFalse(werewolf in seer.divinedTargets)
+        assertFalse(werewolf in seer.divinedTargets())
     }
 }

--- a/src/test/kotlin/SelectionContextAttackTest.kt
+++ b/src/test/kotlin/SelectionContextAttackTest.kt
@@ -19,7 +19,7 @@ class SelectionContextAttackTest {
         val villager = StubPlayer("Villager", Role.VILLAGER)
         val players = listOf(wolf, villager)
 
-        val candidates = SelectionContext.Attack(wolf, players).candidates()
+        val candidates = SelectionContext.Attack(wolf, players, emptyList()).candidates()
 
         assertFalse(wolf in candidates)
         assertTrue(villager in candidates)
@@ -44,7 +44,7 @@ class SelectionContextAttackTest {
         val villager2 = StubPlayer("V2", Role.VILLAGER)
         val players = listOf(wolf, villager1, villager2)
 
-        val candidates = SelectionContext.Attack(wolf, players).candidates()
+        val candidates = SelectionContext.Attack(wolf, players, emptyList()).candidates()
 
         assertEquals(listOf(villager1, villager2), candidates)
     }

--- a/src/test/kotlin/SelectionContextAttackTest.kt
+++ b/src/test/kotlin/SelectionContextAttackTest.kt
@@ -1,0 +1,51 @@
+package org.example
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SelectionContextAttackTest {
+
+    private class StubPlayer(override val name: String, role: Role) : Player(role) {
+        override fun selectTarget(context: SelectionContext) = this
+        override fun onReceive(event: GameEvent) = Unit
+        override fun discuss(players: List<Player>) = ""
+    }
+
+    @Test
+    fun `excludes self from candidates`() {
+        val wolf = StubPlayer("Wolf", Role.WEREWOLF)
+        val villager = StubPlayer("Villager", Role.VILLAGER)
+        val players = listOf(wolf, villager)
+
+        val candidates = SelectionContext.Attack(wolf, players).candidates()
+
+        assertFalse(wolf in candidates)
+        assertTrue(villager in candidates)
+    }
+
+    @Test
+    fun `excludes werewolf allies from candidates`() {
+        val wolf1 = StubPlayer("Wolf1", Role.WEREWOLF)
+        val wolf2 = StubPlayer("Wolf2", Role.WEREWOLF)
+        val villager = StubPlayer("Villager", Role.VILLAGER)
+        val players = listOf(wolf1, wolf2, villager)
+
+        val candidates = SelectionContext.Attack(wolf1, players, allies = listOf(wolf2)).candidates()
+
+        assertEquals(listOf(villager), candidates)
+    }
+
+    @Test
+    fun `includes all non-self players when no allies`() {
+        val wolf = StubPlayer("Wolf", Role.WEREWOLF)
+        val villager1 = StubPlayer("V1", Role.VILLAGER)
+        val villager2 = StubPlayer("V2", Role.VILLAGER)
+        val players = listOf(wolf, villager1, villager2)
+
+        val candidates = SelectionContext.Attack(wolf, players).candidates()
+
+        assertEquals(listOf(villager1, villager2), candidates)
+    }
+}


### PR DESCRIPTION
## Summary

- `Player` に `receivedEvents` リストを追加し、`receive()` を `final` 化。サブクラスは `onReceive()` をオーバーライドする設計に変更
- `GameEvent.WerewolfAllyRevealed` を追加し、`Oracle.initiatePlayers()` でゲーム開始時に人狼同士へ仲間を通知
- `Role.WEREWOLF.normalNightAction()` が `receivedEvents` から仲間を特定し、`SelectionContext.Attack` の候補から除外することで人狼が仲間を攻撃できない仕様を回復
- `SelectionContext.Attack` に `allies` パラメータを追加（デフォルト `emptyList()`）
- テストの `receive()` を `onReceive()` に更新し、`receivedEvents` を活用するよう簡略化
- `SelectionContextAttackTest` を追加（自分・仲間の除外を検証）

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)