### PR TITLE
Derive medium's reveal target from knowledge instead of PlayerManager tracking

### DIFF
--- a/src/main/kotlin/NightAction.kt
+++ b/src/main/kotlin/NightAction.kt
@@ -5,6 +5,6 @@ sealed interface NightAction {
     data class Attack(val target: Player) : NightAction
     data object FirstNightDivine : NightAction
     data class Divine(val target: Player) : NightAction
-    data object MediumReveal : NightAction
+    data class MediumReveal(val target: Player) : NightAction
     data class Guard(val target: Player) : NightAction
 }

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -5,7 +5,6 @@ class PlayerManager(setup: GameSetup) {
     private val oracle = setup.oracle
     private val _allPlayers: List<Player> = setup.players
     private val _alivePlayers: MutableList<Player> = _allPlayers.toMutableList()
-    private val _executedPlayers: MutableList<Player> = mutableListOf()
     private val _attackedPlayers: MutableList<Player> = mutableListOf()
     val players: List<Player> get() = _alivePlayers
 
@@ -43,9 +42,7 @@ class PlayerManager(setup: GameSetup) {
                 is NightAction.Guard -> Unit
                 is NightAction.FirstNightDivine -> oracle.firstNightDivine(player, _alivePlayers)
                 is NightAction.Divine -> oracle.divine(player, decision.target)
-                is NightAction.MediumReveal -> _executedPlayers.lastOrNull()?.let { target ->
-                    oracle.mediumReveal(player, target)
-                }
+                is NightAction.MediumReveal -> oracle.mediumReveal(player, decision.target)
             }
         }
     }
