### PR TITLE
Extract RoleAwareCpuStrategy from RoleAwareCpuPlayer

### DIFF
--- a/src/main/kotlin/CitizenVoting.kt
+++ b/src/main/kotlin/CitizenVoting.kt
@@ -1,0 +1,14 @@
+package org.example
+
+class CitizenVoting(player: RoleAwareCpuPlayer) : VotingStrategy {
+    private val query = KnowledgeQuery(player)
+
+    override fun selectVoteTarget(candidates: List<Player>): Player {
+        val reportedWolves = query.reportedAs(DivineResult.WEREWOLF, candidates)
+        val reportedInnocent = query.reportedAs(DivineResult.NOT_WEREWOLF, candidates)
+
+        if (reportedWolves.isNotEmpty()) return reportedWolves.random()
+        val votable = candidates - reportedInnocent.toSet()
+        return if (votable.isNotEmpty()) votable.random() else candidates.random()
+    }
+}

--- a/src/main/kotlin/HunterCpuStrategy.kt
+++ b/src/main/kotlin/HunterCpuStrategy.kt
@@ -1,0 +1,30 @@
+package org.example
+
+class HunterCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.HUNTER) {
+
+    override fun discuss(knowledge: List<GameEvent>) = Statement.Plain("")
+
+    override fun selectTarget(context: SelectionContext, knowledge: List<GameEvent>): Player {
+        val candidates = context.candidates()
+        return when (context) {
+            is SelectionContext.Guard -> selectGuardTarget(candidates, knowledge)
+            is SelectionContext.Vote -> selectVoteTarget(candidates, knowledge)
+            else -> candidates.random()
+        }
+    }
+
+    private fun selectGuardTarget(candidates: List<Player>, knowledge: List<GameEvent>): Player {
+        val targets = candidates.filter { it in claimedSeers(knowledge) }
+        return if (targets.isNotEmpty()) targets.random() else candidates.random()
+    }
+
+    private fun selectVoteTarget(candidates: List<Player>, knowledge: List<GameEvent>): Player {
+        val reported = reportedDivinations(knowledge)
+        val reportedWolves = candidatesWith(DivineResult.WEREWOLF, reported, candidates)
+        val reportedInnocent = candidatesWith(DivineResult.NOT_WEREWOLF, reported, candidates)
+
+        if (reportedWolves.isNotEmpty()) return reportedWolves.random()
+        val votable = candidates - reportedInnocent.toSet()
+        return if (votable.isNotEmpty()) votable.random() else candidates.random()
+    }
+}

--- a/src/main/kotlin/HunterCpuStrategy.kt
+++ b/src/main/kotlin/HunterCpuStrategy.kt
@@ -1,30 +1,18 @@
 package org.example
 
