### PR TITLE
Add werewolf conclave before night attack selection

### DIFF
--- a/src/main/kotlin/Conclave.kt
+++ b/src/main/kotlin/Conclave.kt
@@ -1,0 +1,7 @@
+package org.example
+
+open class Conclave(wolves: List<Player>) : Discussion(wolves, AllPlayers(wolves)) {
+    override fun speakingOrder(players: List<Player>) = players.shuffled()
+    override fun sendStatement(round: Int, speakerName: String, statement: String, recipients: AllPlayers) =
+        GameEvent.WerewolfStatementMade.send(round, speakerName, statement, recipients)
+}

--- a/src/main/kotlin/Conclave.kt
+++ b/src/main/kotlin/Conclave.kt
@@ -1,7 +1,8 @@
 package org.example
 
 open class Conclave(wolves: List<Player>) : Discussion(wolves, AllPlayers(wolves)) {
-    override fun speakingOrder(players: List<Player>) = players.shuffled()
+    override val rounds = 3
+    override fun speakingOrder(speakers: List<Player>) = speakers.shuffled()
     override fun sendStatement(round: Int, speakerName: String, statement: String, recipients: AllPlayers) =
         GameEvent.WerewolfStatementMade.send(round, speakerName, statement, recipients)
 }

--- a/src/main/kotlin/DayPhase.kt
+++ b/src/main/kotlin/DayPhase.kt
@@ -6,7 +6,7 @@ class DayPhase(
     private val nightNumber: Int
 ) : Phase {
     override fun proceed(): Phase {
-        RandomOrderDiscussion(playerManager.players, playerManager.allPlayers).conduct()
+        OpenDiscussion(playerManager.players, playerManager.allPlayers).conduct()
         val votes = playerManager.players.map { it.selectTarget(SelectionContext.Vote(it, playerManager.players)) }
         val mostVoted = MajorityVoteResolver.resolveNonEmpty(votes)
         playerManager.execute(mostVoted)

--- a/src/main/kotlin/Discussion.kt
+++ b/src/main/kotlin/Discussion.kt
@@ -4,16 +4,13 @@ abstract class Discussion(
     private val speakers: List<Player>,
     private val recipients: AllPlayers
 ) {
-    companion object {
-        private const val ROUNDS = 3
-    }
-
-    protected abstract fun speakingOrder(players: List<Player>): List<Player>
+    protected abstract val rounds: Int
+    protected abstract fun speakingOrder(speakers: List<Player>): List<Player>
     protected abstract fun sendStatement(round: Int, speakerName: String, statement: String, recipients: AllPlayers)
 
     fun conduct() {
         val order = speakingOrder(speakers)
-        repeat(ROUNDS) { index ->
+        repeat(rounds) { index ->
             order.forEach { speaker ->
                 val statement = speaker.discuss(speakers)
                 sendStatement(index + 1, speaker.name, statement, recipients)
@@ -23,7 +20,8 @@ abstract class Discussion(
 }
 
 open class OpenDiscussion(speakers: List<Player>, recipients: AllPlayers) : Discussion(speakers, recipients) {
-    override fun speakingOrder(players: List<Player>) = players.shuffled()
+    override val rounds = 3
+    override fun speakingOrder(speakers: List<Player>) = speakers.shuffled()
     override fun sendStatement(round: Int, speakerName: String, statement: String, recipients: AllPlayers) =
         GameEvent.StatementMade.send(round, speakerName, statement, recipients)
 }

--- a/src/main/kotlin/Discussion.kt
+++ b/src/main/kotlin/Discussion.kt
@@ -1,23 +1,29 @@
 package org.example
 
-abstract class Discussion(private val alivePlayers: List<Player>, private val allPlayers: AllPlayers) {
+abstract class Discussion(
+    private val speakers: List<Player>,
+    private val recipients: AllPlayers
+) {
     companion object {
         private const val ROUNDS = 3
     }
 
     protected abstract fun speakingOrder(players: List<Player>): List<Player>
+    protected abstract fun sendStatement(round: Int, speakerName: String, statement: String, recipients: AllPlayers)
 
     fun conduct() {
-        val order = speakingOrder(alivePlayers)
+        val order = speakingOrder(speakers)
         repeat(ROUNDS) { index ->
             order.forEach { speaker ->
-                val statement = speaker.discuss(alivePlayers)
-                GameEvent.StatementMade.send(index + 1, speaker.name, statement, allPlayers)
+                val statement = speaker.discuss(speakers)
+                sendStatement(index + 1, speaker.name, statement, recipients)
             }
         }
     }
 }
 
-class RandomOrderDiscussion(alivePlayers: List<Player>, allPlayers: AllPlayers) : Discussion(alivePlayers, allPlayers) {
+open class OpenDiscussion(speakers: List<Player>, recipients: AllPlayers) : Discussion(speakers, recipients) {
     override fun speakingOrder(players: List<Player>) = players.shuffled()
+    override fun sendStatement(round: Int, speakerName: String, statement: String, recipients: AllPlayers) =
+        GameEvent.StatementMade.send(round, speakerName, statement, recipients)
 }

--- a/src/main/kotlin/GameEvent.kt
+++ b/src/main/kotlin/GameEvent.kt
@@ -122,4 +122,15 @@ sealed class GameEvent {
             fun send(ally: Player, recipient: Player) = WerewolfAllyRevealed(ally, recipient).dispatch()
         }
     }
+
+    @ConsistentCopyVisibility
+    data class WerewolfStatementMade private constructor(val round: Int, val speakerName: String, val statement: String, private val wolves: AllPlayers) : GameEvent() {
+        override val title = "密談（${round}ラウンド目）"
+        override fun body(self: Player) = "$speakerName: $statement"
+        override val recipients: Notifiable = wolves
+        companion object {
+            fun send(round: Int, speakerName: String, statement: String, wolves: AllPlayers) =
+                WerewolfStatementMade(round, speakerName, statement, wolves).dispatch()
+        }
+    }
 }

--- a/src/main/kotlin/NightPhase.kt
+++ b/src/main/kotlin/NightPhase.kt
@@ -7,6 +7,7 @@ class NightPhase(
 ) : Phase {
     override fun proceed(): Phase {
         GameEvent.TimeChanged.send(TimeOfDay.Night(nightNumber), playerManager.allPlayers)
+        Conclave(oracle.werewolves(playerManager.players)).conduct()
         val decisions = playerManager.players.map { it to it.buildNightAction(playerManager.players, nightNumber == 1) }
 
         val attacks = decisions.map { it.second }.filterIsInstance<NightAction.Attack>()

--- a/src/test/kotlin/ConclaveTest.kt
+++ b/src/test/kotlin/ConclaveTest.kt
@@ -1,0 +1,70 @@
+package org.example
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ConclaveTest {
+
+    private class TestPlayer(
+        override val name: String,
+        role: Role,
+        private val statements: List<String>
+    ) : Player(role) {
+        private val _log = mutableListOf<String>()
+        val log: List<String> get() = _log
+        private var statementIndex = 0
+
+        override fun discuss(players: List<Player>): String {
+            val statement = statements[statementIndex++]
+            _log.add("$name:said:$statement")
+            return statement
+        }
+
+        override fun onReceive(event: GameEvent) {
+            when (event) {
+                is GameEvent.WerewolfStatementMade -> _log.add("$name:heard:${event.speakerName}:${event.statement}")
+                else -> error("unexpected event in conclave test: $event")
+            }
+        }
+
+        override fun selectTarget(context: SelectionContext): Player = error("not expected in conclave test")
+    }
+
+    private fun fixedOrderConclave(wolves: List<Player>) =
+        object : Conclave(wolves) {
+            override fun speakingOrder(players: List<Player>) = players
+        }
+
+    @Test
+    fun `statements are delivered to all wolves in round order`() {
+        val alpha = TestPlayer("Alpha", Role.WEREWOLF, listOf("r1a", "r2a", "r3a"))
+        val beta = TestPlayer("Beta", Role.WEREWOLF, listOf("r1b", "r2b", "r3b"))
+        val wolves = listOf(alpha, beta)
+
+        fixedOrderConclave(wolves).conduct()
+
+        assertEquals(listOf(
+            "Alpha:said:r1a",
+            "Alpha:heard:Alpha:r1a",
+            "Alpha:heard:Beta:r1b",
+            "Alpha:said:r2a",
+            "Alpha:heard:Alpha:r2a",
+            "Alpha:heard:Beta:r2b",
+            "Alpha:said:r3a",
+            "Alpha:heard:Alpha:r3a",
+            "Alpha:heard:Beta:r3b",
+        ), alpha.log)
+
+        assertEquals(listOf(
+            "Beta:heard:Alpha:r1a",
+            "Beta:said:r1b",
+            "Beta:heard:Beta:r1b",
+            "Beta:heard:Alpha:r2a",
+            "Beta:said:r2b",
+            "Beta:heard:Beta:r2b",
+            "Beta:heard:Alpha:r3a",
+            "Beta:said:r3b",
+            "Beta:heard:Beta:r3b",
+        ), beta.log)
+    }
+}

--- a/src/test/kotlin/ConclaveTest.kt
+++ b/src/test/kotlin/ConclaveTest.kt
@@ -32,7 +32,7 @@ class ConclaveTest {
 
     private fun fixedOrderConclave(wolves: List<Player>) =
         object : Conclave(wolves) {
-            override fun speakingOrder(players: List<Player>) = players
+            override fun speakingOrder(speakers: List<Player>) = speakers
         }
 
     @Test

--- a/src/test/kotlin/DiscussionTest.kt
+++ b/src/test/kotlin/DiscussionTest.kt
@@ -32,7 +32,7 @@ class DiscussionTest {
 
     private fun fixedOrderDiscussion(alivePlayers: List<Player>, allPlayers: AllPlayers) =
         object : OpenDiscussion(alivePlayers, allPlayers) {
-            override fun speakingOrder(players: List<Player>) = players
+            override fun speakingOrder(speakers: List<Player>) = speakers
         }
 
     @Test

--- a/src/test/kotlin/DiscussionTest.kt
+++ b/src/test/kotlin/DiscussionTest.kt
@@ -31,7 +31,7 @@ class DiscussionTest {
     }
 
     private fun fixedOrderDiscussion(alivePlayers: List<Player>, allPlayers: AllPlayers) =
-        object : Discussion(alivePlayers, allPlayers) {
+        object : OpenDiscussion(alivePlayers, allPlayers) {
             override fun speakingOrder(players: List<Player>) = players
         }
 

--- a/src/test/kotlin/OracleWerewolvesTest.kt
+++ b/src/test/kotlin/OracleWerewolvesTest.kt
@@ -1,0 +1,32 @@
+package org.example
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OracleWerewolvesTest {
+
+    private class TestPlayer(role: Role, override val name: String) : Player(role) {
+        override fun selectTarget(context: SelectionContext) = this
+        override fun onReceive(event: GameEvent) {}
+        override fun discuss(players: List<Player>) = ""
+    }
+
+    @Test
+    fun `returns only werewolf players from mixed team`() {
+        val wolf1 = TestPlayer(Role.WEREWOLF, "Wolf1")
+        val wolf2 = TestPlayer(Role.WEREWOLF, "Wolf2")
+        val villager = TestPlayer(Role.VILLAGER, "Villager")
+        val oracle = Oracle(mapOf(wolf1 to Role.WEREWOLF, wolf2 to Role.WEREWOLF, villager to Role.VILLAGER))
+
+        assertEquals(listOf(wolf1, wolf2), oracle.werewolves(listOf(wolf1, wolf2, villager)))
+    }
+
+    @Test
+    fun `returns empty list when no werewolves are alive`() {
+        val villager1 = TestPlayer(Role.VILLAGER, "V1")
+        val villager2 = TestPlayer(Role.VILLAGER, "V2")
+        val oracle = Oracle(mapOf(villager1 to Role.VILLAGER, villager2 to Role.VILLAGER))
+
+        assertEquals(emptyList(), oracle.werewolves(listOf(villager1, villager2)))
+    }
+}


### PR DESCRIPTION
## Summary

- 夜フェーズの襲撃対象決定前に、人狼同士で密談（`Conclave`）を行う機能を追加
- 密談の内容は `GameEvent.WerewolfStatementMade` で人狼のみに配信され、他のプレイヤーには通知されない
- `Discussion` を abstract 基底クラスに昇格し、`OpenDiscussion`（昼の議論）と `Conclave`（夜の密談）で共通化

## Changes

- `GameEvent.WerewolfStatementMade` を追加（人狼専用の発言イベント）
- `Discussion` を abstract 基底クラスに昇格。`sendStatement` を abstract メソッドとして追加
- `RandomOrderDiscussion` を `OpenDiscussion` にリネーム・整理
- `Conclave` を新規追加（`Discussion` のサブクラス）
- `NightPhase` で `Conclave` を呼び出すよう変更
- `ConclaveTest` を新規追加

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)