### PR TITLE
Use Kotlin by-delegation for Iterable in AllPlayers

### DIFF
--- a/src/main/kotlin/Notifiable.kt
+++ b/src/main/kotlin/Notifiable.kt
@@ -5,10 +5,9 @@ interface Notifiable {
     fun receive(event: GameEvent)
 }
 
-class AllPlayers(private val players: List<Player>) : Notifiable, Iterable<Player> {
+class AllPlayers(private val players: List<Player>) : Notifiable, Iterable<Player> by players {
     override val recipientName = "全プレイヤー"
     override fun receive(event: GameEvent) = players.forEach { it.receive(event) }
-    override fun iterator() = players.iterator()
 }
 
 class Wolves(private val oracle: Oracle, private val playerManager: PlayerManager) : Notifiable {


### PR DESCRIPTION
## Summary

- `AllPlayers` の `Iterable<Player>` を `by players` 委譲に変更
- `override fun iterator()` が不要になり削除

## Test plan

- [x] `./gradlew build` が BUILD SUCCESSFUL

Closes #131

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)