### PR TITLE
Change win condition to support Madman winning with werewolves

### DIFF
--- a/src/main/kotlin/Oracle.kt
+++ b/src/main/kotlin/Oracle.kt
@@ -23,5 +23,5 @@ class Oracle(private val roles: Map<Player, Role>) {
 
     fun aliveCounts(alivePlayers: List<Player>): AliveCounts =
         AliveCounts(Side.entries.associateWith { side -> alivePlayers.count { roleOf(it).side == side } })
-    fun isWinner(player: Player, winningSide: Side): Boolean = roleOf(player).side == winningSide
+    fun isWinner(player: Player, winningSide: Side): Boolean = roleOf(player).isWinner(winningSide)
 }

--- a/src/main/kotlin/Role.kt
+++ b/src/main/kotlin/Role.kt
@@ -1,6 +1,6 @@
 package org.example
 
-enum class Role(val displayName: String, val side: Side, val divineResult: DivineResult, val mediumResult: MediumResult) {
+enum class Role(val displayName: String, val side: Side, val divineResult: DivineResult, val mediumResult: MediumResult, val winningSide: Side = side) {
     WEREWOLF("人狼", Side.WEREWOLF, DivineResult.WEREWOLF, MediumResult.WEREWOLF) {
         override fun firstNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction = NightAction.None
         override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction {
@@ -36,7 +36,7 @@ enum class Role(val displayName: String, val side: Side, val divineResult: Divin
         override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction =
             NightAction.Guard(self.selectTarget(SelectionContext.Guard(self, players)))
     },
-    MADMAN("狂人", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
+    MADMAN("狂人", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF, Side.WEREWOLF) {
         override fun firstNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction = NightAction.None
         override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction = NightAction.None
     };
@@ -46,4 +46,6 @@ enum class Role(val displayName: String, val side: Side, val divineResult: Divin
 
     fun buildNightAction(self: Player, players: List<Player>, isFirstNight: Boolean, knowledge: List<GameEvent>): NightAction =
         if (isFirstNight) firstNightAction(self, players, knowledge) else normalNightAction(self, players, knowledge)
+
+    fun isWinner(winningSide: Side) = this.winningSide == winningSide
 }

--- a/src/test/kotlin/OracleIsWinnerTest.kt
+++ b/src/test/kotlin/OracleIsWinnerTest.kt
@@ -1,0 +1,47 @@
+package org.example
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class OracleIsWinnerTest {
+
+    private fun oracle(vararg pairs: Pair<Player, Role>) = Oracle(mapOf(*pairs))
+    private fun player(role: Role) = NothingPlayer(role, "p")
+
+    @Test
+    fun `villager wins when citizen side wins`() {
+        val p = player(Role.VILLAGER)
+        assertTrue(oracle(p to Role.VILLAGER).isWinner(p, Side.CITIZEN))
+    }
+
+    @Test
+    fun `villager loses when werewolf side wins`() {
+        val p = player(Role.VILLAGER)
+        assertFalse(oracle(p to Role.VILLAGER).isWinner(p, Side.WEREWOLF))
+    }
+
+    @Test
+    fun `werewolf wins when werewolf side wins`() {
+        val p = player(Role.WEREWOLF)
+        assertTrue(oracle(p to Role.WEREWOLF).isWinner(p, Side.WEREWOLF))
+    }
+
+    @Test
+    fun `werewolf loses when citizen side wins`() {
+        val p = player(Role.WEREWOLF)
+        assertFalse(oracle(p to Role.WEREWOLF).isWinner(p, Side.CITIZEN))
+    }
+
+    @Test
+    fun `madman wins when werewolf side wins`() {
+        val p = player(Role.MADMAN)
+        assertTrue(oracle(p to Role.MADMAN).isWinner(p, Side.WEREWOLF))
+    }
+
+    @Test
+    fun `madman loses when citizen side wins`() {
+        val p = player(Role.MADMAN)
+        assertFalse(oracle(p to Role.MADMAN).isWinner(p, Side.CITIZEN))
+    }
+}


### PR DESCRIPTION
## Summary

- `Role` に `winningSide` プロパティを追加（デフォルトは `side`）
- `Role.isWinner()` を追加して勝利判定ロジックを `Role` に集約
- `Oracle.isWinner()` が `Role.isWinner()` に委譲するよう変更
- `MADMAN` の `winningSide` は `Side.WEREWOLF`（市民陣営だが人狼と同じ条件で勝利）

## Test plan

- [x] `./gradlew build` が BUILD SUCCESSFUL
- [x] `OracleIsWinnerTest` で村人・人狼・狂人の勝敗判定を網羅

Closes #122

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)