### PR TITLE
Add HonestCpuPlayer that speaks received events in discussion

### DIFF
--- a/src/main/kotlin/GameEvent.kt
+++ b/src/main/kotlin/GameEvent.kt
@@ -8,6 +8,7 @@ sealed class GameEvent {
     abstract fun body(self: Player): String
     protected abstract val recipients: Notifiable
     protected fun dispatch() = recipients.receive(this)
+    fun isPublicKnowledge(): Boolean = recipients is AllPlayers
 
     @ConsistentCopyVisibility
     data class RoleAssigned private constructor(val role: Role, private val recipient: Player) : GameEvent() {

--- a/src/main/kotlin/HonestCpuLodge.kt
+++ b/src/main/kotlin/HonestCpuLodge.kt
@@ -1,0 +1,5 @@
+package org.example
+
+object HonestCpuLodge : CpuLodge() {
+    override fun createCpuPlayer(role: Role, name: String) = HonestCpuPlayer(role, name)
+}

--- a/src/main/kotlin/HonestCpuPlayer.kt
+++ b/src/main/kotlin/HonestCpuPlayer.kt
@@ -1,0 +1,18 @@
+package org.example
+
+class HonestCpuPlayer(role: Role, override val name: String) : Player(role) {
+    private val unspoken = mutableListOf<GameEvent>()
+    private var selectCount = 0
+
+    override fun onReceive(event: GameEvent) { unspoken.add(event) }
+
+    override fun discuss(players: List<Player>): String {
+        if (unspoken.isEmpty()) return ""
+        return unspoken.removeFirst().body(this)
+    }
+
+    override fun selectTarget(context: SelectionContext): Player {
+        val candidates = context.candidates()
+        return candidates[selectCount++ % candidates.size]
+    }
+}

--- a/src/main/kotlin/HonestCpuPlayer.kt
+++ b/src/main/kotlin/HonestCpuPlayer.kt
@@ -4,7 +4,9 @@ class HonestCpuPlayer(role: Role, override val name: String) : Player(role) {
     private val unspoken = mutableListOf<GameEvent>()
     private var selectCount = 0
 
-    override fun onReceive(event: GameEvent) { unspoken.add(event) }
+    override fun onReceive(event: GameEvent) {
+        if (!event.isPublicKnowledge()) unspoken.add(event)
+    }
 
     override fun discuss(players: List<Player>): String {
         if (unspoken.isEmpty()) return ""

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -12,10 +12,11 @@ fun main() {
 }
 
 private fun getLodge(): Lodge {
-    println("Lodgeを選択してください: AllHuman / RollerCPU / RandomCPU")
+    println("Lodgeを選択してください: AllHuman / RollerCPU / RandomCPU / HonestCPU")
     return when (readLine()?.trim()) {
         "RollerCPU" -> RollerCpuLodge
         "RandomCPU" -> RandomCpuLodge
+        "HonestCPU" -> HonestCpuLodge
         else -> SmallLodge
     }
 }


### PR DESCRIPTION
## Summary
- `HonestCpuPlayer` を追加（受け取ったイベントを未発言の順に一つずつ `discuss()` で返す）
- `HonestCpuLodge` を追加（`CpuLodge` を継承）
- `getLodge()` に "HonestCPU" の選択肢を追加

Closes #98
