### PR TITLE
Introduce Wolves type for werewolf conclave notifications

### DIFF
--- a/src/main/kotlin/Conclave.kt
+++ b/src/main/kotlin/Conclave.kt
@@ -1,8 +1,10 @@
 package org.example
 
-open class Conclave(wolves: List<Player>) : Discussion(wolves, AllPlayers(wolves)) {
+open class Conclave(oracle: Oracle, playerManager: PlayerManager) :
+    Discussion(oracle.werewolves(playerManager.players)) {
+    private val wolves = Wolves(oracle, playerManager)
     override val rounds = 3
     override fun speakingOrder(speakers: List<Player>) = speakers.shuffled()
-    override fun sendStatement(round: Int, speakerName: String, statement: Statement, recipients: AllPlayers) =
-        GameEvent.WerewolfStatementMade.send(round, speakerName, statement.text(), recipients)
+    override fun sendStatement(round: Int, speakerName: String, statement: Statement) =
+        GameEvent.WerewolfStatementMade.send(round, speakerName, statement.text(), wolves)
 }

--- a/src/main/kotlin/Conclave.kt
+++ b/src/main/kotlin/Conclave.kt
@@ -1,10 +1,9 @@
 package org.example
 
 open class Conclave(oracle: Oracle, playerManager: PlayerManager) :
-    Discussion(oracle.werewolves(playerManager.players)) {
-    private val wolves = Wolves(oracle, playerManager)
+    Discussion<Wolves>(oracle.werewolves(playerManager.players), Wolves(oracle, playerManager)) {
     override val rounds = 3
     override fun speakingOrder(speakers: List<Player>) = speakers.shuffled()
-    override fun sendStatement(round: Int, speakerName: String, statement: Statement) =
-        GameEvent.WerewolfStatementMade.send(round, speakerName, statement.text(), wolves)
+    override fun sendStatement(round: Int, speakerName: String, statement: Statement, recipients: Wolves) =
+        GameEvent.WerewolfStatementMade.send(round, speakerName, statement.text(), recipients)
 }

--- a/src/main/kotlin/Discussion.kt
+++ b/src/main/kotlin/Discussion.kt
@@ -1,24 +1,27 @@
 package org.example
 
-abstract class Discussion(private val speakers: List<Player>) {
+abstract class Discussion<R : Notifiable>(
+    private val speakers: List<Player>,
+    private val recipients: R
+) {
     protected abstract val rounds: Int
     protected abstract fun speakingOrder(speakers: List<Player>): List<Player>
-    protected abstract fun sendStatement(round: Int, speakerName: String, statement: Statement)
+    protected abstract fun sendStatement(round: Int, speakerName: String, statement: Statement, recipients: R)
 
     fun conduct() {
         val order = speakingOrder(speakers)
         repeat(rounds) { index ->
             order.forEach { speaker ->
                 val statement = speaker.discuss(speakers)
-                sendStatement(index + 1, speaker.name, statement)
+                sendStatement(index + 1, speaker.name, statement, recipients)
             }
         }
     }
 }
 
-open class OpenDiscussion(speakers: List<Player>, private val recipients: AllPlayers) : Discussion(speakers) {
+open class OpenDiscussion(speakers: List<Player>, allPlayers: AllPlayers) : Discussion<AllPlayers>(speakers, allPlayers) {
     override val rounds = 3
     override fun speakingOrder(speakers: List<Player>) = speakers.shuffled()
-    override fun sendStatement(round: Int, speakerName: String, statement: Statement) =
+    override fun sendStatement(round: Int, speakerName: String, statement: Statement, recipients: AllPlayers) =
         GameEvent.StatementMade.send(round, speakerName, statement, recipients)
 }

--- a/src/main/kotlin/Discussion.kt
+++ b/src/main/kotlin/Discussion.kt
@@ -1,27 +1,24 @@
 package org.example
 
-abstract class Discussion(
-    private val speakers: List<Player>,
-    private val recipients: AllPlayers
-) {
+abstract class Discussion(private val speakers: List<Player>) {
     protected abstract val rounds: Int
     protected abstract fun speakingOrder(speakers: List<Player>): List<Player>
-    protected abstract fun sendStatement(round: Int, speakerName: String, statement: Statement, recipients: AllPlayers)
+    protected abstract fun sendStatement(round: Int, speakerName: String, statement: Statement)
 
     fun conduct() {
         val order = speakingOrder(speakers)
         repeat(rounds) { index ->
             order.forEach { speaker ->
                 val statement = speaker.discuss(speakers)
-                sendStatement(index + 1, speaker.name, statement, recipients)
+                sendStatement(index + 1, speaker.name, statement)
             }
         }
     }
 }
 
-open class OpenDiscussion(speakers: List<Player>, recipients: AllPlayers) : Discussion(speakers, recipients) {
+open class OpenDiscussion(speakers: List<Player>, private val recipients: AllPlayers) : Discussion(speakers) {
     override val rounds = 3
     override fun speakingOrder(speakers: List<Player>) = speakers.shuffled()
-    override fun sendStatement(round: Int, speakerName: String, statement: Statement, recipients: AllPlayers) =
+    override fun sendStatement(round: Int, speakerName: String, statement: Statement) =
         GameEvent.StatementMade.send(round, speakerName, statement, recipients)
 }

--- a/src/main/kotlin/GameEvent.kt
+++ b/src/main/kotlin/GameEvent.kt
@@ -125,12 +125,12 @@ sealed class GameEvent {
     }
 
     @ConsistentCopyVisibility
-    data class WerewolfStatementMade private constructor(val round: Int, val speakerName: String, val statement: String, private val wolves: AllPlayers) : GameEvent() {
+    data class WerewolfStatementMade private constructor(val round: Int, val speakerName: String, val statement: String, private val wolves: Wolves) : GameEvent() {
         override val title = "密談（${round}ラウンド目）"
         override fun body() = "$speakerName: $statement"
         override val recipients: Notifiable = wolves
         companion object {
-            fun send(round: Int, speakerName: String, statement: String, wolves: AllPlayers) =
+            fun send(round: Int, speakerName: String, statement: String, wolves: Wolves) =
                 WerewolfStatementMade(round, speakerName, statement, wolves).dispatch()
         }
     }

--- a/src/main/kotlin/NightPhase.kt
+++ b/src/main/kotlin/NightPhase.kt
@@ -7,7 +7,7 @@ class NightPhase(
 ) : Phase {
     override fun proceed(): Phase {
         GameEvent.TimeChanged.send(TimeOfDay.Night(nightNumber), playerManager.allPlayers)
-        Conclave(oracle.werewolves(playerManager.players)).conduct()
+        Conclave(oracle, playerManager).conduct()
         val decisions = playerManager.players.map { it to it.buildNightAction(playerManager.players, nightNumber == 1) }
 
         val attacks = decisions.map { it.second }.filterIsInstance<NightAction.Attack>()

--- a/src/main/kotlin/Notifiable.kt
+++ b/src/main/kotlin/Notifiable.kt
@@ -10,3 +10,9 @@ class AllPlayers(private val players: List<Player>) : Notifiable, Iterable<Playe
     override fun receive(event: GameEvent) = players.forEach { it.receive(event) }
     override fun iterator() = players.iterator()
 }
+
+class Wolves(private val oracle: Oracle, private val playerManager: PlayerManager) : Notifiable {
+    override val recipientName = "全人狼"
+    override fun receive(event: GameEvent) =
+        oracle.werewolves(playerManager.allPlayers.toList()).forEach { it.receive(event) }
+}

--- a/src/test/kotlin/ConclaveTest.kt
+++ b/src/test/kotlin/ConclaveTest.kt
@@ -30,8 +30,8 @@ class ConclaveTest {
         override fun selectTarget(context: SelectionContext): Player = error("not expected in conclave test")
     }
 
-    private fun fixedOrderConclave(wolves: List<Player>) =
-        object : Conclave(wolves) {
+    private fun fixedOrderConclave(oracle: Oracle, playerManager: PlayerManager) =
+        object : Conclave(oracle, playerManager) {
             override fun speakingOrder(speakers: List<Player>) = speakers
         }
 
@@ -40,8 +40,10 @@ class ConclaveTest {
         val alpha = TestPlayer("Alpha", Role.WEREWOLF, listOf("r1a", "r2a", "r3a"))
         val beta = TestPlayer("Beta", Role.WEREWOLF, listOf("r1b", "r2b", "r3b"))
         val wolves = listOf(alpha, beta)
+        val oracle = Oracle(wolves.associateWith { Role.WEREWOLF })
+        val playerManager = PlayerManager(GameSetup(wolves, oracle))
 
-        fixedOrderConclave(wolves).conduct()
+        fixedOrderConclave(oracle, playerManager).conduct()
 
         assertEquals(listOf(
             "Alpha:said:r1a",


### PR DESCRIPTION
fixes #88

## 変更内容

- `Wolves(oracle: Oracle, playerManager: PlayerManager) : Notifiable` を新設。死者含む全人狼を通知先とし、`recipientName = "全人狼"`
- `WerewolfStatementMade.send()` の引数型を `AllPlayers` → `Wolves` に変更。全員通知イベントと人狼密談イベントが型レベルで区別できるようになった
- `Conclave` のコンストラクタを `List<Player>` から `Oracle + PlayerManager` に変更し、内部で `Wolves` を生成
- `Discussion` 抽象クラスから `recipients` パラメータを除去。各サブクラスが自分の受信先を型安全に管理する形に変更（`OpenDiscussion` は `AllPlayers`、`Conclave` は `Wolves`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)