### PR TITLE
Add RollerCpuPlayer and lodge selection in Main

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,12 +1,20 @@
 package org.example
 
 fun main() {
-    val setup = SmallLodge.create()
+    val setup = getLodge().create()
     val manager = PlayerManager(setup)
     var phase: Phase = InitialPhase(manager, setup.oracle)
     try {
         while (true) { phase = phase.proceed() }
     } catch (signal: GameOverSignal) {
         EndPhase(manager, setup.oracle, signal).proceed()
+    }
+}
+
+private fun getLodge(): Lodge {
+    println("Lodgeを選択してください: AllHuman / RollerCPU")
+    return when (readLine()?.trim()) {
+        "RollerCPU" -> RollerCpuLodge
+        else -> SmallLodge
     }
 }

--- a/src/main/kotlin/RollerCpuLodge.kt
+++ b/src/main/kotlin/RollerCpuLodge.kt
@@ -1,0 +1,20 @@
+package org.example
+
+object RollerCpuLodge : Lodge {
+    override fun create(): GameSetup {
+        val assignments: List<Pair<Role, (Role) -> Player>> = listOf(
+            Role.HUNTER   to { HumanPlayer(it, "1", ConsolePlayerIO()) },
+            Role.VILLAGER to { RollerCpuPlayer(it, "2") },
+            Role.VILLAGER to { RollerCpuPlayer(it, "3") },
+            Role.WEREWOLF to { RollerCpuPlayer(it, "4") },
+            Role.SEER     to { RollerCpuPlayer(it, "5") },
+            Role.MEDIUM   to { RollerCpuPlayer(it, "6") },
+            Role.WEREWOLF to { RollerCpuPlayer(it, "7") },
+        )
+        val playerRoles = assignments.map { (role, factory) -> factory(role) to role }
+        return GameSetup(
+            players = playerRoles.map { it.first },
+            oracle = Oracle(playerRoles.toMap()),
+        )
+    }
+}

--- a/src/main/kotlin/RollerCpuPlayer.kt
+++ b/src/main/kotlin/RollerCpuPlayer.kt
@@ -1,0 +1,13 @@
+package org.example
+
+class RollerCpuPlayer(role: Role, override val name: String) : Player(role) {
+    private var selectCount = 0
+
+    override fun selectTarget(context: SelectionContext): Player {
+        val candidates = context.candidates()
+        return candidates[selectCount++ % candidates.size]
+    }
+
+    override fun discuss(players: List<Player>) = ""
+    override fun onReceive(event: GameEvent) {}
+}


### PR DESCRIPTION
## Summary
- `RollerCpuPlayer` を追加（候補を順番に選ぶローラー方式）
- `RollerCpuLodge` を追加（1人HumanPlayer + 残りRollerCpuPlayer）
- `Main.kt` に `getLodge()` を追加（AllHuman / RollerCPU を stdin で選択）

Closes #92
