### PR TITLE
Randomize role assignment and extract Lodge template method

### DIFF
--- a/src/main/kotlin/CpuLodge.kt
+++ b/src/main/kotlin/CpuLodge.kt
@@ -1,18 +1,15 @@
 package org.example
 
-abstract class CpuLodge : Lodge {
+abstract class CpuLodge : Lodge() {
     protected abstract fun createCpuPlayer(role: Role, name: String): Player
 
-    override fun create(): GameSetup {
+    override fun assignments(): List<Pair<Player, Role>> {
         val roles = listOf(
             Role.HUNTER, Role.VILLAGER, Role.VILLAGER,
             Role.WEREWOLF, Role.SEER, Role.MEDIUM, Role.WEREWOLF,
         ).shuffled()
         val players = listOf(HumanPlayer(roles[0], "1", ConsolePlayerIO())) +
             roles.drop(1).mapIndexed { i, role -> createCpuPlayer(role, "${i + 2}") }
-        return GameSetup(
-            players = players,
-            oracle = Oracle(players.zip(roles).toMap()),
-        )
+        return players.zip(roles)
     }
 }

--- a/src/main/kotlin/CpuLodge.kt
+++ b/src/main/kotlin/CpuLodge.kt
@@ -1,0 +1,18 @@
+package org.example
+
+abstract class CpuLodge : Lodge {
+    protected abstract fun createCpuPlayer(role: Role, name: String): Player
+
+    override fun create(): GameSetup {
+        val roles = listOf(
+            Role.HUNTER, Role.VILLAGER, Role.VILLAGER,
+            Role.WEREWOLF, Role.SEER, Role.MEDIUM, Role.WEREWOLF,
+        ).shuffled()
+        val players = listOf(HumanPlayer(roles[0], "1", ConsolePlayerIO())) +
+            roles.drop(1).mapIndexed { i, role -> createCpuPlayer(role, "${i + 2}") }
+        return GameSetup(
+            players = players,
+            oracle = Oracle(players.zip(roles).toMap()),
+        )
+    }
+}

--- a/src/main/kotlin/Lodge.kt
+++ b/src/main/kotlin/Lodge.kt
@@ -1,5 +1,13 @@
 package org.example
 
-interface Lodge {
-    fun create(): GameSetup
+abstract class Lodge {
+    abstract fun assignments(): List<Pair<Player, Role>>
+
+    fun create(): GameSetup {
+        val assignments = assignments()
+        return GameSetup(
+            players = assignments.map { it.first },
+            oracle = Oracle(assignments.toMap()),
+        )
+    }
 }

--- a/src/main/kotlin/RandomCpuLodge.kt
+++ b/src/main/kotlin/RandomCpuLodge.kt
@@ -1,20 +1,5 @@
 package org.example
 
-object RandomCpuLodge : Lodge {
-    override fun create(): GameSetup {
-        val assignments: List<Pair<Role, (Role) -> Player>> = listOf(
-            Role.HUNTER   to { HumanPlayer(it, "1", ConsolePlayerIO()) },
-            Role.VILLAGER to { RandomCpuPlayer(it, "2") },
-            Role.VILLAGER to { RandomCpuPlayer(it, "3") },
-            Role.WEREWOLF to { RandomCpuPlayer(it, "4") },
-            Role.SEER     to { RandomCpuPlayer(it, "5") },
-            Role.MEDIUM   to { RandomCpuPlayer(it, "6") },
-            Role.WEREWOLF to { RandomCpuPlayer(it, "7") },
-        )
-        val playerRoles = assignments.map { (role, factory) -> factory(role) to role }
-        return GameSetup(
-            players = playerRoles.map { it.first },
-            oracle = Oracle(playerRoles.toMap()),
-        )
-    }
+object RandomCpuLodge : CpuLodge() {
+    override fun createCpuPlayer(role: Role, name: String) = RandomCpuPlayer(role, name)
 }

--- a/src/main/kotlin/RollerCpuLodge.kt
+++ b/src/main/kotlin/RollerCpuLodge.kt
@@ -1,20 +1,5 @@
 package org.example
 
-object RollerCpuLodge : Lodge {
-    override fun create(): GameSetup {
-        val assignments: List<Pair<Role, (Role) -> Player>> = listOf(
-            Role.HUNTER   to { HumanPlayer(it, "1", ConsolePlayerIO()) },
-            Role.VILLAGER to { RollerCpuPlayer(it, "2") },
-            Role.VILLAGER to { RollerCpuPlayer(it, "3") },
-            Role.WEREWOLF to { RollerCpuPlayer(it, "4") },
-            Role.SEER     to { RollerCpuPlayer(it, "5") },
-            Role.MEDIUM   to { RollerCpuPlayer(it, "6") },
-            Role.WEREWOLF to { RollerCpuPlayer(it, "7") },
-        )
-        val playerRoles = assignments.map { (role, factory) -> factory(role) to role }
-        return GameSetup(
-            players = playerRoles.map { it.first },
-            oracle = Oracle(playerRoles.toMap()),
-        )
-    }
+object RollerCpuLodge : CpuLodge() {
+    override fun createCpuPlayer(role: Role, name: String) = RollerCpuPlayer(role, name)
 }

--- a/src/main/kotlin/SmallLodge.kt
+++ b/src/main/kotlin/SmallLodge.kt
@@ -1,20 +1,13 @@
 package org.example
 
-object SmallLodge : Lodge {
-    override fun create(): GameSetup {
-        val assignments: List<Pair<Role, (Role) -> Player>> = listOf(
-            Role.HUNTER  to { HumanPlayer(it, "1", ConsolePlayerIO()) },
-            Role.VILLAGER to { HumanPlayer(it, "2", ConsolePlayerIO()) },
-            Role.VILLAGER to { HumanPlayer(it, "3", ConsolePlayerIO()) },
-            Role.WEREWOLF to { HumanPlayer(it, "4", ConsolePlayerIO()) },
-            Role.SEER    to { HumanPlayer(it, "5", ConsolePlayerIO()) },
-            Role.MEDIUM  to { HumanPlayer(it, "6", ConsolePlayerIO()) },
-            Role.WEREWOLF to { HumanPlayer(it, "7", ConsolePlayerIO()) },
-        )
-        val playerRoles = assignments.map { (role, factory) -> factory(role) to role }
-        return GameSetup(
-            players = playerRoles.map { it.first },
-            oracle = Oracle(playerRoles.toMap()),
-        )
-    }
+object SmallLodge : Lodge() {
+    override fun assignments() = listOf(
+        HumanPlayer(Role.HUNTER,   "1", ConsolePlayerIO()) to Role.HUNTER,
+        HumanPlayer(Role.VILLAGER, "2", ConsolePlayerIO()) to Role.VILLAGER,
+        HumanPlayer(Role.VILLAGER, "3", ConsolePlayerIO()) to Role.VILLAGER,
+        HumanPlayer(Role.WEREWOLF, "4", ConsolePlayerIO()) to Role.WEREWOLF,
+        HumanPlayer(Role.SEER,     "5", ConsolePlayerIO()) to Role.SEER,
+        HumanPlayer(Role.MEDIUM,   "6", ConsolePlayerIO()) to Role.MEDIUM,
+        HumanPlayer(Role.WEREWOLF, "7", ConsolePlayerIO()) to Role.WEREWOLF,
+    )
 }


### PR DESCRIPTION
## Summary
- `Lodge` を interface から abstract class に変更し、`GameSetup` 組み立てを共通化（template method）
- `SmallLodge` を新しいパターンに移行（固定割り当て・変更なし）
- `CpuLodge` を `Lodge` に移行し、役職シャッフルロジックを統合
- `RollerCpuLodge` / `RandomCpuLodge` はゲームのたびに役職がランダムに割り当てられる

Closes #96
