### PR TITLE
Extract night actions as NightPhase

### DIFF
--- a/src/main/kotlin/NightPhase.kt
+++ b/src/main/kotlin/NightPhase.kt
@@ -1,0 +1,35 @@
+package org.example
+
+class NightPhase(
+    private val playerManager: PlayerManager,
+    private val oracle: Oracle,
+    private val nightNumber: Int
+) : Phase {
+    override fun proceed() {
+        val decisions = playerManager.players.map { it to it.buildNightAction(playerManager.players, nightNumber == 1) }
+
+        val attacks = decisions.map { it.second }.filterIsInstance<NightAction.Attack>()
+        val guards = decisions.map { it.second }.filterIsInstance<NightAction.Guard>()
+        attackIfNotGuarded(attacks, guards)
+
+        revealNightSecrets(decisions)
+    }
+
+    private fun attackIfNotGuarded(attacks: List<NightAction.Attack>, guards: List<NightAction.Guard>) {
+        val target = MajorityVoteResolver.resolve(attacks.map { it.target }) ?: return
+        if (guards.none { it.target === target }) playerManager.kill(target)
+    }
+
+    private fun revealNightSecrets(decisions: List<Pair<Player, NightAction>>) {
+        decisions.forEach { (player, decision) ->
+            when (decision) {
+                is NightAction.None -> Unit
+                is NightAction.Attack -> Unit
+                is NightAction.Guard -> Unit
+                is NightAction.FirstNightDivine -> oracle.firstNightDivine(player, playerManager.players)
+                is NightAction.Divine -> oracle.divine(player, decision.target)
+                is NightAction.MediumReveal -> oracle.mediumReveal(player, decision.target)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -23,37 +23,9 @@ class PlayerManager(setup: GameSetup) {
         _nightDeath = null
     }
 
-    private fun runNightActions(nightNumber: Int) {
-        val decisions = _alivePlayers.map { it to it.buildNightAction(_alivePlayers, nightNumber == 1) }
-
-        val attacks = decisions.map { it.second }.filterIsInstance<NightAction.Attack>()
-        val guards = decisions.map { it.second }.filterIsInstance<NightAction.Guard>()
-        attackIfNotGuarded(attacks, guards)
-
-        revealNightSecrets(decisions)
-    }
-
-    private fun revealNightSecrets(decisions: List<Pair<Player, NightAction>>) {
-        decisions.forEach { (player, decision) ->
-            when (decision) {
-                is NightAction.None -> Unit
-                is NightAction.Attack -> Unit
-                is NightAction.Guard -> Unit
-                is NightAction.FirstNightDivine -> oracle.firstNightDivine(player, _alivePlayers)
-                is NightAction.Divine -> oracle.divine(player, decision.target)
-                is NightAction.MediumReveal -> oracle.mediumReveal(player, decision.target)
-            }
-        }
-    }
-
-    private fun attackIfNotGuarded(attacks: List<NightAction.Attack>, guards: List<NightAction.Guard>) {
-        val target = MajorityVoteResolver.resolve(attacks.map { it.target }) ?: return
-        if (guards.none { it.target === target }) attack(target)
-    }
-
     fun runTurn(nightNumber: Int) {
         GameEvent.TimeChanged.send(TimeOfDay.Night(nightNumber), allPlayers)
-        runNightActions(nightNumber)
+        NightPhase(this, oracle, nightNumber).proceed()
         GameEvent.TimeChanged.send(TimeOfDay.Morning, allPlayers)
         GameEvent.MorningReport.send(_nightDeath, allPlayers)
         bury()
@@ -81,7 +53,7 @@ class PlayerManager(setup: GameSetup) {
         die(mostVoted)
     }
 
-    private fun attack(target: Player) {
+    fun kill(target: Player) {
         GameEvent.PlayerAttacked.send(target, allPlayers)
         _nightDeath = target
         die(target)


### PR DESCRIPTION
## Summary

- `NightPhase` を作成し、夜行動の解決ロジック（`runNightActions`・`revealNightSecrets`・`attackIfNotGuarded`）を `PlayerManager` から移した
- `PlayerManager.attack()` を `kill()` に改名して public にし、`NightPhase` から呼べるようにした
- `PlayerManager.runTurn()` は `NightPhase(this, oracle, nightNumber).proceed()` を呼ぶ形に変更した
- この時点では `proceed()` は `Unit` を返す移行期の実装

Closes #74

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)