### PR TITLE
Wire up phases and remove PlayerManager orchestration

### DIFF
--- a/src/main/kotlin/DayPhase.kt
+++ b/src/main/kotlin/DayPhase.kt
@@ -1,10 +1,17 @@
 package org.example
 
-class DayPhase(private val playerManager: PlayerManager) : Phase {
-    override fun proceed() {
+class DayPhase(
+    private val playerManager: PlayerManager,
+    private val oracle: Oracle,
+    private val nightNumber: Int
+) : Phase {
+    override fun proceed(): Phase {
         RandomOrderDiscussion(playerManager.players, playerManager.allPlayers).conduct()
         val votes = playerManager.players.map { it.selectTarget(SelectionContext.Vote(it, playerManager.players)) }
         val mostVoted = MajorityVoteResolver.resolveNonEmpty(votes)
         playerManager.execute(mostVoted)
+        return nextNight()
     }
+
+    private fun nextNight() = NightPhase(playerManager, oracle, nightNumber + 1)
 }

--- a/src/main/kotlin/EndPhase.kt
+++ b/src/main/kotlin/EndPhase.kt
@@ -1,0 +1,13 @@
+package org.example
+
+class EndPhase(
+    private val playerManager: PlayerManager,
+    private val oracle: Oracle,
+    private val signal: GameOverSignal
+) : Phase {
+    override fun proceed(): Phase {
+        GameEvent.GameOver.send(signal.winningSide, playerManager.allPlayers)
+        playerManager.allPlayers.forEach { GameEvent.GameResult.send(oracle.isWinner(it, signal.winningSide), it) }
+        return this
+    }
+}

--- a/src/main/kotlin/InitialPhase.kt
+++ b/src/main/kotlin/InitialPhase.kt
@@ -1,5 +1,8 @@
 package org.example
 
-class InitialPhase(private val oracle: Oracle) : Phase {
-    override fun proceed() = oracle.initiatePlayers()
+class InitialPhase(private val playerManager: PlayerManager, private val oracle: Oracle) : Phase {
+    override fun proceed(): Phase {
+        oracle.initiatePlayers()
+        return NightPhase(playerManager, oracle, 1)
+    }
 }

--- a/src/main/kotlin/InitialPhase.kt
+++ b/src/main/kotlin/InitialPhase.kt
@@ -2,7 +2,13 @@ package org.example
 
 class InitialPhase(private val playerManager: PlayerManager, private val oracle: Oracle) : Phase {
     override fun proceed(): Phase {
-        oracle.initiatePlayers()
+        playerManager.allPlayers.forEach { oracle.revealRole(it) }
+        val wolves = oracle.werewolves(playerManager.players)
+        wolves.forEach { self ->
+            wolves.filterNot { it === self }.forEach { ally ->
+                GameEvent.WerewolfAllyRevealed.send(ally, self)
+            }
+        }
         return NightPhase(playerManager, oracle, 1)
     }
 }

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,18 +1,12 @@
 package org.example
 
-//TIP コードを<b>実行</b>するには、<shortcut actionId="Run"/> を押すか
-// ガターの <icon src="AllIcons.Actions.Execute"/> アイコンをクリックします。
 fun main() {
     val setup = SmallLodge.create()
     val manager = PlayerManager(setup)
-    InitialPhase(setup.oracle).proceed()
-    var nightNumber = 1
+    var phase: Phase = InitialPhase(manager, setup.oracle)
     try {
-        while (true) {
-            manager.runTurn(nightNumber)
-            nightNumber++
-        }
+        while (true) { phase = phase.proceed() }
     } catch (signal: GameOverSignal) {
-        manager.endGame(signal)
+        EndPhase(manager, setup.oracle, signal).proceed()
     }
 }

--- a/src/main/kotlin/MorningPhase.kt
+++ b/src/main/kotlin/MorningPhase.kt
@@ -1,9 +1,14 @@
 package org.example
 
-class MorningPhase(private val playerManager: PlayerManager) : Phase {
-    override fun proceed() {
+class MorningPhase(
+    private val playerManager: PlayerManager,
+    private val oracle: Oracle,
+    private val nightNumber: Int
+) : Phase {
+    override fun proceed(): Phase {
         GameEvent.TimeChanged.send(TimeOfDay.Morning, playerManager.allPlayers)
         GameEvent.MorningReport.send(playerManager.nightDeath, playerManager.allPlayers)
         playerManager.bury()
+        return DayPhase(playerManager, oracle, nightNumber)
     }
 }

--- a/src/main/kotlin/NightPhase.kt
+++ b/src/main/kotlin/NightPhase.kt
@@ -5,7 +5,8 @@ class NightPhase(
     private val oracle: Oracle,
     private val nightNumber: Int
 ) : Phase {
-    override fun proceed() {
+    override fun proceed(): Phase {
+        GameEvent.TimeChanged.send(TimeOfDay.Night(nightNumber), playerManager.allPlayers)
         val decisions = playerManager.players.map { it to it.buildNightAction(playerManager.players, nightNumber == 1) }
 
         val attacks = decisions.map { it.second }.filterIsInstance<NightAction.Attack>()
@@ -13,6 +14,7 @@ class NightPhase(
         attackIfNotGuarded(attacks, guards)
 
         revealNightSecrets(decisions)
+        return MorningPhase(playerManager, oracle, nightNumber)
     }
 
     private fun attackIfNotGuarded(attacks: List<NightAction.Attack>, guards: List<NightAction.Guard>) {

--- a/src/main/kotlin/Notifiable.kt
+++ b/src/main/kotlin/Notifiable.kt
@@ -4,6 +4,7 @@ interface Notifiable {
     fun receive(event: GameEvent)
 }
 
-class AllPlayers(private val players: List<Player>) : Notifiable {
+class AllPlayers(private val players: List<Player>) : Notifiable, Iterable<Player> {
     override fun receive(event: GameEvent) = players.forEach { it.receive(event) }
+    override fun iterator() = players.iterator()
 }

--- a/src/main/kotlin/Oracle.kt
+++ b/src/main/kotlin/Oracle.kt
@@ -4,15 +4,9 @@ class Oracle(private val roles: Map<Player, Role>) {
     private fun roleOf(player: Player): Role =
         requireNotNull(roles[player]) { "Player not in Oracle: ${player.name}" }
 
-    fun initiatePlayers() {
-        roles.forEach { (player, role) -> GameEvent.RoleAssigned.send(role, player) }
-        val werewolves = roles.filter { it.value == Role.WEREWOLF }.keys.toList()
-        werewolves.forEach { wolf ->
-            werewolves.filterNot { it === wolf }.forEach { ally ->
-                GameEvent.WerewolfAllyRevealed.send(ally, wolf)
-            }
-        }
-    }
+    fun revealRole(player: Player) = GameEvent.RoleAssigned.send(roleOf(player), player)
+
+    fun werewolves(alivePlayers: List<Player>): List<Player> = alivePlayers.filter { roleOf(it) == Role.WEREWOLF }
 
     fun divine(seer: Player, target: Player) =
         GameEvent.Divined.send(target, roleOf(target).divineResult, seer)

--- a/src/main/kotlin/Phase.kt
+++ b/src/main/kotlin/Phase.kt
@@ -1,5 +1,5 @@
 package org.example
 
 fun interface Phase {
-    fun proceed()
+    fun proceed(): Phase
 }

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -23,18 +23,6 @@ class PlayerManager(setup: GameSetup) {
         _nightDeath = null
     }
 
-    fun runTurn(nightNumber: Int) {
-        GameEvent.TimeChanged.send(TimeOfDay.Night(nightNumber), allPlayers)
-        NightPhase(this, oracle, nightNumber).proceed()
-        MorningPhase(this).proceed()
-        DayPhase(this).proceed()
-    }
-
-    fun endGame(signal: GameOverSignal) {
-        GameEvent.GameOver.send(signal.winningSide, allPlayers)
-        _allPlayers.forEach { GameEvent.GameResult.send(oracle.isWinner(it, signal.winningSide), it) }
-    }
-
     fun execute(mostVoted: Player) {
         GameEvent.PlayerExecuted.send(mostVoted, allPlayers)
         die(mostVoted)

--- a/src/test/kotlin/GameEventRoleAssignedTest.kt
+++ b/src/test/kotlin/GameEventRoleAssignedTest.kt
@@ -20,7 +20,7 @@ class GameEventRoleAssignedTest {
             players = listOf(villager, werewolf),
             oracle = Oracle(mapOf(villager to Role.VILLAGER, werewolf to Role.WEREWOLF)),
         )
-        InitialPhase(setup.oracle).proceed()
+        InitialPhase(PlayerManager(setup), setup.oracle).proceed()
 
         val villagerEvent = villager.received.single() as GameEvent.RoleAssigned
         assertEquals(Role.VILLAGER, villagerEvent.role)


### PR DESCRIPTION
## Summary

- `Phase.proceed()` の戻り値を `Unit` から `Phase` に変更し、各フェーズが次のフェーズを返すようにした
- `main()` をフェーズチェーン（`while(true) { phase = phase.proceed() }`）に切り替えた
- `EndPhase` を新設し、ゲーム終了時のイベント送信を担わせた
- `PlayerManager` のオーケストレーションメソッド（`runTurn()`、`endGame()`）を削除した
- `AllPlayers` に `Iterable<Player>` を実装し、`EndPhase` で全プレイヤーを走査できるようにした

Closes #77

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)