### PR TITLE
Add RoleAwareCpuPlayer with seer intelligence

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -12,11 +12,12 @@ fun main() {
 }
 
 private fun getLodge(): Lodge {
-    println("Lodgeを選択してください: AllHuman / RollerCPU / RandomCPU / HonestCPU")
+    println("Lodgeを選択してください: AllHuman / RollerCPU / RandomCPU / HonestCPU / RoleAwareCPU")
     return when (readLine()?.trim()) {
-        "RollerCPU" -> RollerCpuLodge
-        "RandomCPU" -> RandomCpuLodge
-        "HonestCPU" -> HonestCpuLodge
+        "RollerCPU"   -> RollerCpuLodge
+        "RandomCPU"   -> RandomCpuLodge
+        "HonestCPU"   -> HonestCpuLodge
+        "RoleAwareCPU" -> RoleAwareCpuLodge
         else -> SmallLodge
     }
 }

--- a/src/main/kotlin/RoleAwareCpuLodge.kt
+++ b/src/main/kotlin/RoleAwareCpuLodge.kt
@@ -1,0 +1,5 @@
+package org.example
+
+object RoleAwareCpuLodge : CpuLodge() {
+    override fun createCpuPlayer(role: Role, name: String) = RoleAwareCpuPlayer(role, name)
+}

--- a/src/main/kotlin/RoleAwareCpuPlayer.kt
+++ b/src/main/kotlin/RoleAwareCpuPlayer.kt
@@ -1,0 +1,39 @@
+package org.example
+
+class RoleAwareCpuPlayer(private val myRole: Role, override val name: String) : Player(myRole) {
+    private val divinedResults = mutableMapOf<Player, DivineResult>()
+    private val unspokenDivinations = mutableListOf<GameEvent.Divined>()
+
+    override fun onReceive(event: GameEvent) {
+        if (event is GameEvent.Divined) {
+            divinedResults[event.target] = event.result
+            unspokenDivinations.add(event)
+        }
+    }
+
+    override fun discuss(players: List<Player>): String {
+        if (myRole != Role.SEER || unspokenDivinations.isEmpty()) return ""
+        return unspokenDivinations.removeFirst().body(this)
+    }
+
+    override fun selectTarget(context: SelectionContext): Player = when {
+        myRole == Role.SEER && context is SelectionContext.Divine -> selectDivineTarget(context)
+        myRole == Role.SEER && context is SelectionContext.Vote   -> selectVoteTarget(context)
+        else -> context.candidates().random()
+    }
+
+    private fun selectDivineTarget(context: SelectionContext.Divine): Player {
+        val candidates = context.candidates()
+        val undivined = candidates.filter { it !in divinedResults }
+        return if (undivined.isNotEmpty()) undivined.random() else candidates.random()
+    }
+
+    private fun selectVoteTarget(context: SelectionContext.Vote): Player {
+        val candidates = context.candidates()
+        val confirmedWerewolves = candidates.filter { divinedResults[it] == DivineResult.WEREWOLF }
+        if (confirmedWerewolves.isNotEmpty()) return confirmedWerewolves.random()
+        val confirmedVillagers = candidates.filter { divinedResults[it] == DivineResult.NOT_WEREWOLF }
+        val votable = candidates - confirmedVillagers.toSet()
+        return if (votable.isNotEmpty()) votable.random() else candidates.random()
+    }
+}


### PR DESCRIPTION
## Summary
- `RoleAwareCpuPlayer` を追加
  - 占い師：未占いプレイヤーを優先して占い、結果を議論で発言。投票では人狼確定者を優先し、非人狼確定者を除外して投票
  - その他の役職：ランダム選択・無言
- `RoleAwareCpuLodge` を追加
- `getLodge()` に "RoleAwareCPU" の選択肢を追加

Closes #100
