### PR TITLE
Wire detekt into the build lifecycle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,10 @@ detekt {
     config.setFrom(files("config/detekt/detekt.yml"))
 }
 
+tasks.check {
+    dependsOn(tasks.detekt)
+}
+
 tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
     reports {
         xml.required.set(true)


### PR DESCRIPTION
## Summary

- `tasks.check { dependsOn(tasks.detekt) }` を追加
- `./gradlew build` で detekt が自動実行されるようになった

## Test plan

- [x] `./gradlew build --rerun-tasks` で `:detekt` → `:check` → `:build` の順に実行されることを確認
- [x] detekt 違反があると `./gradlew build` が FAILED になることを確認

Closes #136

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)