### PR TITLE
Add medium, werewolf, and hunter intelligence to RoleAwareCpuPlayer

### DIFF
--- a/src/main/kotlin/RoleAwareCpuPlayer.kt
+++ b/src/main/kotlin/RoleAwareCpuPlayer.kt
@@ -5,7 +5,7 @@ class RoleAwareCpuPlayer(private val myRole: Role, override val name: String) : 
     private val reportedDivinations = mutableMapOf<Player, DivineResult>()
     private val unspokenDivinations = mutableListOf<GameEvent.Divined>()
     private val unspokenMediumReveals = mutableListOf<GameEvent.MediumRevealed>()
-    private val claimedSeers = mutableListOf<Player>()
+    private val claimedSeers = mutableSetOf<Player>()
 
     override fun onReceive(event: GameEvent) {
         when (event) {
@@ -18,7 +18,7 @@ class RoleAwareCpuPlayer(private val myRole: Role, override val name: String) : 
                 val statement = event.statement
                 if (statement is Statement.DivinationReport && statement.claimant !== this) {
                     reportedDivinations[statement.target] = statement.result
-                    if (statement.claimant !in claimedSeers) claimedSeers.add(statement.claimant)
+                    claimedSeers.add(statement.claimant)
                 }
             }
             else -> {}

--- a/src/main/kotlin/RoleAwareCpuPlayer.kt
+++ b/src/main/kotlin/RoleAwareCpuPlayer.kt
@@ -4,6 +4,8 @@ class RoleAwareCpuPlayer(private val myRole: Role, override val name: String) : 
     private val myDivinedResults = mutableMapOf<Player, DivineResult>()
     private val reportedDivinations = mutableMapOf<Player, DivineResult>()
     private val unspokenDivinations = mutableListOf<GameEvent.Divined>()
+    private val unspokenMediumReveals = mutableListOf<GameEvent.MediumRevealed>()
+    private val claimedSeers = mutableListOf<Player>()
 
     override fun onReceive(event: GameEvent) {
         when (event) {
@@ -11,10 +13,12 @@ class RoleAwareCpuPlayer(private val myRole: Role, override val name: String) : 
                 myDivinedResults[event.target] = event.result
                 unspokenDivinations.add(event)
             }
+            is GameEvent.MediumRevealed -> unspokenMediumReveals.add(event)
             is GameEvent.StatementMade -> {
                 val statement = event.statement
                 if (statement is Statement.DivinationReport && statement.claimant !== this) {
                     reportedDivinations[statement.target] = statement.result
+                    if (statement.claimant !in claimedSeers) claimedSeers.add(statement.claimant)
                 }
             }
             else -> {}
@@ -22,14 +26,22 @@ class RoleAwareCpuPlayer(private val myRole: Role, override val name: String) : 
     }
 
     override fun discuss(players: List<Player>): Statement {
-        if (myRole != Role.SEER || unspokenDivinations.isEmpty()) return Statement.Plain("")
-        val event = unspokenDivinations.removeFirst()
-        return Statement.DivinationReport(claimant = this, target = event.target, result = event.result)
+        if (myRole == Role.SEER && unspokenDivinations.isNotEmpty()) {
+            val event = unspokenDivinations.removeFirst()
+            return Statement.DivinationReport(claimant = this, target = event.target, result = event.result)
+        }
+        if (myRole == Role.MEDIUM && unspokenMediumReveals.isNotEmpty()) {
+            val event = unspokenMediumReveals.removeFirst()
+            return Statement.MediumReport(claimant = this, target = event.target, result = event.result)
+        }
+        return Statement.Plain("")
     }
 
     override fun selectTarget(context: SelectionContext): Player = when {
         myRole == Role.SEER && context is SelectionContext.Divine -> selectDivineTarget(context)
         context is SelectionContext.Vote -> selectVoteTarget(context)
+        context is SelectionContext.Attack -> selectAttackTarget(context)
+        context is SelectionContext.Guard -> selectGuardTarget(context)
         else -> context.candidates().random()
     }
 
@@ -37,6 +49,18 @@ class RoleAwareCpuPlayer(private val myRole: Role, override val name: String) : 
         val candidates = context.candidates()
         val undivined = candidates.filter { it !in myDivinedResults }
         return if (undivined.isNotEmpty()) undivined.random() else candidates.random()
+    }
+
+    private fun selectAttackTarget(context: SelectionContext.Attack): Player {
+        val candidates = context.candidates()
+        val targetSeers = candidates.filter { it in claimedSeers }
+        return if (targetSeers.isNotEmpty()) targetSeers.random() else candidates.random()
+    }
+
+    private fun selectGuardTarget(context: SelectionContext.Guard): Player {
+        val candidates = context.candidates()
+        val targetSeers = candidates.filter { it in claimedSeers }
+        return if (targetSeers.isNotEmpty()) targetSeers.random() else candidates.random()
     }
 
     private fun selectVoteTarget(context: SelectionContext.Vote): Player {

--- a/src/main/kotlin/Statement.kt
+++ b/src/main/kotlin/Statement.kt
@@ -10,4 +10,8 @@ sealed class Statement {
     data class DivinationReport(val claimant: Player, val target: Player, val result: DivineResult) : Statement() {
         override fun text() = "${target.name} は「${result.displayName}」です。"
     }
+
+    data class MediumReport(val claimant: Player, val target: Player, val result: MediumResult) : Statement() {
+        override fun text() = "${target.name} は「${result.displayName}」です。"
+    }
 }

--- a/src/test/kotlin/RoleAwareCpuPlayerTest.kt
+++ b/src/test/kotlin/RoleAwareCpuPlayerTest.kt
@@ -59,6 +59,49 @@ class RoleAwareCpuPlayerTest {
     }
 
     @Test
+    fun `medium reports medium result as MediumReport`() {
+        val medium = RoleAwareCpuPlayer(Role.MEDIUM, "Medium")
+        val villager = StubPlayer("Villager", Role.VILLAGER)
+        val oracle = Oracle(mapOf(medium to Role.MEDIUM, villager to Role.VILLAGER))
+        oracle.mediumReveal(medium, villager)
+
+        val statement = medium.discuss(emptyList())
+
+        val report = assertIs<Statement.MediumReport>(statement)
+        assertEquals(medium, report.claimant)
+        assertEquals(villager, report.target)
+        assertEquals(MediumResult.NOT_WEREWOLF, report.result)
+    }
+
+    @Test
+    fun `werewolf attacks claimed seer`() {
+        val wolf = RoleAwareCpuPlayer(Role.WEREWOLF, "Wolf")
+        val seer = StubPlayer("Seer", Role.SEER)
+        val villager = StubPlayer("Villager", Role.VILLAGER)
+        val allPlayers = AllPlayers(listOf(wolf, seer, villager))
+        GameEvent.StatementMade.send(1, seer.name, Statement.DivinationReport(seer, villager, DivineResult.NOT_WEREWOLF), allPlayers)
+
+        repeat(100) {
+            val target = wolf.selectTarget(SelectionContext.Attack(wolf, listOf(seer, villager), emptyList()))
+            assertEquals(seer, target)
+        }
+    }
+
+    @Test
+    fun `hunter guards claimed seer`() {
+        val hunter = RoleAwareCpuPlayer(Role.HUNTER, "Hunter")
+        val seer = StubPlayer("Seer", Role.SEER)
+        val villager = StubPlayer("Villager", Role.VILLAGER)
+        val allPlayers = AllPlayers(listOf(hunter, seer, villager))
+        GameEvent.StatementMade.send(1, seer.name, Statement.DivinationReport(seer, villager, DivineResult.NOT_WEREWOLF), allPlayers)
+
+        repeat(100) {
+            val target = hunter.selectTarget(SelectionContext.Guard(hunter, listOf(seer, villager)))
+            assertEquals(seer, target)
+        }
+    }
+
+    @Test
     fun `villager does not vote for player reported as not werewolf when other candidates exist`() {
         val seer = RoleAwareCpuPlayer(Role.SEER, "Seer")
         val villager = RoleAwareCpuPlayer(Role.VILLAGER, "Villager")


### PR DESCRIPTION
## 概要

RoleAwareCpuPlayer に占い師以外の役職の知識を追加した。

## 変更内容

- `Statement.MediumReport` を新規追加（霊能者の霊視報告用）
- 霊能者: `MediumRevealed` を受け取ったら議論で `Statement.MediumReport` として報告する
- 人狼: `DivinationReport` 発言者（自称占い師）を記憶し、`Attack` 選択時に優先して狙う
- 狩人: 同じく自称占い師を `Guard` 選択時に優先して護衛する

Closes #116