### PR TITLE
Add Madman role basics: Role, NightAction, and stub strategy

### DIFF
--- a/src/main/kotlin/CpuLodge.kt
+++ b/src/main/kotlin/CpuLodge.kt
@@ -5,7 +5,7 @@ abstract class CpuLodge : Lodge() {
 
     override fun assignments(): List<Pair<Player, Role>> {
         val roles = listOf(
-            Role.HUNTER, Role.VILLAGER, Role.VILLAGER,
+            Role.HUNTER, Role.VILLAGER, Role.MADMAN,
             Role.WEREWOLF, Role.SEER, Role.MEDIUM, Role.WEREWOLF,
         ).shuffled()
         val players = listOf(HumanPlayer(roles[0], "1", ConsolePlayerIO())) +

--- a/src/main/kotlin/MadmanCpuStrategy.kt
+++ b/src/main/kotlin/MadmanCpuStrategy.kt
@@ -1,0 +1,6 @@
+package org.example
+
+class MadmanCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.MADMAN, CitizenVoting(self)) {
+    override fun discuss() = Statement.Plain("")
+    override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player = candidates.random()
+}

--- a/src/main/kotlin/Role.kt
+++ b/src/main/kotlin/Role.kt
@@ -35,6 +35,10 @@ enum class Role(val displayName: String, val side: Side, val divineResult: Divin
         override fun firstNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction = NightAction.None
         override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction =
             NightAction.Guard(self.selectTarget(SelectionContext.Guard(self, players)))
+    },
+    MADMAN("狂人", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
+        override fun firstNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction = NightAction.None
+        override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction = NightAction.None
     };
 
     abstract fun firstNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction

--- a/src/main/kotlin/RoleAwareCpuPlayer.kt
+++ b/src/main/kotlin/RoleAwareCpuPlayer.kt
@@ -6,7 +6,7 @@ class RoleAwareCpuPlayer(val myRole: Role, override val name: String) : CpuPlaye
 
     private val strategy = setOf(
         SeerCpuStrategy(this), MediumCpuStrategy(this), WerewolfCpuStrategy(this),
-        HunterCpuStrategy(this), VillagerCpuStrategy(this)
+        HunterCpuStrategy(this), VillagerCpuStrategy(this), MadmanCpuStrategy(this)
     ).single { it.appliesTo() }
 
     override fun onReceive(event: GameEvent) { _knowledge.add(event) }


### PR DESCRIPTION
## Summary

- `Role.MADMAN` を追加（市民陣営、占い/霊能結果は NOT_WEREWOLF、夜行動なし）
- `CpuLodge` の役職構成で村人1人を狂人に入れ替え
- `MadmanCpuStrategy` のスタブを追加（`RoleAwareCpuPlayer` の初期化エラーを解消）

## Test plan

- [x] `./gradlew build` が BUILD SUCCESSFUL
- [x] `RoleAwareCPU` Lodge で実行してエラーが出ないことを確認済み

Closes #121

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)