### PR TITLE
Extract morning report as MorningPhase

### DIFF
--- a/src/main/kotlin/MorningPhase.kt
+++ b/src/main/kotlin/MorningPhase.kt
@@ -1,0 +1,9 @@
+package org.example
+
+class MorningPhase(private val playerManager: PlayerManager) : Phase {
+    override fun proceed() {
+        GameEvent.TimeChanged.send(TimeOfDay.Morning, playerManager.allPlayers)
+        GameEvent.MorningReport.send(playerManager.nightDeath, playerManager.allPlayers)
+        playerManager.bury()
+    }
+}

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -6,9 +6,9 @@ class PlayerManager(setup: GameSetup) {
     private val _allPlayers: List<Player> = setup.players
     private val _alivePlayers: MutableList<Player> = _allPlayers.toMutableList()
     private var _nightDeath: Player? = null
+    val nightDeath: Player? get() = _nightDeath
     val players: List<Player> get() = _alivePlayers
-
-    private val allPlayers get() = AllPlayers(_allPlayers)
+    val allPlayers get() = AllPlayers(_allPlayers)
 
     private fun checkWinner() {
         GameOverSignal.throwIfGameOver(oracle.aliveCounts(_alivePlayers))
@@ -26,9 +26,7 @@ class PlayerManager(setup: GameSetup) {
     fun runTurn(nightNumber: Int) {
         GameEvent.TimeChanged.send(TimeOfDay.Night(nightNumber), allPlayers)
         NightPhase(this, oracle, nightNumber).proceed()
-        GameEvent.TimeChanged.send(TimeOfDay.Morning, allPlayers)
-        GameEvent.MorningReport.send(_nightDeath, allPlayers)
-        bury()
+        MorningPhase(this).proceed()
         runDiscussion()
         runVoting()
     }


### PR DESCRIPTION
## Summary

- `MorningPhase` を作成し、`TimeChanged(Morning)` の送信・`MorningReport` の送信・`bury()` の呼び出しを `PlayerManager` から移した
- `PlayerManager` に `nightDeath` と `allPlayers` を public プロパティとして公開した
- `PlayerManager.runTurn()` は `MorningPhase(this).proceed()` を呼ぶ形に変更した
- この時点では `proceed()` は `Unit` を返す移行期の実装

Closes #75

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)