### PR TITLE
Delegate epilogue display to Player instead of println in EndPhase

### DIFF
--- a/src/main/kotlin/CpuPlayer.kt
+++ b/src/main/kotlin/CpuPlayer.kt
@@ -1,0 +1,5 @@
+package org.example
+
+abstract class CpuPlayer(role: Role) : Player(role) {
+    override fun watchEpilogue(events: List<GameEvent>) = Unit
+}

--- a/src/main/kotlin/EndPhase.kt
+++ b/src/main/kotlin/EndPhase.kt
@@ -13,8 +13,7 @@ class EndPhase(
     }
 
     private fun showRecap() {
-        println("=== ゲーム振り返り ===")
-        GameRecap(playerManager, signal).events()
-            .forEach { println("  ${it.recipientName}: [${it.title}] ${it.body()}") }
+        val events = GameRecap(playerManager, signal).events()
+        playerManager.allPlayers.forEach { it.watchEpilogue(events) }
     }
 }

--- a/src/main/kotlin/HonestCpuPlayer.kt
+++ b/src/main/kotlin/HonestCpuPlayer.kt
@@ -1,6 +1,6 @@
 package org.example
 
-class HonestCpuPlayer(role: Role, override val name: String) : Player(role) {
+class HonestCpuPlayer(role: Role, override val name: String) : CpuPlayer(role) {
     private val unspoken = mutableListOf<GameEvent>()
     private var selectCount = 0
 

--- a/src/main/kotlin/HumanPlayer.kt
+++ b/src/main/kotlin/HumanPlayer.kt
@@ -10,4 +10,9 @@ class HumanPlayer(role: Role, override val name: String, private val io: PlayerI
 
     override fun discuss(players: List<Player>): Statement =
         Statement.Plain(io.promptFreeText(name, "議論", "発言してください"))
+
+    override fun watchEpilogue(events: List<GameEvent>) {
+        val content = events.joinToString("\n") { "  ${it.recipientName}: [${it.title}] ${it.body()}" }
+        io.sendMessage(name, "ゲーム振り返り", content)
+    }
 }

--- a/src/main/kotlin/Player.kt
+++ b/src/main/kotlin/Player.kt
@@ -13,6 +13,7 @@ abstract class Player(private val role: Role) : Notifiable {
     protected abstract fun onReceive(event: GameEvent)
     abstract fun selectTarget(context: SelectionContext): Player
     abstract fun discuss(players: List<Player>): Statement
+    abstract fun watchEpilogue(events: List<GameEvent>)
 
     // signal is a capability token: only callers who hold a GameOverSignal (i.e., after game over) can access knowledge
     @Suppress("UnusedParameter")

--- a/src/main/kotlin/RandomCpuPlayer.kt
+++ b/src/main/kotlin/RandomCpuPlayer.kt
@@ -1,6 +1,6 @@
 package org.example
 
-class RandomCpuPlayer(role: Role, override val name: String) : Player(role) {
+class RandomCpuPlayer(role: Role, override val name: String) : CpuPlayer(role) {
     override fun selectTarget(context: SelectionContext): Player = context.candidates().random()
     override fun discuss(players: List<Player>): Statement = Statement.Plain("")
     override fun onReceive(event: GameEvent) { /* does not use received events */ }

--- a/src/main/kotlin/RoleAwareCpuPlayer.kt
+++ b/src/main/kotlin/RoleAwareCpuPlayer.kt
@@ -1,6 +1,6 @@
 package org.example
 
-class RoleAwareCpuPlayer(val myRole: Role, override val name: String) : Player(myRole) {
+class RoleAwareCpuPlayer(val myRole: Role, override val name: String) : CpuPlayer(myRole) {
     private val _knowledge = mutableListOf<GameEvent>()
     val knowledge: List<GameEvent> get() = _knowledge.toList()
 

--- a/src/main/kotlin/RollerCpuPlayer.kt
+++ b/src/main/kotlin/RollerCpuPlayer.kt
@@ -1,6 +1,6 @@
 package org.example
 
-class RollerCpuPlayer(role: Role, override val name: String) : Player(role) {
+class RollerCpuPlayer(role: Role, override val name: String) : CpuPlayer(role) {
     private var selectCount = 0
 
     override fun selectTarget(context: SelectionContext): Player {

--- a/src/test/kotlin/NothingPlayer.kt
+++ b/src/test/kotlin/NothingPlayer.kt
@@ -4,4 +4,5 @@ open class NothingPlayer(role: Role, override val name: String) : Player(role) {
     override fun discuss(players: List<Player>): Statement = error("discuss not expected")
     override fun onReceive(event: GameEvent) { error("onReceive not expected") }
     override fun selectTarget(context: SelectionContext): Player = error("selectTarget not expected")
+    override fun watchEpilogue(events: List<GameEvent>) = error("watchEpilogue not expected")
 }


### PR DESCRIPTION
## Summary

- `Player` に `abstract fun watchEpilogue(events: List<GameEvent>)` を追加
- `CpuPlayer` abstract class を新規導入し、`watchEpilogue` を no-op 実装
- 4つのCPUプレイヤーが `CpuPlayer` を継承するよう変更
- `HumanPlayer` が `PlayerIO` 経由でエピローグを表示
- `EndPhase.showRecap()` の `println` を除去し、各プレイヤーへ委譲

## Test plan

- [x] `./gradlew build` が BUILD SUCCESSFUL
- [x] `./gradlew detekt` が BUILD SUCCESSFUL

Closes #111

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)