@@ -81,7 +78,6 @@ class PlayerManager(setup: GameSetup) {
 
     private fun execute(mostVoted: Player) {
         GameEvent.PlayerExecuted.send(mostVoted, allPlayers)
-        _executedPlayers.add(mostVoted)
         die(mostVoted)
     }
 

--- a/src/main/kotlin/Role.kt
+++ b/src/main/kotlin/Role.kt
@@ -2,7 +2,7 @@ package org.example
 
 enum class Role(val displayName: String, val side: Side, val divineResult: DivineResult, val mediumResult: MediumResult) {
     WEREWOLF("人狼", Side.WEREWOLF, DivineResult.WEREWOLF, MediumResult.WEREWOLF) {
-        override fun firstNightAction(self: Player, players: List<Player>): NightAction = NightAction.None
+        override fun firstNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction = NightAction.None
         override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction {
             val allies = knowledge
                 .filterIsInstance<GameEvent.WerewolfAllyRevealed>()
@@ -11,28 +11,35 @@ enum class Role(val displayName: String, val side: Side, val divineResult: Divin
         }
     },
     SEER("占い師", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
-        override fun firstNightAction(self: Player, players: List<Player>): NightAction =
+        override fun firstNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction =
             NightAction.FirstNightDivine
         override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction =
             NightAction.Divine(self.selectTarget(SelectionContext.Divine(self, players)))
     },
     MEDIUM("霊能者", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
-        override fun firstNightAction(self: Player, players: List<Player>): NightAction = NightAction.MediumReveal
-        override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction = NightAction.MediumReveal
+        override fun firstNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction =
+            normalNightAction(self, players, knowledge)
+        override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction {
+            val revealedTargets = knowledge.filterIsInstance<GameEvent.MediumRevealed>().map { it.target }
+            val nextTarget = knowledge.filterIsInstance<GameEvent.PlayerExecuted>()
+                .map { it.executed }
+                .firstOrNull { executed -> revealedTargets.none { it === executed } }
+            return if (nextTarget != null) NightAction.MediumReveal(nextTarget) else NightAction.None
+        }
     },
     VILLAGER("村人", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
-        override fun firstNightAction(self: Player, players: List<Player>): NightAction = NightAction.None
+        override fun firstNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction = NightAction.None
         override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction = NightAction.None
     },
     HUNTER("狩人", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
-        override fun firstNightAction(self: Player, players: List<Player>): NightAction = NightAction.None
+        override fun firstNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction = NightAction.None
         override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction =
             NightAction.Guard(self.selectTarget(SelectionContext.Guard(self, players)))
     };
 
-    abstract fun firstNightAction(self: Player, players: List<Player>): NightAction
+    abstract fun firstNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction
     abstract fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction
 
     fun buildNightAction(self: Player, players: List<Player>, isFirstNight: Boolean, knowledge: List<GameEvent>): NightAction =
-        if (isFirstNight) firstNightAction(self, players) else normalNightAction(self, players, knowledge)
+        if (isFirstNight) firstNightAction(self, players, knowledge) else normalNightAction(self, players, knowledge)
 }

--- a/src/test/kotlin/RoleMediumNightActionTest.kt
+++ b/src/test/kotlin/RoleMediumNightActionTest.kt
@@ -1,0 +1,83 @@
+package org.example
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RoleMediumNightActionTest {
+
+    private class StubPlayer(override val name: String, role: Role) : Player(role) {
+        override fun selectTarget(context: SelectionContext) = this
+        override fun onReceive(event: GameEvent) = Unit
+        override fun discuss(players: List<Player>) = ""
+    }
+
+    @Test
+    fun `returns None when no executions in knowledge`() {
+        val medium = StubPlayer("Medium", Role.MEDIUM)
+
+        val action = medium.buildNightAction(listOf(medium), isFirstNight = false)
+
+        assertEquals(NightAction.None, action)
+    }
+
+    @Test
+    fun `returns None on first night because no executions yet`() {
+        val medium = StubPlayer("Medium", Role.MEDIUM)
+
+        val action = medium.buildNightAction(listOf(medium), isFirstNight = true)
+
+        assertEquals(NightAction.None, action)
+    }
+
+    @Test
+    fun `reveals executed player when not yet revealed`() {
+        val medium = StubPlayer("Medium", Role.MEDIUM)
+        val villager = StubPlayer("Villager", Role.VILLAGER)
+        GameEvent.PlayerExecuted.send(villager, AllPlayers(listOf(medium, villager)))
+
+        val action = medium.buildNightAction(listOf(medium), isFirstNight = false)
+
+        assertEquals(NightAction.MediumReveal(villager), action)
+    }
+
+    @Test
+    fun `returns None when executed player is already revealed`() {
+        val medium = StubPlayer("Medium", Role.MEDIUM)
+        val villager = StubPlayer("Villager", Role.VILLAGER)
+        GameEvent.PlayerExecuted.send(villager, AllPlayers(listOf(medium, villager)))
+        GameEvent.MediumRevealed.send(villager, MediumResult.NOT_WEREWOLF, medium)
+
+        val action = medium.buildNightAction(listOf(medium), isFirstNight = false)
+
+        assertEquals(NightAction.None, action)
+    }
+
+    @Test
+    fun `reveals players in execution order`() {
+        val medium = StubPlayer("Medium", Role.MEDIUM)
+        val villager1 = StubPlayer("V1", Role.VILLAGER)
+        val villager2 = StubPlayer("V2", Role.VILLAGER)
+        val allPlayers = AllPlayers(listOf(medium, villager1, villager2))
+        GameEvent.PlayerExecuted.send(villager1, allPlayers)
+        GameEvent.PlayerExecuted.send(villager2, allPlayers)
+
+        val action = medium.buildNightAction(listOf(medium), isFirstNight = false)
+
+        assertEquals(NightAction.MediumReveal(villager1), action)
+    }
+
+    @Test
+    fun `reveals next unrevealed player after first is already revealed`() {
+        val medium = StubPlayer("Medium", Role.MEDIUM)
+        val villager1 = StubPlayer("V1", Role.VILLAGER)
+        val villager2 = StubPlayer("V2", Role.VILLAGER)
+        val allPlayers = AllPlayers(listOf(medium, villager1, villager2))
+        GameEvent.PlayerExecuted.send(villager1, allPlayers)
+        GameEvent.MediumRevealed.send(villager1, MediumResult.NOT_WEREWOLF, medium)
+        GameEvent.PlayerExecuted.send(villager2, allPlayers)
+
+        val action = medium.buildNightAction(listOf(medium), isFirstNight = false)
+
+        assertEquals(NightAction.MediumReveal(villager2), action)
+    }
+}


### PR DESCRIPTION
## Summary

- `firstNightAction` に `knowledge` パラメータを追加し、初日・通常夜で統一的に `knowledge` を参照できるようにした
- `MEDIUM` は `knowledge` 内の未霊視の `PlayerExecuted` を順に霊視する。処刑がない夜・すでに霊視済みの場合は `NightAction.None`
- `NightAction.MediumReveal` を `data object` → `data class(val target: Player)` に変更
- `PlayerManager._executedPlayers` を削除し、`revealNightSecrets` を簡略化した

Closes #70

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)