### PR TITLE
Introduce Statement type and extend divination-aware voting

### DIFF
--- a/src/main/kotlin/Conclave.kt
+++ b/src/main/kotlin/Conclave.kt
@@ -3,6 +3,6 @@ package org.example
 open class Conclave(wolves: List<Player>) : Discussion(wolves, AllPlayers(wolves)) {
     override val rounds = 3
     override fun speakingOrder(speakers: List<Player>) = speakers.shuffled()
-    override fun sendStatement(round: Int, speakerName: String, statement: String, recipients: AllPlayers) =
-        GameEvent.WerewolfStatementMade.send(round, speakerName, statement, recipients)
+    override fun sendStatement(round: Int, speakerName: String, statement: Statement, recipients: AllPlayers) =
+        GameEvent.WerewolfStatementMade.send(round, speakerName, statement.text(), recipients)
 }

--- a/src/main/kotlin/Discussion.kt
+++ b/src/main/kotlin/Discussion.kt
@@ -6,7 +6,7 @@ abstract class Discussion(
 ) {
     protected abstract val rounds: Int
     protected abstract fun speakingOrder(speakers: List<Player>): List<Player>
-    protected abstract fun sendStatement(round: Int, speakerName: String, statement: String, recipients: AllPlayers)
+    protected abstract fun sendStatement(round: Int, speakerName: String, statement: Statement, recipients: AllPlayers)
 
     fun conduct() {
         val order = speakingOrder(speakers)
@@ -22,6 +22,6 @@ abstract class Discussion(
 open class OpenDiscussion(speakers: List<Player>, recipients: AllPlayers) : Discussion(speakers, recipients) {
     override val rounds = 3
     override fun speakingOrder(speakers: List<Player>) = speakers.shuffled()
-    override fun sendStatement(round: Int, speakerName: String, statement: String, recipients: AllPlayers) =
+    override fun sendStatement(round: Int, speakerName: String, statement: Statement, recipients: AllPlayers) =
         GameEvent.StatementMade.send(round, speakerName, statement, recipients)
 }

--- a/src/main/kotlin/GameEvent.kt
+++ b/src/main/kotlin/GameEvent.kt
@@ -63,12 +63,12 @@ sealed class GameEvent {
     }
 
     @ConsistentCopyVisibility
-    data class StatementMade private constructor(val round: Int, val speakerName: String, val statement: String, private val allPlayers: AllPlayers) : GameEvent() {
+    data class StatementMade private constructor(val round: Int, val speakerName: String, val statement: Statement, private val allPlayers: AllPlayers) : GameEvent() {
         override val title = "発言（${round}ラウンド目）"
-        override fun body(self: Player) = "$speakerName: $statement"
+        override fun body(self: Player) = "$speakerName: ${statement.text()}"
         override val recipients: Notifiable = allPlayers
         companion object {
-            fun send(round: Int, speakerName: String, statement: String, allPlayers: AllPlayers) =
+            fun send(round: Int, speakerName: String, statement: Statement, allPlayers: AllPlayers) =
                 StatementMade(round, speakerName, statement, allPlayers).dispatch()
         }
     }

--- a/src/main/kotlin/HonestCpuPlayer.kt
+++ b/src/main/kotlin/HonestCpuPlayer.kt
@@ -8,9 +8,9 @@ class HonestCpuPlayer(role: Role, override val name: String) : Player(role) {
         if (!event.isPublicKnowledge()) unspoken.add(event)
     }
 
-    override fun discuss(players: List<Player>): String {
-        if (unspoken.isEmpty()) return ""
-        return unspoken.removeFirst().body(this)
+    override fun discuss(players: List<Player>): Statement {
+        if (unspoken.isEmpty()) return Statement.Plain("")
+        return Statement.Plain(unspoken.removeFirst().body(this))
     }
 
     override fun selectTarget(context: SelectionContext): Player {

--- a/src/main/kotlin/HumanPlayer.kt
+++ b/src/main/kotlin/HumanPlayer.kt
@@ -8,6 +8,6 @@ class HumanPlayer(role: Role, override val name: String, private val io: PlayerI
         io.sendMessage(name, event.title, event.body(this))
     }
 
-    override fun discuss(players: List<Player>): String =
-        io.promptFreeText(name, "議論", "発言してください")
+    override fun discuss(players: List<Player>): Statement =
+        Statement.Plain(io.promptFreeText(name, "議論", "発言してください"))
 }

--- a/src/main/kotlin/Player.kt
+++ b/src/main/kotlin/Player.kt
@@ -11,7 +11,7 @@ abstract class Player(private val role: Role) : Notifiable {
 
     protected abstract fun onReceive(event: GameEvent)
     abstract fun selectTarget(context: SelectionContext): Player
-    abstract fun discuss(players: List<Player>): String
+    abstract fun discuss(players: List<Player>): Statement
 
     fun buildNightAction(players: List<Player>, isFirstNight: Boolean): NightAction =
         role.buildNightAction(this, players, isFirstNight, _knowledge.toList())

--- a/src/main/kotlin/RandomCpuPlayer.kt
+++ b/src/main/kotlin/RandomCpuPlayer.kt
@@ -2,6 +2,6 @@ package org.example
 
 class RandomCpuPlayer(role: Role, override val name: String) : Player(role) {
     override fun selectTarget(context: SelectionContext): Player = context.candidates().random()
-    override fun discuss(players: List<Player>) = ""
+    override fun discuss(players: List<Player>): Statement = Statement.Plain("")
     override fun onReceive(event: GameEvent) {}
 }

--- a/src/main/kotlin/RoleAwareCpuPlayer.kt
+++ b/src/main/kotlin/RoleAwareCpuPlayer.kt
@@ -1,19 +1,30 @@
 package org.example
 
 class RoleAwareCpuPlayer(private val myRole: Role, override val name: String) : Player(myRole) {
-    private val divinedResults = mutableMapOf<Player, DivineResult>()
+    private val myDivinedResults = mutableMapOf<Player, DivineResult>()
+    private val reportedDivinations = mutableMapOf<Player, DivineResult>()
     private val unspokenDivinations = mutableListOf<GameEvent.Divined>()
 
     override fun onReceive(event: GameEvent) {
-        if (event is GameEvent.Divined) {
-            divinedResults[event.target] = event.result
-            unspokenDivinations.add(event)
+        when (event) {
+            is GameEvent.Divined -> {
+                myDivinedResults[event.target] = event.result
+                unspokenDivinations.add(event)
+            }
+            is GameEvent.StatementMade -> {
+                val statement = event.statement
+                if (statement is Statement.DivinationReport && statement.claimant !== this) {
+                    reportedDivinations[statement.target] = statement.result
+                }
+            }
+            else -> {}
         }
     }
 
-    override fun discuss(players: List<Player>): String {
-        if (myRole != Role.SEER || unspokenDivinations.isEmpty()) return ""
-        return unspokenDivinations.removeFirst().body(this)
+    override fun discuss(players: List<Player>): Statement {
+        if (myRole != Role.SEER || unspokenDivinations.isEmpty()) return Statement.Plain("")
+        val event = unspokenDivinations.removeFirst()
+        return Statement.DivinationReport(claimant = this, target = event.target, result = event.result)
     }
 
     override fun selectTarget(context: SelectionContext): Player = when {
@@ -24,16 +35,23 @@ class RoleAwareCpuPlayer(private val myRole: Role, override val name: String) : 
 
     private fun selectDivineTarget(context: SelectionContext.Divine): Player {
         val candidates = context.candidates()
-        val undivined = candidates.filter { it !in divinedResults }
+        val undivined = candidates.filter { it !in myDivinedResults }
         return if (undivined.isNotEmpty()) undivined.random() else candidates.random()
     }
 
     private fun selectVoteTarget(context: SelectionContext.Vote): Player {
         val candidates = context.candidates()
-        val confirmedWerewolves = candidates.filter { divinedResults[it] == DivineResult.WEREWOLF }
-        if (confirmedWerewolves.isNotEmpty()) return confirmedWerewolves.random()
-        val confirmedVillagers = candidates.filter { divinedResults[it] == DivineResult.NOT_WEREWOLF }
-        val votable = candidates - confirmedVillagers.toSet()
+        // ① 自分の占いで人狼と確認した候補
+        val myConfirmedWerewolves = candidates.filter { myDivinedResults[it] == DivineResult.WEREWOLF }
+        if (myConfirmedWerewolves.isNotEmpty()) return myConfirmedWerewolves.random()
+        // ② 他者が人狼と報告した候補（自分の占いで非人狼と確認した者は除く）
+        val reportedWerewolves = candidates.filter {
+            reportedDivinations[it] == DivineResult.WEREWOLF && myDivinedResults[it] != DivineResult.NOT_WEREWOLF
+        }
+        if (reportedWerewolves.isNotEmpty()) return reportedWerewolves.random()
+        // ③ 自分の占いで非人狼と確認した候補を除いてランダム
+        val myConfirmedVillagers = candidates.filter { myDivinedResults[it] == DivineResult.NOT_WEREWOLF }
+        val votable = candidates - myConfirmedVillagers.toSet()
         return if (votable.isNotEmpty()) votable.random() else candidates.random()
     }
 }

--- a/src/main/kotlin/RoleAwareCpuPlayer.kt
+++ b/src/main/kotlin/RoleAwareCpuPlayer.kt
@@ -29,7 +29,7 @@ class RoleAwareCpuPlayer(private val myRole: Role, override val name: String) : 
 
     override fun selectTarget(context: SelectionContext): Player = when {
         myRole == Role.SEER && context is SelectionContext.Divine -> selectDivineTarget(context)
-        myRole == Role.SEER && context is SelectionContext.Vote   -> selectVoteTarget(context)
+        context is SelectionContext.Vote -> selectVoteTarget(context)
         else -> context.candidates().random()
     }
 
@@ -49,9 +49,11 @@ class RoleAwareCpuPlayer(private val myRole: Role, override val name: String) : 
             reportedDivinations[it] == DivineResult.WEREWOLF && myDivinedResults[it] != DivineResult.NOT_WEREWOLF
         }
         if (reportedWerewolves.isNotEmpty()) return reportedWerewolves.random()
-        // ③ 自分の占いで非人狼と確認した候補を除いてランダム
-        val myConfirmedVillagers = candidates.filter { myDivinedResults[it] == DivineResult.NOT_WEREWOLF }
-        val votable = candidates - myConfirmedVillagers.toSet()
+        // ③ 自分の占いまたは他者の報告で非人狼と確認した候補を除いてランダム
+        val confirmedNotWerewolf = candidates.filter {
+            myDivinedResults[it] == DivineResult.NOT_WEREWOLF || reportedDivinations[it] == DivineResult.NOT_WEREWOLF
+        }
+        val votable = candidates - confirmedNotWerewolf.toSet()
         return if (votable.isNotEmpty()) votable.random() else candidates.random()
     }
 }

--- a/src/main/kotlin/RollerCpuPlayer.kt
+++ b/src/main/kotlin/RollerCpuPlayer.kt
@@ -8,6 +8,6 @@ class RollerCpuPlayer(role: Role, override val name: String) : Player(role) {
         return candidates[selectCount++ % candidates.size]
     }
 
-    override fun discuss(players: List<Player>) = ""
+    override fun discuss(players: List<Player>): Statement = Statement.Plain("")
     override fun onReceive(event: GameEvent) {}
 }

--- a/src/main/kotlin/Statement.kt
+++ b/src/main/kotlin/Statement.kt
@@ -1,0 +1,13 @@
+package org.example
+
+sealed class Statement {
+    abstract fun text(): String
+
+    data class Plain(private val content: String) : Statement() {
+        override fun text() = content
+    }
+
+    data class DivinationReport(val claimant: Player, val target: Player, val result: DivineResult) : Statement() {
+        override fun text() = "${target.name} は「${result.displayName}」です。"
+    }
+}

--- a/src/test/kotlin/ConclaveTest.kt
+++ b/src/test/kotlin/ConclaveTest.kt
@@ -14,10 +14,10 @@ class ConclaveTest {
         val log: List<String> get() = _log
         private var statementIndex = 0
 
-        override fun discuss(players: List<Player>): String {
+        override fun discuss(players: List<Player>): Statement {
             val statement = statements[statementIndex++]
             _log.add("$name:said:$statement")
-            return statement
+            return Statement.Plain(statement)
         }
 
         override fun onReceive(event: GameEvent) {

--- a/src/test/kotlin/DiscussionTest.kt
+++ b/src/test/kotlin/DiscussionTest.kt
@@ -14,15 +14,15 @@ class DiscussionTest {
         val log: List<String> get() = _log
         private var statementIndex = 0
 
-        override fun discuss(players: List<Player>): String {
+        override fun discuss(players: List<Player>): Statement {
             val statement = statements[statementIndex++]
             _log.add("$name:said:$statement")
-            return statement
+            return Statement.Plain(statement)
         }
 
         override fun onReceive(event: GameEvent) {
             when (event) {
-                is GameEvent.StatementMade -> _log.add("$name:heard:${event.speakerName}:${event.statement}")
+                is GameEvent.StatementMade -> _log.add("$name:heard:${event.speakerName}:${event.statement.text()}")
                 else -> error("unexpected event in discussion test: $event")
             }
         }

--- a/src/test/kotlin/GameEventRoleAssignedTest.kt
+++ b/src/test/kotlin/GameEventRoleAssignedTest.kt
@@ -9,7 +9,7 @@ class GameEventRoleAssignedTest {
         val received = mutableListOf<GameEvent>()
         override fun selectTarget(context: SelectionContext) = this
         override fun onReceive(event: GameEvent) { received.add(event) }
-        override fun discuss(players: List<Player>) = ""
+        override fun discuss(players: List<Player>): Statement = Statement.Plain("")
     }
 
     @Test

--- a/src/test/kotlin/OracleFirstNightDivineTest.kt
+++ b/src/test/kotlin/OracleFirstNightDivineTest.kt
@@ -14,7 +14,7 @@ class OracleFirstNightDivineTest {
                 else -> error("unexpected event in oracle first night divine test: $event")
             }
         }
-        override fun discuss(players: List<Player>) = ""
+        override fun discuss(players: List<Player>): Statement = Statement.Plain("")
     }
 
     @Test

--- a/src/test/kotlin/OracleWerewolvesTest.kt
+++ b/src/test/kotlin/OracleWerewolvesTest.kt
@@ -8,7 +8,7 @@ class OracleWerewolvesTest {
     private class TestPlayer(role: Role, override val name: String) : Player(role) {
         override fun selectTarget(context: SelectionContext) = this
         override fun onReceive(event: GameEvent) {}
-        override fun discuss(players: List<Player>) = ""
+        override fun discuss(players: List<Player>): Statement = Statement.Plain("")
     }
 
     @Test

--- a/src/test/kotlin/RoleAwareCpuPlayerTest.kt
+++ b/src/test/kotlin/RoleAwareCpuPlayerTest.kt
@@ -1,0 +1,77 @@
+package org.example
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
+
+class RoleAwareCpuPlayerTest {
+
+    private class StubPlayer(override val name: String, role: Role) : Player(role) {
+        override fun selectTarget(context: SelectionContext) = this
+        override fun onReceive(event: GameEvent) {}
+        override fun discuss(players: List<Player>): Statement = Statement.Plain("")
+    }
+
+    @Test
+    fun `seer reports divination result as DivinationReport`() {
+        val seer = RoleAwareCpuPlayer(Role.SEER, "Seer")
+        val villager = StubPlayer("Villager", Role.VILLAGER)
+        val oracle = Oracle(mapOf(seer to Role.SEER, villager to Role.VILLAGER))
+        oracle.divine(seer, villager)
+
+        val statement = seer.discuss(emptyList())
+
+        val report = assertIs<Statement.DivinationReport>(statement)
+        assertEquals(seer, report.claimant)
+        assertEquals(villager, report.target)
+        assertEquals(DivineResult.NOT_WEREWOLF, report.result)
+    }
+
+    @Test
+    fun `seer does not vote for white-confirmed player when other candidates exist`() {
+        val seer = RoleAwareCpuPlayer(Role.SEER, "Seer")
+        val wolf = StubPlayer("Wolf", Role.WEREWOLF)
+        val villager = StubPlayer("Villager", Role.VILLAGER)
+        val oracle = Oracle(mapOf(seer to Role.SEER, wolf to Role.WEREWOLF, villager to Role.VILLAGER))
+        oracle.divine(seer, villager)
+
+        repeat(100) {
+            val voted = seer.selectTarget(SelectionContext.Vote(seer, listOf(seer, wolf, villager)))
+            assertNotEquals(villager, voted)
+        }
+    }
+
+    @Test
+    fun `villager votes for player reported as werewolf`() {
+        val seer = RoleAwareCpuPlayer(Role.SEER, "Seer")
+        val villager = RoleAwareCpuPlayer(Role.VILLAGER, "Villager")
+        val wolf = StubPlayer("Wolf", Role.WEREWOLF)
+        val oracle = Oracle(mapOf(seer to Role.SEER, villager to Role.VILLAGER, wolf to Role.WEREWOLF))
+        val allPlayers = AllPlayers(listOf(seer, villager, wolf))
+        oracle.divine(seer, wolf)
+        GameEvent.StatementMade.send(1, seer.name, seer.discuss(emptyList()), allPlayers)
+
+        repeat(100) {
+            val voted = villager.selectTarget(SelectionContext.Vote(villager, listOf(seer, villager, wolf)))
+            assertEquals(wolf, voted)
+        }
+    }
+
+    @Test
+    fun `villager does not vote for player reported as not werewolf when other candidates exist`() {
+        val seer = RoleAwareCpuPlayer(Role.SEER, "Seer")
+        val villager = RoleAwareCpuPlayer(Role.VILLAGER, "Villager")
+        val innocent = StubPlayer("Innocent", Role.VILLAGER)
+        val wolf = StubPlayer("Wolf", Role.WEREWOLF)
+        val oracle = Oracle(mapOf(seer to Role.SEER, villager to Role.VILLAGER, innocent to Role.VILLAGER, wolf to Role.WEREWOLF))
+        val allPlayers = AllPlayers(listOf(seer, villager, innocent, wolf))
+        oracle.divine(seer, innocent)
+        GameEvent.StatementMade.send(1, seer.name, seer.discuss(emptyList()), allPlayers)
+
+        repeat(100) {
+            val voted = villager.selectTarget(SelectionContext.Vote(villager, listOf(seer, villager, innocent, wolf)))
+            assertNotEquals(innocent, voted)
+        }
+    }
+}

--- a/src/test/kotlin/RoleMediumNightActionTest.kt
+++ b/src/test/kotlin/RoleMediumNightActionTest.kt
@@ -8,7 +8,7 @@ class RoleMediumNightActionTest {
     private class StubPlayer(override val name: String, role: Role) : Player(role) {
         override fun selectTarget(context: SelectionContext) = this
         override fun onReceive(event: GameEvent) = Unit
-        override fun discuss(players: List<Player>) = ""
+        override fun discuss(players: List<Player>): Statement = Statement.Plain("")
     }
 
     @Test

--- a/src/test/kotlin/SelectionContextAttackTest.kt
+++ b/src/test/kotlin/SelectionContextAttackTest.kt
@@ -10,7 +10,7 @@ class SelectionContextAttackTest {
     private class StubPlayer(override val name: String, role: Role) : Player(role) {
         override fun selectTarget(context: SelectionContext) = this
         override fun onReceive(event: GameEvent) = Unit
-        override fun discuss(players: List<Player>) = ""
+        override fun discuss(players: List<Player>): Statement = Statement.Plain("")
     }
 
     @Test


### PR DESCRIPTION
Closes #104

## Summary
- `Statement` sealed class を追加（`Plain` と `DivinationReport`）
- `Player.discuss()` の戻り値を `String` → `Statement` に変更
- `DivinationReport` は発言者（`claimant`）・対象（`target`）・結果（`result`）を型で保持
- 占い師は `discuss()` で `DivinationReport` を返す
- 占い結果を使った投票ロジックを占い師だけでなく全役職に適用
- 他者の報告で白確定したプレイヤーも投票対象から除外

## Test plan
- [x] `./gradlew test` が通ること
- [x] 占い師が占い結果を `DivinationReport` として発言する
- [x] 占い師が自分の占いで白確定したプレイヤーに投票しない
- [x] 村人が報告で黒確定したプレイヤーに投票する
- [x] 村人が報告で白確定したプレイヤーに投票しない

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)