### PR TITLE
Extract initialization as InitialPhase

### DIFF
--- a/src/main/kotlin/InitialPhase.kt
+++ b/src/main/kotlin/InitialPhase.kt
@@ -1,0 +1,5 @@
+package org.example
+
+class InitialPhase(private val oracle: Oracle) : Phase {
+    override fun proceed() = oracle.initiatePlayers()
+}

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -3,8 +3,9 @@ package org.example
 //TIP コードを<b>実行</b>するには、<shortcut actionId="Run"/> を押すか
 // ガターの <icon src="AllIcons.Actions.Execute"/> アイコンをクリックします。
 fun main() {
-    val manager = PlayerManager(SmallLodge.create())
-    manager.startGame()
+    val setup = SmallLodge.create()
+    val manager = PlayerManager(setup)
+    InitialPhase(setup.oracle).proceed()
     var nightNumber = 1
     try {
         while (true) {

--- a/src/main/kotlin/Phase.kt
+++ b/src/main/kotlin/Phase.kt
@@ -1,0 +1,5 @@
+package org.example
+
+fun interface Phase {
+    fun proceed()
+}

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -23,10 +23,6 @@ class PlayerManager(setup: GameSetup) {
         _nightDeath = null
     }
 
-    fun startGame() {
-        oracle.initiatePlayers()
-    }
-
     private fun runNightActions(nightNumber: Int) {
         val decisions = _alivePlayers.map { it to it.buildNightAction(_alivePlayers, nightNumber == 1) }
 

--- a/src/test/kotlin/GameEventRoleAssignedTest.kt
+++ b/src/test/kotlin/GameEventRoleAssignedTest.kt
@@ -13,14 +13,14 @@ class GameEventRoleAssignedTest {
     }
 
     @Test
-    fun `startGame notifies each player of their assigned role`() {
+    fun `InitialPhase notifies each player of their assigned role`() {
         val villager = RecordingPlayer(Role.VILLAGER, "Alice")
         val werewolf = RecordingPlayer(Role.WEREWOLF, "Bob")
         val setup = GameSetup(
             players = listOf(villager, werewolf),
             oracle = Oracle(mapOf(villager to Role.VILLAGER, werewolf to Role.WEREWOLF)),
         )
-        PlayerManager(setup).startGame()
+        InitialPhase(setup.oracle).proceed()
 
         val villagerEvent = villager.received.single() as GameEvent.RoleAssigned
         assertEquals(Role.VILLAGER, villagerEvent.role)


### PR DESCRIPTION
## Summary

- `Phase` interface（`proceed(): Unit`）を導入した（移行期のため `Unit` を返す）
- `InitialPhase` を作成し、`oracle.initiatePlayers()` の呼び出しを移した
- `Main.kt` で `GameSetup` を明示的に変数に受け、`setup.oracle` を `InitialPhase` に渡すよう変更した
- `PlayerManager.startGame()` を削除した
- `GameEventRoleAssignedTest` を `InitialPhase` を使う形に更新した

Closes #73

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)