### PR TITLE
Extract discussion and voting as DayPhase

### DIFF
--- a/src/main/kotlin/DayPhase.kt
+++ b/src/main/kotlin/DayPhase.kt
@@ -2,7 +2,7 @@ package org.example
 
 class DayPhase(private val playerManager: PlayerManager) : Phase {
     override fun proceed() {
-        RandomOrderDiscussion(playerManager.players, playerManager.everyPlayer).conduct()
+        RandomOrderDiscussion(playerManager.players, playerManager.allPlayers).conduct()
         val votes = playerManager.players.map { it.selectTarget(SelectionContext.Vote(it, playerManager.players)) }
         val mostVoted = MajorityVoteResolver.resolveNonEmpty(votes)
         playerManager.execute(mostVoted)

--- a/src/main/kotlin/DayPhase.kt
+++ b/src/main/kotlin/DayPhase.kt
@@ -1,0 +1,10 @@
+package org.example
+
+class DayPhase(private val playerManager: PlayerManager) : Phase {
+    override fun proceed() {
+        RandomOrderDiscussion(playerManager.players, playerManager.everyPlayer).conduct()
+        val votes = playerManager.players.map { it.selectTarget(SelectionContext.Vote(it, playerManager.players)) }
+        val mostVoted = MajorityVoteResolver.resolveNonEmpty(votes)
+        playerManager.execute(mostVoted)
+    }
+}

--- a/src/main/kotlin/Discussion.kt
+++ b/src/main/kotlin/Discussion.kt
@@ -1,6 +1,6 @@
 package org.example
 
-abstract class Discussion(private val alivePlayers: List<Player>, private val allPlayers: List<Player>) {
+abstract class Discussion(private val alivePlayers: List<Player>, private val allPlayers: AllPlayers) {
     companion object {
         private const val ROUNDS = 3
     }
@@ -9,16 +9,15 @@ abstract class Discussion(private val alivePlayers: List<Player>, private val al
 
     fun conduct() {
         val order = speakingOrder(alivePlayers)
-        val recipients = AllPlayers(allPlayers)
         repeat(ROUNDS) { index ->
             order.forEach { speaker ->
                 val statement = speaker.discuss(alivePlayers)
-                GameEvent.StatementMade.send(index + 1, speaker.name, statement, recipients)
+                GameEvent.StatementMade.send(index + 1, speaker.name, statement, allPlayers)
             }
         }
     }
 }
 
-class RandomOrderDiscussion(alivePlayers: List<Player>, allPlayers: List<Player>) : Discussion(alivePlayers, allPlayers) {
+class RandomOrderDiscussion(alivePlayers: List<Player>, allPlayers: AllPlayers) : Discussion(alivePlayers, allPlayers) {
     override fun speakingOrder(players: List<Player>) = players.shuffled()
 }

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -8,7 +8,6 @@ class PlayerManager(setup: GameSetup) {
     private var _nightDeath: Player? = null
     val nightDeath: Player? get() = _nightDeath
     val players: List<Player> get() = _alivePlayers
-    val everyPlayer: List<Player> get() = _allPlayers
     val allPlayers get() = AllPlayers(_allPlayers)
 
     private fun checkWinner() {

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -8,6 +8,7 @@ class PlayerManager(setup: GameSetup) {
     private var _nightDeath: Player? = null
     val nightDeath: Player? get() = _nightDeath
     val players: List<Player> get() = _alivePlayers
+    val everyPlayer: List<Player> get() = _allPlayers
     val allPlayers get() = AllPlayers(_allPlayers)
 
     private fun checkWinner() {
@@ -27,18 +28,7 @@ class PlayerManager(setup: GameSetup) {
         GameEvent.TimeChanged.send(TimeOfDay.Night(nightNumber), allPlayers)
         NightPhase(this, oracle, nightNumber).proceed()
         MorningPhase(this).proceed()
-        runDiscussion()
-        runVoting()
-    }
-
-    private fun runDiscussion() {
-        RandomOrderDiscussion(_alivePlayers, _allPlayers).conduct()
-    }
-
-    private fun runVoting() {
-        val votes = _alivePlayers.map { it.selectTarget(SelectionContext.Vote(it, _alivePlayers)) }
-        val mostVoted = MajorityVoteResolver.resolveNonEmpty(votes)
-        execute(mostVoted)
+        DayPhase(this).proceed()
     }
 
     fun endGame(signal: GameOverSignal) {
@@ -46,7 +36,7 @@ class PlayerManager(setup: GameSetup) {
         _allPlayers.forEach { GameEvent.GameResult.send(oracle.isWinner(it, signal.winningSide), it) }
     }
 
-    private fun execute(mostVoted: Player) {
+    fun execute(mostVoted: Player) {
         GameEvent.PlayerExecuted.send(mostVoted, allPlayers)
         die(mostVoted)
     }

--- a/src/test/kotlin/DiscussionTest.kt
+++ b/src/test/kotlin/DiscussionTest.kt
@@ -30,7 +30,7 @@ class DiscussionTest {
         override fun selectTarget(context: SelectionContext): Player = error("not expected in discussion test")
     }
 
-    private fun fixedOrderDiscussion(alivePlayers: List<Player>, allPlayers: List<Player>) =
+    private fun fixedOrderDiscussion(alivePlayers: List<Player>, allPlayers: AllPlayers) =
         object : Discussion(alivePlayers, allPlayers) {
             override fun speakingOrder(players: List<Player>) = players
         }
@@ -49,7 +49,7 @@ class DiscussionTest {
         ))
         val players = listOf(alice, bob)
 
-        fixedOrderDiscussion(players, players).conduct()
+        fixedOrderDiscussion(players, AllPlayers(players)).conduct()
 
         assertEquals(listOf(
             "Alice:said:私はBobが怪しいと思う",
@@ -84,7 +84,7 @@ class DiscussionTest {
         val alivePlayers = listOf(alice, bob)
         val allPlayers = listOf(alice, bob, charlie)
 
-        fixedOrderDiscussion(alivePlayers, allPlayers).conduct()
+        fixedOrderDiscussion(alivePlayers, AllPlayers(allPlayers)).conduct()
 
         assertEquals(listOf(
             "Charlie:heard:Alice:村人として発言します",


### PR DESCRIPTION
## Summary

- `DayPhase` を作成し、議論（`RandomOrderDiscussion`）と投票・処刑の処理を `PlayerManager` から移した
- `PlayerManager` に `everyPlayer: List<Player>`（`Discussion` の全プレイヤー渡し用）を追加し、`execute()` を public にした
- `PlayerManager.runTurn()` は `DayPhase(this).proceed()` を呼ぶ形に変更した
- この時点では `proceed()` は `Unit` を返す移行期の実装

Closes #76

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)