-class HunterCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.HUNTER) {
+class HunterCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.HUNTER, CitizenVoting(self)) {
+    private val query = KnowledgeQuery(self)
 
-    override fun discuss(knowledge: List<GameEvent>) = Statement.Plain("")
+    override fun discuss() = Statement.Plain("")
 
-    override fun selectTarget(context: SelectionContext, knowledge: List<GameEvent>): Player {
-        val candidates = context.candidates()
-        return when (context) {
-            is SelectionContext.Guard -> selectGuardTarget(candidates, knowledge)
-            is SelectionContext.Vote -> selectVoteTarget(candidates, knowledge)
+    override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
+        when (context) {
+            is SelectionContext.Guard -> selectGuardTarget(candidates)
             else -> candidates.random()
         }
-    }
 
-    private fun selectGuardTarget(candidates: List<Player>, knowledge: List<GameEvent>): Player {
-        val targets = candidates.filter { it in claimedSeers(knowledge) }
+    private fun selectGuardTarget(candidates: List<Player>): Player {
+        val targets = candidates.filter { it in query.claimedSeers() }
         return if (targets.isNotEmpty()) targets.random() else candidates.random()
-    }
-
-    private fun selectVoteTarget(candidates: List<Player>, knowledge: List<GameEvent>): Player {
-        val reported = reportedDivinations(knowledge)
-        val reportedWolves = candidatesWith(DivineResult.WEREWOLF, reported, candidates)
-        val reportedInnocent = candidatesWith(DivineResult.NOT_WEREWOLF, reported, candidates)
-
-        if (reportedWolves.isNotEmpty()) return reportedWolves.random()
-        val votable = candidates - reportedInnocent.toSet()
-        return if (votable.isNotEmpty()) votable.random() else candidates.random()
     }
 }

--- a/src/main/kotlin/KnowledgeQuery.kt
+++ b/src/main/kotlin/KnowledgeQuery.kt
@@ -1,0 +1,25 @@
+package org.example
+
+class KnowledgeQuery(private val player: RoleAwareCpuPlayer) {
+    private val knowledge get() = player.knowledge
+    private val self: Player get() = player
+
+    fun divinedAs(result: DivineResult, candidates: List<Player>): List<Player> {
+        val myDivined = knowledge.filterIsInstance<GameEvent.Divined>().associate { it.target to it.result }
+        return candidates.filter { myDivined[it] == result }
+    }
+
+    fun reportedAs(result: DivineResult, candidates: List<Player>): List<Player> {
+        val others = knowledge.filterIsInstance<GameEvent.StatementMade>()
+            .map { it.statement }.filterIsInstance<Statement.DivinationReport>()
+            .filter { it.claimant !== self }
+            .associate { it.target to it.result }
+        return candidates.filter { others[it] == result }
+    }
+
+    fun claimedSeers(): Set<Player> =
+        knowledge.filterIsInstance<GameEvent.StatementMade>()
+            .map { it.statement }.filterIsInstance<Statement.DivinationReport>()
+            .filter { it.claimant !== self }
+            .map { it.claimant }.toSet()
+}

--- a/src/main/kotlin/MediumCpuStrategy.kt
+++ b/src/main/kotlin/MediumCpuStrategy.kt
@@ -1,0 +1,38 @@
+package org.example
+
+class MediumCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.MEDIUM) {
+
+    override fun discuss(knowledge: List<GameEvent>): Statement {
+        val next = nextUnreportedReveal(knowledge) ?: return Statement.Plain("")
+        return Statement.MediumReport(self, next.target, next.result)
+    }
+
+    override fun selectTarget(context: SelectionContext, knowledge: List<GameEvent>): Player {
+        val candidates = context.candidates()
+        return when (context) {
+            is SelectionContext.Vote -> selectVoteTarget(candidates, knowledge)
+            else -> candidates.random()
+        }
+    }
+
+    private fun nextUnreportedReveal(knowledge: List<GameEvent>): GameEvent.MediumRevealed? {
+        val reported = reportedTargets(knowledge)
+        return knowledge.filterIsInstance<GameEvent.MediumRevealed>().firstOrNull { it.target !in reported }
+    }
+
+    private fun reportedTargets(knowledge: List<GameEvent>): Set<Player> =
+        knowledge.filterIsInstance<GameEvent.StatementMade>()
+            .map { it.statement }.filterIsInstance<Statement.MediumReport>()
+            .filter { it.claimant === self }.map { it.target }.toSet()
+
+    private fun selectVoteTarget(candidates: List<Player>, knowledge: List<GameEvent>): Player {
+        val reported = reportedDivinations(knowledge)
+
+        val reportedWolves = candidatesWith(DivineResult.WEREWOLF, reported, candidates)
+        val reportedInnocent = candidatesWith(DivineResult.NOT_WEREWOLF, reported, candidates)
+
+        if (reportedWolves.isNotEmpty()) return reportedWolves.random()
+        val votable = candidates - reportedInnocent.toSet()
+        return if (votable.isNotEmpty()) votable.random() else candidates.random()
+    }
+}

--- a/src/main/kotlin/MediumCpuStrategy.kt
+++ b/src/main/kotlin/MediumCpuStrategy.kt
@@ -1,38 +1,22 @@
 package org.example
 
-class MediumCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.MEDIUM) {
+class MediumCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.MEDIUM, CitizenVoting(self)) {
 
-    override fun discuss(knowledge: List<GameEvent>): Statement {
-        val next = nextUnreportedReveal(knowledge) ?: return Statement.Plain("")
+    override fun discuss(): Statement {
+        val next = nextUnreportedReveal() ?: return Statement.Plain("")
         return Statement.MediumReport(self, next.target, next.result)
     }
 
-    override fun selectTarget(context: SelectionContext, knowledge: List<GameEvent>): Player {
-        val candidates = context.candidates()
-        return when (context) {
-            is SelectionContext.Vote -> selectVoteTarget(candidates, knowledge)
-            else -> candidates.random()
-        }
+    override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
+        candidates.random()
+
+    private fun nextUnreportedReveal(): GameEvent.MediumRevealed? {
+        val reported = reportedTargets()
+        return self.knowledge.filterIsInstance<GameEvent.MediumRevealed>().firstOrNull { it.target !in reported }
     }
 
-    private fun nextUnreportedReveal(knowledge: List<GameEvent>): GameEvent.MediumRevealed? {
-        val reported = reportedTargets(knowledge)
-        return knowledge.filterIsInstance<GameEvent.MediumRevealed>().firstOrNull { it.target !in reported }
-    }
-
-    private fun reportedTargets(knowledge: List<GameEvent>): Set<Player> =
-        knowledge.filterIsInstance<GameEvent.StatementMade>()
+    private fun reportedTargets(): Set<Player> =
+        self.knowledge.filterIsInstance<GameEvent.StatementMade>()
             .map { it.statement }.filterIsInstance<Statement.MediumReport>()
             .filter { it.claimant === self }.map { it.target }.toSet()
-
-    private fun selectVoteTarget(candidates: List<Player>, knowledge: List<GameEvent>): Player {
-        val reported = reportedDivinations(knowledge)
-
-        val reportedWolves = candidatesWith(DivineResult.WEREWOLF, reported, candidates)
-        val reportedInnocent = candidatesWith(DivineResult.NOT_WEREWOLF, reported, candidates)
-
-        if (reportedWolves.isNotEmpty()) return reportedWolves.random()
-        val votable = candidates - reportedInnocent.toSet()
-        return if (votable.isNotEmpty()) votable.random() else candidates.random()
-    }
 }

--- a/src/main/kotlin/RoleAwareCpuPlayer.kt
+++ b/src/main/kotlin/RoleAwareCpuPlayer.kt
@@ -1,83 +1,13 @@
 package org.example
 
-class RoleAwareCpuPlayer(private val myRole: Role, override val name: String) : Player(myRole) {
-    private val myDivinedResults = mutableMapOf<Player, DivineResult>()
-    private val reportedDivinations = mutableMapOf<Player, DivineResult>()
-    private val unspokenDivinations = mutableListOf<GameEvent.Divined>()
-    private val unspokenMediumReveals = mutableListOf<GameEvent.MediumRevealed>()
-    private val claimedSeers = mutableSetOf<Player>()
+class RoleAwareCpuPlayer(val myRole: Role, override val name: String) : Player(myRole) {
+    private val knowledge = mutableListOf<GameEvent>()
+    private val strategy = setOf(
+        SeerCpuStrategy(this), MediumCpuStrategy(this), WerewolfCpuStrategy(this),
+        HunterCpuStrategy(this), VillagerCpuStrategy(this)
+    ).single { it.appliesTo() }
 
-    override fun onReceive(event: GameEvent) {
-        when (event) {
-            is GameEvent.Divined -> {
-                myDivinedResults[event.target] = event.result
-                unspokenDivinations.add(event)
-            }
-            is GameEvent.MediumRevealed -> unspokenMediumReveals.add(event)
-            is GameEvent.StatementMade -> {
-                val statement = event.statement
-                if (statement is Statement.DivinationReport && statement.claimant !== this) {
-                    reportedDivinations[statement.target] = statement.result
-                    claimedSeers.add(statement.claimant)
-                }
-            }
-            else -> {}
-        }
-    }
-
-    override fun discuss(players: List<Player>): Statement {
-        if (myRole == Role.SEER && unspokenDivinations.isNotEmpty()) {
-            val event = unspokenDivinations.removeFirst()
-            return Statement.DivinationReport(claimant = this, target = event.target, result = event.result)
-        }
-        if (myRole == Role.MEDIUM && unspokenMediumReveals.isNotEmpty()) {
-            val event = unspokenMediumReveals.removeFirst()
-            return Statement.MediumReport(claimant = this, target = event.target, result = event.result)
-        }
-        return Statement.Plain("")
-    }
-
-    override fun selectTarget(context: SelectionContext): Player = when {
-        myRole == Role.SEER && context is SelectionContext.Divine -> selectDivineTarget(context)
-        context is SelectionContext.Vote -> selectVoteTarget(context)
-        context is SelectionContext.Attack -> selectAttackTarget(context)
-        context is SelectionContext.Guard -> selectGuardTarget(context)
-        else -> context.candidates().random()
-    }
-
-    private fun selectDivineTarget(context: SelectionContext.Divine): Player {
-        val candidates = context.candidates()
-        val undivined = candidates.filter { it !in myDivinedResults }
-        return if (undivined.isNotEmpty()) undivined.random() else candidates.random()
-    }
-
-    private fun selectAttackTarget(context: SelectionContext.Attack): Player {
-        val candidates = context.candidates()
-        val targetSeers = candidates.filter { it in claimedSeers }
-        return if (targetSeers.isNotEmpty()) targetSeers.random() else candidates.random()
-    }
-
-    private fun selectGuardTarget(context: SelectionContext.Guard): Player {
-        val candidates = context.candidates()
-        val targetSeers = candidates.filter { it in claimedSeers }
-        return if (targetSeers.isNotEmpty()) targetSeers.random() else candidates.random()
-    }
-
-    private fun selectVoteTarget(context: SelectionContext.Vote): Player {
-        val candidates = context.candidates()
-        // ① 自分の占いで人狼と確認した候補
-        val myConfirmedWerewolves = candidates.filter { myDivinedResults[it] == DivineResult.WEREWOLF }
-        if (myConfirmedWerewolves.isNotEmpty()) return myConfirmedWerewolves.random()
-        // ② 他者が人狼と報告した候補（自分の占いで非人狼と確認した者は除く）
-        val reportedWerewolves = candidates.filter {
-            reportedDivinations[it] == DivineResult.WEREWOLF && myDivinedResults[it] != DivineResult.NOT_WEREWOLF
-        }
-        if (reportedWerewolves.isNotEmpty()) return reportedWerewolves.random()
-        // ③ 自分の占いまたは他者の報告で非人狼と確認した候補を除いてランダム
-        val confirmedNotWerewolf = candidates.filter {
-            myDivinedResults[it] == DivineResult.NOT_WEREWOLF || reportedDivinations[it] == DivineResult.NOT_WEREWOLF
-        }
-        val votable = candidates - confirmedNotWerewolf.toSet()
-        return if (votable.isNotEmpty()) votable.random() else candidates.random()
-    }
+    override fun onReceive(event: GameEvent) { knowledge.add(event) }
+    override fun discuss(players: List<Player>) = strategy.discuss(knowledge.toList())
+    override fun selectTarget(context: SelectionContext) = strategy.selectTarget(context, knowledge.toList())
 }

--- a/src/main/kotlin/RoleAwareCpuPlayer.kt
+++ b/src/main/kotlin/RoleAwareCpuPlayer.kt
@@ -1,13 +1,15 @@
 package org.example
 
 class RoleAwareCpuPlayer(val myRole: Role, override val name: String) : Player(myRole) {
-    private val knowledge = mutableListOf<GameEvent>()
+    private val _knowledge = mutableListOf<GameEvent>()
+    val knowledge: List<GameEvent> get() = _knowledge.toList()
+
     private val strategy = setOf(
         SeerCpuStrategy(this), MediumCpuStrategy(this), WerewolfCpuStrategy(this),
         HunterCpuStrategy(this), VillagerCpuStrategy(this)
     ).single { it.appliesTo() }
 
-    override fun onReceive(event: GameEvent) { knowledge.add(event) }
-    override fun discuss(players: List<Player>) = strategy.discuss(knowledge.toList())
-    override fun selectTarget(context: SelectionContext) = strategy.selectTarget(context, knowledge.toList())
+    override fun onReceive(event: GameEvent) { _knowledge.add(event) }
+    override fun discuss(players: List<Player>) = strategy.discuss()
+    override fun selectTarget(context: SelectionContext) = strategy.selectTarget(context)
 }

--- a/src/main/kotlin/RoleAwareCpuStrategy.kt
+++ b/src/main/kotlin/RoleAwareCpuStrategy.kt
@@ -2,25 +2,20 @@ package org.example
 
 abstract class RoleAwareCpuStrategy(
     protected val self: RoleAwareCpuPlayer,
-    private val targetRole: Role
+    private val targetRole: Role,
+    private val votingStrategy: VotingStrategy
 ) {
     fun appliesTo() = self.myRole == targetRole
-    abstract fun discuss(knowledge: List<GameEvent>): Statement
-    abstract fun selectTarget(context: SelectionContext, knowledge: List<GameEvent>): Player
 
-    protected fun claimedSeers(knowledge: List<GameEvent>): Set<Player> =
-        knowledge.filterIsInstance<GameEvent.StatementMade>()
-            .map { it.statement }.filterIsInstance<Statement.DivinationReport>()
-            .map { it.claimant }.toSet()
+    abstract fun discuss(): Statement
 
-    protected fun reportedDivinations(knowledge: List<GameEvent>): Map<Player, DivineResult> =
-        knowledge.filterIsInstance<GameEvent.StatementMade>()
-            .map { it.statement }.filterIsInstance<Statement.DivinationReport>()
-            .associate { it.target to it.result }
+    fun selectTarget(context: SelectionContext): Player {
+        val candidates = context.candidates()
+        return if (context is SelectionContext.Vote)
+            votingStrategy.selectVoteTarget(candidates)
+        else
+            selectTargetForOthers(context, candidates)
+    }
 
-    protected fun candidatesWith(
-        result: DivineResult,
-        from: Map<Player, DivineResult>,
-        candidates: List<Player>
-    ): List<Player> = candidates.filter { from[it] == result }
+    abstract fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player
 }

--- a/src/main/kotlin/RoleAwareCpuStrategy.kt
+++ b/src/main/kotlin/RoleAwareCpuStrategy.kt
@@ -1,0 +1,26 @@
+package org.example
+
+abstract class RoleAwareCpuStrategy(
+    protected val self: RoleAwareCpuPlayer,
+    private val targetRole: Role
+) {
+    fun appliesTo() = self.myRole == targetRole
+    abstract fun discuss(knowledge: List<GameEvent>): Statement
+    abstract fun selectTarget(context: SelectionContext, knowledge: List<GameEvent>): Player
+
+    protected fun claimedSeers(knowledge: List<GameEvent>): Set<Player> =
+        knowledge.filterIsInstance<GameEvent.StatementMade>()
+            .map { it.statement }.filterIsInstance<Statement.DivinationReport>()
+            .map { it.claimant }.toSet()
+
+    protected fun reportedDivinations(knowledge: List<GameEvent>): Map<Player, DivineResult> =
+        knowledge.filterIsInstance<GameEvent.StatementMade>()
+            .map { it.statement }.filterIsInstance<Statement.DivinationReport>()
+            .associate { it.target to it.result }
+
+    protected fun candidatesWith(
+        result: DivineResult,
+        from: Map<Player, DivineResult>,
+        candidates: List<Player>
+    ): List<Player> = candidates.filter { from[it] == result }
+}

--- a/src/main/kotlin/SeerCpuStrategy.kt
+++ b/src/main/kotlin/SeerCpuStrategy.kt
@@ -1,54 +1,31 @@
 package org.example
 
-class SeerCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.SEER) {
+class SeerCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.SEER, SeerVoting(self)) {
 
-    override fun discuss(knowledge: List<GameEvent>): Statement {
-        val next = nextUnreportedDivination(knowledge) ?: return Statement.Plain("")
+    override fun discuss(): Statement {
+        val next = nextUnreportedDivination() ?: return Statement.Plain("")
         return Statement.DivinationReport(self, next.target, next.result)
     }
 
-    override fun selectTarget(context: SelectionContext, knowledge: List<GameEvent>): Player {
-        val candidates = context.candidates()
-        return when (context) {
-            is SelectionContext.Divine -> selectDivineTarget(candidates, knowledge)
-            is SelectionContext.Vote -> selectVoteTarget(candidates, knowledge)
+    override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
+        when (context) {
+            is SelectionContext.Divine -> selectDivineTarget(candidates)
             else -> candidates.random()
         }
+
+    private fun nextUnreportedDivination(): GameEvent.Divined? {
+        val reported = reportedTargets()
+        return self.knowledge.filterIsInstance<GameEvent.Divined>().firstOrNull { it.target !in reported }
     }
 
-    private fun nextUnreportedDivination(knowledge: List<GameEvent>): GameEvent.Divined? {
-        val reported = reportedTargets(knowledge)
-        return knowledge.filterIsInstance<GameEvent.Divined>().firstOrNull { it.target !in reported }
-    }
-
-    private fun reportedTargets(knowledge: List<GameEvent>): Set<Player> =
-        knowledge.filterIsInstance<GameEvent.StatementMade>()
+    private fun reportedTargets(): Set<Player> =
+        self.knowledge.filterIsInstance<GameEvent.StatementMade>()
             .map { it.statement }.filterIsInstance<Statement.DivinationReport>()
             .filter { it.claimant === self }.map { it.target }.toSet()
 
-    private fun selectDivineTarget(candidates: List<Player>, knowledge: List<GameEvent>): Player {
-        val divined = knowledge.filterIsInstance<GameEvent.Divined>().map { it.target }.toSet()
+    private fun selectDivineTarget(candidates: List<Player>): Player {
+        val divined = self.knowledge.filterIsInstance<GameEvent.Divined>().map { it.target }.toSet()
         val undivined = candidates.filter { it !in divined }
         return if (undivined.isNotEmpty()) undivined.random() else candidates.random()
     }
-
-    private fun selectVoteTarget(candidates: List<Player>, knowledge: List<GameEvent>): Player {
-        val myDivined = myDivinedResults(knowledge)
-        val reported = reportedDivinations(knowledge)
-
-        val myWolves = candidatesWith(DivineResult.WEREWOLF, myDivined, candidates)
-        val reportedWolves = candidatesWith(DivineResult.WEREWOLF, reported, candidates)
-        val myInnocent = candidatesWith(DivineResult.NOT_WEREWOLF, myDivined, candidates)
-        val reportedInnocent = candidatesWith(DivineResult.NOT_WEREWOLF, reported, candidates)
-
-        if (myWolves.isNotEmpty()) return myWolves.random()
-        val suspectedWolves = reportedWolves - myInnocent.toSet()
-        if (suspectedWolves.isNotEmpty()) return suspectedWolves.random()
-        val votable = candidates - myInnocent.toSet() - reportedInnocent.toSet()
-        return if (votable.isNotEmpty()) votable.random() else candidates.random()
-    }
-
-    private fun myDivinedResults(knowledge: List<GameEvent>): Map<Player, DivineResult> =
-        knowledge.filterIsInstance<GameEvent.Divined>().associate { it.target to it.result }
-
 }

--- a/src/main/kotlin/SeerCpuStrategy.kt
+++ b/src/main/kotlin/SeerCpuStrategy.kt
@@ -1,0 +1,54 @@
+package org.example
+
+class SeerCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.SEER) {
+
+    override fun discuss(knowledge: List<GameEvent>): Statement {
+        val next = nextUnreportedDivination(knowledge) ?: return Statement.Plain("")
+        return Statement.DivinationReport(self, next.target, next.result)
+    }
+
+    override fun selectTarget(context: SelectionContext, knowledge: List<GameEvent>): Player {
+        val candidates = context.candidates()
+        return when (context) {
+            is SelectionContext.Divine -> selectDivineTarget(candidates, knowledge)
+            is SelectionContext.Vote -> selectVoteTarget(candidates, knowledge)
+            else -> candidates.random()
+        }
+    }
+
+    private fun nextUnreportedDivination(knowledge: List<GameEvent>): GameEvent.Divined? {
+        val reported = reportedTargets(knowledge)
+        return knowledge.filterIsInstance<GameEvent.Divined>().firstOrNull { it.target !in reported }
+    }
+
+    private fun reportedTargets(knowledge: List<GameEvent>): Set<Player> =
+        knowledge.filterIsInstance<GameEvent.StatementMade>()
+            .map { it.statement }.filterIsInstance<Statement.DivinationReport>()
+            .filter { it.claimant === self }.map { it.target }.toSet()
+
+    private fun selectDivineTarget(candidates: List<Player>, knowledge: List<GameEvent>): Player {
+        val divined = knowledge.filterIsInstance<GameEvent.Divined>().map { it.target }.toSet()
+        val undivined = candidates.filter { it !in divined }
+        return if (undivined.isNotEmpty()) undivined.random() else candidates.random()
+    }
+
+    private fun selectVoteTarget(candidates: List<Player>, knowledge: List<GameEvent>): Player {
+        val myDivined = myDivinedResults(knowledge)
+        val reported = reportedDivinations(knowledge)
+
+        val myWolves = candidatesWith(DivineResult.WEREWOLF, myDivined, candidates)
+        val reportedWolves = candidatesWith(DivineResult.WEREWOLF, reported, candidates)
+        val myInnocent = candidatesWith(DivineResult.NOT_WEREWOLF, myDivined, candidates)
+        val reportedInnocent = candidatesWith(DivineResult.NOT_WEREWOLF, reported, candidates)
+
+        if (myWolves.isNotEmpty()) return myWolves.random()
+        val suspectedWolves = reportedWolves - myInnocent.toSet()
+        if (suspectedWolves.isNotEmpty()) return suspectedWolves.random()
+        val votable = candidates - myInnocent.toSet() - reportedInnocent.toSet()
+        return if (votable.isNotEmpty()) votable.random() else candidates.random()
+    }
+
+    private fun myDivinedResults(knowledge: List<GameEvent>): Map<Player, DivineResult> =
+        knowledge.filterIsInstance<GameEvent.Divined>().associate { it.target to it.result }
+
+}

--- a/src/main/kotlin/SeerVoting.kt
+++ b/src/main/kotlin/SeerVoting.kt
@@ -1,0 +1,18 @@
+package org.example
+
+class SeerVoting(player: RoleAwareCpuPlayer) : VotingStrategy {
+    private val query = KnowledgeQuery(player)
+
+    override fun selectVoteTarget(candidates: List<Player>): Player {
+        val myWolves = query.divinedAs(DivineResult.WEREWOLF, candidates)
+        val reportedWolves = query.reportedAs(DivineResult.WEREWOLF, candidates)
+        val myInnocent = query.divinedAs(DivineResult.NOT_WEREWOLF, candidates)
+        val reportedInnocent = query.reportedAs(DivineResult.NOT_WEREWOLF, candidates)
+
+        if (myWolves.isNotEmpty()) return myWolves.random()
+        val suspectedWolves = reportedWolves - myInnocent.toSet()
+        if (suspectedWolves.isNotEmpty()) return suspectedWolves.random()
+        val votable = candidates - myInnocent.toSet() - reportedInnocent.toSet()
+        return if (votable.isNotEmpty()) votable.random() else candidates.random()
+    }
+}

--- a/src/main/kotlin/VillagerCpuStrategy.kt
+++ b/src/main/kotlin/VillagerCpuStrategy.kt
@@ -1,24 +1,9 @@
 package org.example
 
-class VillagerCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.VILLAGER) {
+class VillagerCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.VILLAGER, CitizenVoting(self)) {
 
-    override fun discuss(knowledge: List<GameEvent>) = Statement.Plain("")
+    override fun discuss() = Statement.Plain("")
 
-    override fun selectTarget(context: SelectionContext, knowledge: List<GameEvent>): Player {
-        val candidates = context.candidates()
-        return when (context) {
-            is SelectionContext.Vote -> selectVoteTarget(candidates, knowledge)
-            else -> candidates.random()
-        }
-    }
-
-    private fun selectVoteTarget(candidates: List<Player>, knowledge: List<GameEvent>): Player {
-        val reported = reportedDivinations(knowledge)
-        val reportedWolves = candidatesWith(DivineResult.WEREWOLF, reported, candidates)
-        val reportedInnocent = candidatesWith(DivineResult.NOT_WEREWOLF, reported, candidates)
-
-        if (reportedWolves.isNotEmpty()) return reportedWolves.random()
-        val votable = candidates - reportedInnocent.toSet()
-        return if (votable.isNotEmpty()) votable.random() else candidates.random()
-    }
+    override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
+        candidates.random()
 }

--- a/src/main/kotlin/VillagerCpuStrategy.kt
+++ b/src/main/kotlin/VillagerCpuStrategy.kt
@@ -1,0 +1,24 @@
+package org.example
+
+class VillagerCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.VILLAGER) {
+
+    override fun discuss(knowledge: List<GameEvent>) = Statement.Plain("")
+
+    override fun selectTarget(context: SelectionContext, knowledge: List<GameEvent>): Player {
+        val candidates = context.candidates()
+        return when (context) {
+            is SelectionContext.Vote -> selectVoteTarget(candidates, knowledge)
+            else -> candidates.random()
+        }
+    }
+
+    private fun selectVoteTarget(candidates: List<Player>, knowledge: List<GameEvent>): Player {
+        val reported = reportedDivinations(knowledge)
+        val reportedWolves = candidatesWith(DivineResult.WEREWOLF, reported, candidates)
+        val reportedInnocent = candidatesWith(DivineResult.NOT_WEREWOLF, reported, candidates)
+
+        if (reportedWolves.isNotEmpty()) return reportedWolves.random()
+        val votable = candidates - reportedInnocent.toSet()
+        return if (votable.isNotEmpty()) votable.random() else candidates.random()
+    }
+}

--- a/src/main/kotlin/VotingStrategy.kt
+++ b/src/main/kotlin/VotingStrategy.kt
@@ -1,0 +1,5 @@
+package org.example
+
+interface VotingStrategy {
+    fun selectVoteTarget(candidates: List<Player>): Player
+}

--- a/src/main/kotlin/WerewolfCpuStrategy.kt
+++ b/src/main/kotlin/WerewolfCpuStrategy.kt
@@ -1,0 +1,25 @@
+package org.example
+
+class WerewolfCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.WEREWOLF) {
+
+    override fun discuss(knowledge: List<GameEvent>) = Statement.Plain("")
+
+    override fun selectTarget(context: SelectionContext, knowledge: List<GameEvent>): Player {
+        val candidates = context.candidates()
+        return when (context) {
+            is SelectionContext.Attack -> selectAttackTarget(candidates, knowledge)
+            is SelectionContext.Vote -> selectVoteTarget(candidates, knowledge)
+            else -> candidates.random()
+        }
+    }
+
+    private fun selectAttackTarget(candidates: List<Player>, knowledge: List<GameEvent>): Player {
+        val targets = candidates.filter { it in claimedSeers(knowledge) }
+        return if (targets.isNotEmpty()) targets.random() else candidates.random()
+    }
+
+    private fun selectVoteTarget(candidates: List<Player>, knowledge: List<GameEvent>): Player {
+        val targets = candidates.filter { it in claimedSeers(knowledge) }
+        return if (targets.isNotEmpty()) targets.random() else candidates.random()
+    }
+}

--- a/src/main/kotlin/WerewolfCpuStrategy.kt
+++ b/src/main/kotlin/WerewolfCpuStrategy.kt
@@ -1,25 +1,18 @@
 package org.example
 
-class WerewolfCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.WEREWOLF) {
+class WerewolfCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.WEREWOLF, WerewolfVoting(self)) {
+    private val query = KnowledgeQuery(self)
 
-    override fun discuss(knowledge: List<GameEvent>) = Statement.Plain("")
+    override fun discuss() = Statement.Plain("")
 
-    override fun selectTarget(context: SelectionContext, knowledge: List<GameEvent>): Player {
-        val candidates = context.candidates()
-        return when (context) {
-            is SelectionContext.Attack -> selectAttackTarget(candidates, knowledge)
-            is SelectionContext.Vote -> selectVoteTarget(candidates, knowledge)
+    override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
+        when (context) {
+            is SelectionContext.Attack -> selectAttackTarget(candidates)
             else -> candidates.random()
         }
-    }
 
-    private fun selectAttackTarget(candidates: List<Player>, knowledge: List<GameEvent>): Player {
-        val targets = candidates.filter { it in claimedSeers(knowledge) }
-        return if (targets.isNotEmpty()) targets.random() else candidates.random()
-    }
-
-    private fun selectVoteTarget(candidates: List<Player>, knowledge: List<GameEvent>): Player {
-        val targets = candidates.filter { it in claimedSeers(knowledge) }
+    private fun selectAttackTarget(candidates: List<Player>): Player {
+        val targets = candidates.filter { it in query.claimedSeers() }
         return if (targets.isNotEmpty()) targets.random() else candidates.random()
     }
 }

--- a/src/main/kotlin/WerewolfVoting.kt
+++ b/src/main/kotlin/WerewolfVoting.kt
@@ -1,0 +1,10 @@
+package org.example
+
+class WerewolfVoting(player: RoleAwareCpuPlayer) : VotingStrategy {
+    private val query = KnowledgeQuery(player)
+
+    override fun selectVoteTarget(candidates: List<Player>): Player {
+        val targets = candidates.filter { it in query.claimedSeers() }
+        return if (targets.isNotEmpty()) targets.random() else candidates.random()
+    }
+}

--- a/src/test/kotlin/RoleAwareCpuPlayerTest.kt
+++ b/src/test/kotlin/RoleAwareCpuPlayerTest.kt
@@ -102,6 +102,20 @@ class RoleAwareCpuPlayerTest {
     }
 
     @Test
+    fun `werewolf votes for claimed seer`() {
+        val wolf = RoleAwareCpuPlayer(Role.WEREWOLF, "Wolf")
+        val seer = StubPlayer("Seer", Role.SEER)
+        val villager = StubPlayer("Villager", Role.VILLAGER)
+        val allPlayers = AllPlayers(listOf(wolf, seer, villager))
+        GameEvent.StatementMade.send(1, seer.name, Statement.DivinationReport(seer, villager, DivineResult.NOT_WEREWOLF), allPlayers)
+
+        repeat(100) {
+            val voted = wolf.selectTarget(SelectionContext.Vote(wolf, listOf(seer, villager)))
+            assertEquals(seer, voted)
+        }
+    }
+
+    @Test
     fun `villager does not vote for player reported as not werewolf when other candidates exist`() {
         val seer = RoleAwareCpuPlayer(Role.SEER, "Seer")
         val villager = RoleAwareCpuPlayer(Role.VILLAGER, "Villager")


### PR DESCRIPTION
## 概要

役職ごとの判断ロジックを `RoleAwareCpuStrategy` として `RoleAwareCpuPlayer` から分離した。

## 変更内容

- `RoleAwareCpuStrategy` 抽象クラスを導入し、各役職のストラテジーを実装: `SeerCpuStrategy` / `MediumCpuStrategy` / `WerewolfCpuStrategy` / `HunterCpuStrategy` / `VillagerCpuStrategy`
- 共通ヘルパー（`claimedSeers` / `reportedDivinations` / `candidatesWith`）を親クラスに `protected` で配置
- `RoleAwareCpuPlayer` は `knowledge` の蓄積とストラテジーへの委譲のみを担う

## issueとの差分

- **`interface` ではなく `abstract class`**: `protected` ヘルパーを持つため
- **クラス名を `RoleAwareCpuStrategy`**: CPU専用であることを明示するため
- **`appliesTo()` は引数なし**: コンストラクタで受け取った `targetRole` と `self.myRole` を比較する設計にしたため
- **`RoleAwareCpuPlayer.myRole` を公開**: ストラテジーの `appliesTo()` から参照するため
- **人狼の投票ロジックを変更**: ランダム → 自称占い師を優先して口封じするよう変更

Closes #118