### PR TITLE
Add game recap in EndPhase

### DIFF
--- a/src/main/kotlin/EndPhase.kt
+++ b/src/main/kotlin/EndPhase.kt
@@ -8,6 +8,13 @@ class EndPhase(
     override fun proceed(): Phase {
         GameEvent.GameOver.send(signal.winningSide, playerManager.allPlayers)
         playerManager.allPlayers.forEach { GameEvent.GameResult.send(oracle.isWinner(it, signal.winningSide), it) }
+        showRecap()
         return this
+    }
+
+    private fun showRecap() {
+        println("=== ゲーム振り返り ===")
+        GameRecap(playerManager, signal).events()
+            .forEach { println("  ${it.recipientName}: [${it.title}] ${it.body()}") }
     }
 }

--- a/src/main/kotlin/GameEvent.kt
+++ b/src/main/kotlin/GameEvent.kt
@@ -4,16 +4,18 @@ package org.example
 // that creates and dispatches atomically. This ensures notification targets are
 // always defined explicitly at the point of creation.
 sealed class GameEvent {
+    val sequenceId: Long = System.nanoTime()
     abstract val title: String
-    abstract fun body(self: Player): String
+    abstract fun body(): String
     protected abstract val recipients: Notifiable
+    val recipientName: String get() = recipients.recipientName
     protected fun dispatch() = recipients.receive(this)
     fun isPublicKnowledge(): Boolean = recipients is AllPlayers
 
     @ConsistentCopyVisibility
     data class RoleAssigned private constructor(val role: Role, private val recipient: Player) : GameEvent() {
         override val title = "役職通知"
-        override fun body(self: Player) = "あなたの役職は「${role.displayName}」です。"
+        override fun body() = "あなたの役職は「${role.displayName}」です。"
         override val recipients: Notifiable = recipient
         companion object {
             fun send(role: Role, recipient: Player) = RoleAssigned(role, recipient).dispatch()
@@ -23,8 +25,7 @@ sealed class GameEvent {
     @ConsistentCopyVisibility
     data class PlayerExecuted private constructor(val executed: Player, private val allPlayers: AllPlayers) : GameEvent() {
         override val title = "処刑通知"
-        override fun body(self: Player) =
-            if (executed === self) "あなたは処刑されました。" else "${executed.name} が処刑されました。"
+        override fun body() = "${executed.name}が処刑されました。"
         override val recipients: Notifiable = allPlayers
         companion object {
             fun send(executed: Player, allPlayers: AllPlayers) = PlayerExecuted(executed, allPlayers).dispatch()
@@ -34,8 +35,7 @@ sealed class GameEvent {
     @ConsistentCopyVisibility
     data class PlayerAttacked private constructor(val attacked: Player, private val allPlayers: AllPlayers) : GameEvent() {
         override val title = "襲撃通知"
-        override fun body(self: Player) =
-            if (attacked === self) "あなたは襲撃されました。" else "${attacked.name} が襲撃されました。"
+        override fun body() = "${attacked.name}が襲撃されました。"
         override val recipients: Notifiable = allPlayers
         companion object {
             fun send(attacked: Player, allPlayers: AllPlayers) = PlayerAttacked(attacked, allPlayers).dispatch()
@@ -45,7 +45,7 @@ sealed class GameEvent {
     @ConsistentCopyVisibility
     data class Divined private constructor(val target: Player, val result: DivineResult, private val recipient: Player) : GameEvent() {
         override val title = "占い結果"
-        override fun body(self: Player) = "${target.name} は「${result.displayName}」です。"
+        override fun body() = "${target.name}は「${result.displayName}」です。"
         override val recipients: Notifiable = recipient
         companion object {
             fun send(target: Player, result: DivineResult, recipient: Player) = Divined(target, result, recipient).dispatch()
@@ -55,7 +55,7 @@ sealed class GameEvent {
     @ConsistentCopyVisibility
     data class MediumRevealed private constructor(val target: Player, val result: MediumResult, private val recipient: Player) : GameEvent() {
         override val title = "霊視結果"
-        override fun body(self: Player) = "${target.name} は「${result.displayName}」です。"
+        override fun body() = "${target.name}は「${result.displayName}」です。"
         override val recipients: Notifiable = recipient
         companion object {
             fun send(target: Player, result: MediumResult, recipient: Player) = MediumRevealed(target, result, recipient).dispatch()
@@ -65,7 +65,7 @@ sealed class GameEvent {
     @ConsistentCopyVisibility
     data class StatementMade private constructor(val round: Int, val speakerName: String, val statement: Statement, private val allPlayers: AllPlayers) : GameEvent() {
         override val title = "発言（${round}ラウンド目）"
-        override fun body(self: Player) = "$speakerName: ${statement.text()}"
+        override fun body() = "$speakerName: ${statement.text()}"
         override val recipients: Notifiable = allPlayers
         companion object {
             fun send(round: Int, speakerName: String, statement: Statement, allPlayers: AllPlayers) =
@@ -76,7 +76,7 @@ sealed class GameEvent {
     @ConsistentCopyVisibility
     data class TimeChanged private constructor(val timeOfDay: TimeOfDay, private val allPlayers: AllPlayers) : GameEvent() {
         override val title = "${timeOfDay.name}の訪れ"
-        override fun body(self: Player) = "${timeOfDay.displayName}になりました。"
+        override fun body() = "${timeOfDay.displayName}になりました。"
         override val recipients: Notifiable = allPlayers
         companion object {
             fun send(timeOfDay: TimeOfDay, allPlayers: AllPlayers) = TimeChanged(timeOfDay, allPlayers).dispatch()
@@ -86,8 +86,8 @@ sealed class GameEvent {
     @ConsistentCopyVisibility
     data class MorningReport private constructor(val victim: Player?, private val allPlayers: AllPlayers) : GameEvent() {
         override val title = "朝の報告"
-        override fun body(self: Player) =
-            if (victim != null) "昨夜は ${victim.name} が襲撃されました。" else "昨夜は犠牲者がいませんでした。"
+        override fun body() =
+            if (victim != null) "昨夜は${victim.name}が襲撃されました。" else "昨夜は犠牲者がいませんでした。"
         override val recipients: Notifiable = allPlayers
         companion object {
             fun send(victim: Player?, allPlayers: AllPlayers) = MorningReport(victim, allPlayers).dispatch()
@@ -97,7 +97,7 @@ sealed class GameEvent {
     @ConsistentCopyVisibility
     data class GameOver private constructor(val winnerSide: Side, private val allPlayers: AllPlayers) : GameEvent() {
         override val title = "ゲーム終了"
-        override fun body(self: Player) = "${winnerSide.displayName}陣営の勝利です！"
+        override fun body() = "${winnerSide.displayName}陣営の勝利です！"
         override val recipients: Notifiable = allPlayers
         companion object {
             fun send(winnerSide: Side, allPlayers: AllPlayers) = GameOver(winnerSide, allPlayers).dispatch()
@@ -107,7 +107,7 @@ sealed class GameEvent {
     @ConsistentCopyVisibility
     data class GameResult private constructor(val isWinner: Boolean, private val recipient: Player) : GameEvent() {
         override val title = "勝敗結果"
-        override fun body(self: Player) = if (isWinner) "あなたは勝利しました。" else "あなたは敗北しました。"
+        override fun body() = if (isWinner) "あなたは勝利しました。" else "あなたは敗北しました。"
         override val recipients: Notifiable = recipient
         companion object {
             fun send(isWinner: Boolean, recipient: Player) = GameResult(isWinner, recipient).dispatch()
@@ -117,7 +117,7 @@ sealed class GameEvent {
     @ConsistentCopyVisibility
     data class WerewolfAllyRevealed private constructor(val ally: Player, private val recipient: Player) : GameEvent() {
         override val title = "仲間通知"
-        override fun body(self: Player) = "${ally.name} は仲間の人狼です。"
+        override fun body() = "${ally.name}は仲間の人狼です。"
         override val recipients: Notifiable = recipient
         companion object {
             fun send(ally: Player, recipient: Player) = WerewolfAllyRevealed(ally, recipient).dispatch()
@@ -127,7 +127,7 @@ sealed class GameEvent {
     @ConsistentCopyVisibility
     data class WerewolfStatementMade private constructor(val round: Int, val speakerName: String, val statement: String, private val wolves: AllPlayers) : GameEvent() {
         override val title = "密談（${round}ラウンド目）"
-        override fun body(self: Player) = "$speakerName: $statement"
+        override fun body() = "$speakerName: $statement"
         override val recipients: Notifiable = wolves
         companion object {
             fun send(round: Int, speakerName: String, statement: String, wolves: AllPlayers) =

--- a/src/main/kotlin/GameRecap.kt
+++ b/src/main/kotlin/GameRecap.kt
@@ -1,0 +1,9 @@
+package org.example
+
+class GameRecap(private val playerManager: PlayerManager, private val signal: GameOverSignal) {
+    fun events(): List<GameEvent> =
+        playerManager.allPlayers
+            .flatMap { it.revealKnowledge(signal) }
+            .distinct()
+            .sortedBy { it.sequenceId }
+}

--- a/src/main/kotlin/HonestCpuPlayer.kt
+++ b/src/main/kotlin/HonestCpuPlayer.kt
@@ -10,7 +10,7 @@ class HonestCpuPlayer(role: Role, override val name: String) : Player(role) {
 
     override fun discuss(players: List<Player>): Statement {
         if (unspoken.isEmpty()) return Statement.Plain("")
-        return Statement.Plain(unspoken.removeFirst().body(this))
+        return Statement.Plain(unspoken.removeFirst().body())
     }
 
     override fun selectTarget(context: SelectionContext): Player {

--- a/src/main/kotlin/HumanPlayer.kt
+++ b/src/main/kotlin/HumanPlayer.kt
@@ -5,7 +5,7 @@ class HumanPlayer(role: Role, override val name: String, private val io: PlayerI
         io.prompt(name, context.title, context.description, context.candidates())
 
     override fun onReceive(event: GameEvent) {
-        io.sendMessage(name, event.title, event.body(this))
+        io.sendMessage(name, event.title, event.body())
     }
 
     override fun discuss(players: List<Player>): Statement =

--- a/src/main/kotlin/Notifiable.kt
+++ b/src/main/kotlin/Notifiable.kt
@@ -1,10 +1,12 @@
 package org.example
 
 interface Notifiable {
+    val recipientName: String
     fun receive(event: GameEvent)
 }
 
 class AllPlayers(private val players: List<Player>) : Notifiable, Iterable<Player> {
+    override val recipientName = "全プレイヤー"
     override fun receive(event: GameEvent) = players.forEach { it.receive(event) }
     override fun iterator() = players.iterator()
 }

--- a/src/main/kotlin/Player.kt
+++ b/src/main/kotlin/Player.kt
@@ -14,6 +14,7 @@ abstract class Player(private val role: Role) : Notifiable {
     abstract fun selectTarget(context: SelectionContext): Player
     abstract fun discuss(players: List<Player>): Statement
 
+    // signal is a capability token: only callers who hold a GameOverSignal (i.e., after game over) can access knowledge
     fun revealKnowledge(signal: GameOverSignal): List<GameEvent> = _knowledge.toList()
 
     fun buildNightAction(players: List<Player>, isFirstNight: Boolean): NightAction =

--- a/src/main/kotlin/Player.kt
+++ b/src/main/kotlin/Player.kt
@@ -2,6 +2,7 @@ package org.example
 
 abstract class Player(private val role: Role) : Notifiable {
     abstract val name: String
+    override val recipientName: String get() = name
     private val _knowledge: MutableList<GameEvent> = mutableListOf()
 
     final override fun receive(event: GameEvent) {
@@ -12,6 +13,8 @@ abstract class Player(private val role: Role) : Notifiable {
     protected abstract fun onReceive(event: GameEvent)
     abstract fun selectTarget(context: SelectionContext): Player
     abstract fun discuss(players: List<Player>): Statement
+
+    fun revealKnowledge(signal: GameOverSignal): List<GameEvent> = _knowledge.toList()
 
     fun buildNightAction(players: List<Player>, isFirstNight: Boolean): NightAction =
         role.buildNightAction(this, players, isFirstNight, _knowledge.toList())

--- a/src/test/kotlin/GameEventRoleAssignedTest.kt
+++ b/src/test/kotlin/GameEventRoleAssignedTest.kt
@@ -24,10 +24,10 @@ class GameEventRoleAssignedTest {
 
         val villagerEvent = villager.received.single() as GameEvent.RoleAssigned
         assertEquals(Role.VILLAGER, villagerEvent.role)
-        assertEquals("あなたの役職は「村人」です。", villagerEvent.body(villager))
+        assertEquals("あなたの役職は「村人」です。", villagerEvent.body())
 
         val werewolfEvent = werewolf.received.single() as GameEvent.RoleAssigned
         assertEquals(Role.WEREWOLF, werewolfEvent.role)
-        assertEquals("あなたの役職は「人狼」です。", werewolfEvent.body(werewolf))
+        assertEquals("あなたの役職は「人狼」です。", werewolfEvent.body())
     }
 }

--- a/src/test/kotlin/GameRecapTest.kt
+++ b/src/test/kotlin/GameRecapTest.kt
@@ -1,0 +1,72 @@
+package org.example
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GameRecapTest {
+
+    private class StubPlayer(role: Role, override val name: String) : Player(role) {
+        override fun selectTarget(context: SelectionContext) = this
+        override fun onReceive(event: GameEvent) {}
+        override fun discuss(players: List<Player>): Statement = Statement.Plain("")
+    }
+
+    private fun playerManager(vararg players: Player): PlayerManager {
+        val oracle = Oracle(players.associateWith { Role.VILLAGER })
+        return PlayerManager(GameSetup(players.toList(), oracle))
+    }
+
+    private fun anySignal(): GameOverSignal {
+        return try {
+            GameOverSignal.throwIfGameOver(AliveCounts(mapOf(Side.CITIZEN to 0, Side.WEREWOLF to 1)))
+            error("unreachable")
+        } catch (s: GameOverSignal) { s }
+    }
+
+    @Test
+    fun `public events appear only once even when received by multiple players`() {
+        val playerA = StubPlayer(Role.VILLAGER, "A")
+        val playerB = StubPlayer(Role.VILLAGER, "B")
+        val pm = playerManager(playerA, playerB)
+
+        GameEvent.TimeChanged.send(TimeOfDay.Night(1), pm.allPlayers)
+
+        val events = GameRecap(pm, anySignal()).events()
+        assertEquals(1, events.size)
+    }
+
+    @Test
+    fun `private events from each player are all collected`() {
+        val playerA = StubPlayer(Role.VILLAGER, "A")
+        val playerB = StubPlayer(Role.VILLAGER, "B")
+        val pm = playerManager(playerA, playerB)
+
+        GameEvent.RoleAssigned.send(Role.VILLAGER, playerA)
+        GameEvent.RoleAssigned.send(Role.VILLAGER, playerB)
+
+        val events = GameRecap(pm, anySignal()).events()
+        assertEquals(2, events.size)
+    }
+
+    @Test
+    fun `events are sorted by creation order across players`() {
+        val playerA = StubPlayer(Role.VILLAGER, "A")
+        val playerB = StubPlayer(Role.VILLAGER, "B")
+        val pm = playerManager(playerA, playerB)
+
+        // 作成順: RoleAssigned(A) → RoleAssigned(B) → TimeChanged(全員)
+        // flatMap後: [RoleAssigned(A), TimeChanged, RoleAssigned(B), TimeChanged]
+        // distinct後: [RoleAssigned(A), TimeChanged, RoleAssigned(B)] ← ソートなしでは誤順
+        // sortedBy後: [RoleAssigned(A), RoleAssigned(B), TimeChanged] ← 正しい順
+        GameEvent.RoleAssigned.send(Role.VILLAGER, playerA)
+        GameEvent.RoleAssigned.send(Role.VILLAGER, playerB)
+        GameEvent.TimeChanged.send(TimeOfDay.Night(1), pm.allPlayers)
+
+        val events = GameRecap(pm, anySignal()).events()
+        assertEquals(3, events.size)
+        assertEquals("A", events[0].recipientName)
+        assertEquals("B", events[1].recipientName)
+        assertTrue(events[2] is GameEvent.TimeChanged)
+    }
+}


### PR DESCRIPTION
fixes #108

## 変更内容

- `GameRecap` クラスを追加し、全プレイヤーのイベントを収集・重複除去・ソートする責務を `EndPhase` から分離
- `GameEvent` に `sequenceId`（`System.nanoTime()`）を追加し、複数プレイヤーの知識をマージした後も正しい時系列順に並べられるようにした
- `Notifiable` / `GameEvent` に `recipientName` を追加し、振り返りで「受取人名: [title] body()」形式で表示できるようにした
- `Player.revealSecrets` を `revealKnowledge` に改名し、秘密イベントだけでなく全イベントを返すよう変更
- `body(self: Player)` の `self ===` 比較による一人称/三人称の切り替えを廃止し、`body()` に統一

## issue記載からの変更点

当初の方針（秘密イベントのみ表示・`isPublicKnowledge()` でフィルタ）は、実際に動かしてみると時系列の文脈が失われることが判明したため、全イベントを対象に変更した。公開イベントの重複は `distinct()` で除去している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)