### PR TITLE
Cancel Discussion if speakers are 1 or fewer

### DIFF
--- a/src/main/kotlin/Discussion.kt
+++ b/src/main/kotlin/Discussion.kt
@@ -9,6 +9,7 @@ abstract class Discussion<R : Notifiable>(
     protected abstract fun sendStatement(round: Int, speakerName: String, statement: Statement, recipients: R)
 
     fun conduct() {
+        if (speakers.size <= 1) return
         val order = speakingOrder(speakers)
         repeat(rounds) { index ->
             order.forEach { speaker ->

--- a/src/test/kotlin/ConclaveTest.kt
+++ b/src/test/kotlin/ConclaveTest.kt
@@ -36,6 +36,18 @@ class ConclaveTest {
         }
 
     @Test
+    fun `single werewolf does not speak`() {
+        val alpha = TestPlayer("Alpha", Role.WEREWOLF, emptyList())
+        val wolves = listOf(alpha)
+        val oracle = Oracle(wolves.associateWith { Role.WEREWOLF })
+        val playerManager = PlayerManager(GameSetup(wolves, oracle))
+
+        fixedOrderConclave(oracle, playerManager).conduct()
+
+        assertEquals(emptyList(), alpha.log)
+    }
+
+    @Test
     fun `statements are delivered to all wolves in round order`() {
         val alpha = TestPlayer("Alpha", Role.WEREWOLF, listOf("r1a", "r2a", "r3a"))
         val beta = TestPlayer("Beta", Role.WEREWOLF, listOf("r1b", "r2b", "r3b"))

--- a/src/test/kotlin/DiscussionTest.kt
+++ b/src/test/kotlin/DiscussionTest.kt
@@ -77,25 +77,6 @@ class DiscussionTest {
     }
 
     @Test
-    fun `single speaker does not speak`() {
-        val alice = TestPlayer("Alice", Role.VILLAGER, emptyList())
-        val players = listOf(alice)
-
-        fixedOrderDiscussion(players, AllPlayers(players)).conduct()
-
-        assertEquals(emptyList(), alice.log)
-    }
-
-    @Test
-    fun `empty speakers do nothing`() {
-        val alice = TestPlayer("Alice", Role.VILLAGER, emptyList())
-
-        fixedOrderDiscussion(emptyList(), AllPlayers(listOf(alice))).conduct()
-
-        assertEquals(emptyList(), alice.log)
-    }
-
-    @Test
     fun `dead players receive all statements without speaking`() {
         val alice = TestPlayer("Alice", Role.VILLAGER, listOf("村人として発言します", "続けて発言します", "最終発言です"))
         val bob = TestPlayer("Bob", Role.WEREWOLF, listOf("人狼として発言します", "続けて発言します", "最終発言です"))

--- a/src/test/kotlin/DiscussionTest.kt
+++ b/src/test/kotlin/DiscussionTest.kt
@@ -77,6 +77,25 @@ class DiscussionTest {
     }
 
     @Test
+    fun `single speaker does not speak`() {
+        val alice = TestPlayer("Alice", Role.VILLAGER, emptyList())
+        val players = listOf(alice)
+
+        fixedOrderDiscussion(players, AllPlayers(players)).conduct()
+
+        assertEquals(emptyList(), alice.log)
+    }
+
+    @Test
+    fun `empty speakers do nothing`() {
+        val alice = TestPlayer("Alice", Role.VILLAGER, emptyList())
+
+        fixedOrderDiscussion(emptyList(), AllPlayers(listOf(alice))).conduct()
+
+        assertEquals(emptyList(), alice.log)
+    }
+
+    @Test
     fun `dead players receive all statements without speaking`() {
         val alice = TestPlayer("Alice", Role.VILLAGER, listOf("村人として発言します", "続けて発言します", "最終発言です"))
         val bob = TestPlayer("Bob", Role.WEREWOLF, listOf("人狼として発言します", "続けて発言します", "最終発言です"))


### PR DESCRIPTION
## 概要

speaker が1人以下の場合は `Discussion.conduct()` を即座に終了するよう修正した。

## 変更内容

- `Discussion.conduct()` の先頭に `if (speakers.size <= 1) return` を追加
- `ConclaveTest` に人狼が1人のケースのテストを追加

Closes #114