### PR TITLE
Add Madman role

### DIFF
--- a/src/main/kotlin/CpuLodge.kt
+++ b/src/main/kotlin/CpuLodge.kt
@@ -5,7 +5,7 @@ abstract class CpuLodge : Lodge() {
 
     override fun assignments(): List<Pair<Player, Role>> {
         val roles = listOf(
-            Role.HUNTER, Role.VILLAGER, Role.VILLAGER,
+            Role.HUNTER, Role.VILLAGER, Role.MADMAN,
             Role.WEREWOLF, Role.SEER, Role.MEDIUM, Role.WEREWOLF,
         ).shuffled()
         val players = listOf(HumanPlayer(roles[0], "1", ConsolePlayerIO())) +

--- a/src/main/kotlin/HunterCpuStrategy.kt
+++ b/src/main/kotlin/HunterCpuStrategy.kt
@@ -3,7 +3,7 @@ package org.example
 class HunterCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.HUNTER, CitizenVoting(self)) {
     private val query = KnowledgeQuery(self)
 
-    override fun discuss() = Statement.Plain("")
+    override fun discuss(players: List<Player>) = Statement.Plain("")
 
     override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
         when (context) {

--- a/src/main/kotlin/MadmanCpuStrategy.kt
+++ b/src/main/kotlin/MadmanCpuStrategy.kt
@@ -1,6 +1,26 @@
 package org.example
 
-class MadmanCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.MADMAN, CitizenVoting(self)) {
-    override fun discuss() = Statement.Plain("")
-    override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player = candidates.random()
+class MadmanCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.MADMAN, WerewolfVoting(self)) {
+
+    override fun discuss(players: List<Player>): Statement {
+        val target = nextUnreportedTarget(players) ?: return Statement.Plain("")
+        return Statement.DivinationReport(self, target, DivineResult.WEREWOLF)
+    }
+
+    override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
+        candidates.random()
+
+    private fun nextUnreportedTarget(players: List<Player>): Player? {
+        val accused = accusedByMe()
+        return players.filter { it !== self && it !in accused }.randomOrNull()
+    }
+
+    private fun accusedByMe(): Set<Player> =
+        self.knowledge.filterIsInstance<GameEvent.StatementMade>()
+            .map { it.statement }
+            .filterIsInstance<Statement.DivinationReport>()
+            .filter { it.claimant === self }
+            .map { it.target }
+            .toSet()
 }
+

--- a/src/main/kotlin/MadmanCpuStrategy.kt
+++ b/src/main/kotlin/MadmanCpuStrategy.kt
@@ -1,14 +1,12 @@
 package org.example
 
-class MadmanCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.MADMAN, WerewolfVoting(self)) {
+class MadmanCpuStrategy(
+    self: RoleAwareCpuPlayer,
+    private val impersonating: Role = listOf(Role.SEER, Role.MEDIUM).random(),
+) : RoleAwareCpuStrategy(self, Role.MADMAN, WerewolfVoting(self)) {
 
-    private val impersonating = listOf(Role.SEER, Role.MEDIUM).random()
-
-    override fun discuss(players: List<Player>): Statement = when (impersonating) {
-        Role.SEER -> fakeSeerDiscuss(players)
-        Role.MEDIUM -> fakeMediumDiscuss()
-        else -> Statement.Plain("")
-    }
+    override fun discuss(players: List<Player>): Statement =
+        if (impersonating == Role.SEER) fakeSeerDiscuss(players) else fakeMediumDiscuss()
 
     override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
         candidates.random()

--- a/src/main/kotlin/MadmanCpuStrategy.kt
+++ b/src/main/kotlin/MadmanCpuStrategy.kt
@@ -2,17 +2,29 @@ package org.example
 
 class MadmanCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.MADMAN, WerewolfVoting(self)) {
 
-    override fun discuss(players: List<Player>): Statement {
-        val target = nextUnreportedTarget(players) ?: return Statement.Plain("")
-        return Statement.DivinationReport(self, target, DivineResult.WEREWOLF)
+    private val impersonating = listOf(Role.SEER, Role.MEDIUM).random()
+
+    override fun discuss(players: List<Player>): Statement = when (impersonating) {
+        Role.SEER -> fakeSeerDiscuss(players)
+        Role.MEDIUM -> fakeMediumDiscuss()
+        else -> Statement.Plain("")
     }
 
     override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
         candidates.random()
 
-    private fun nextUnreportedTarget(players: List<Player>): Player? {
-        val accused = accusedByMe()
-        return players.filter { it !== self && it !in accused }.randomOrNull()
+    private fun fakeSeerDiscuss(players: List<Player>): Statement {
+        val target = players.filter { it !== self && it !in accusedByMe() }.randomOrNull()
+            ?: return Statement.Plain("")
+        return Statement.DivinationReport(self, target, DivineResult.WEREWOLF)
+    }
+
+    private fun fakeMediumDiscuss(): Statement {
+        val target = self.knowledge.filterIsInstance<GameEvent.PlayerExecuted>()
+            .map { it.executed }
+            .firstOrNull { it !in fakeMediumedByMe() }
+            ?: return Statement.Plain("")
+        return Statement.MediumReport(self, target, MediumResult.NOT_WEREWOLF)
     }
 
     private fun accusedByMe(): Set<Player> =
@@ -22,5 +34,12 @@ class MadmanCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, R
             .filter { it.claimant === self }
             .map { it.target }
             .toSet()
-}
 
+    private fun fakeMediumedByMe(): Set<Player> =
+        self.knowledge.filterIsInstance<GameEvent.StatementMade>()
+            .map { it.statement }
+            .filterIsInstance<Statement.MediumReport>()
+            .filter { it.claimant === self }
+            .map { it.target }
+            .toSet()
+}

--- a/src/main/kotlin/MadmanCpuStrategy.kt
+++ b/src/main/kotlin/MadmanCpuStrategy.kt
@@ -1,0 +1,6 @@
+package org.example
+
+class MadmanCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.MADMAN, CitizenVoting(self)) {
+    override fun discuss() = Statement.Plain("")
+    override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player = candidates.random()
+}

--- a/src/main/kotlin/MediumCpuStrategy.kt
+++ b/src/main/kotlin/MediumCpuStrategy.kt
@@ -2,7 +2,7 @@ package org.example
 
 class MediumCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.MEDIUM, CitizenVoting(self)) {
 
-    override fun discuss(): Statement {
+    override fun discuss(players: List<Player>): Statement {
         val next = nextUnreportedReveal() ?: return Statement.Plain("")
         return Statement.MediumReport(self, next.target, next.result)
     }

--- a/src/main/kotlin/Oracle.kt
+++ b/src/main/kotlin/Oracle.kt
@@ -23,5 +23,5 @@ class Oracle(private val roles: Map<Player, Role>) {
 
     fun aliveCounts(alivePlayers: List<Player>): AliveCounts =
         AliveCounts(Side.entries.associateWith { side -> alivePlayers.count { roleOf(it).side == side } })
-    fun isWinner(player: Player, winningSide: Side): Boolean = roleOf(player).side == winningSide
+    fun isWinner(player: Player, winningSide: Side): Boolean = roleOf(player).isWinner(winningSide)
 }

--- a/src/main/kotlin/Role.kt
+++ b/src/main/kotlin/Role.kt
@@ -35,6 +35,10 @@ enum class Role(val displayName: String, val side: Side, val divineResult: Divin
         override fun firstNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction = NightAction.None
         override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction =
             NightAction.Guard(self.selectTarget(SelectionContext.Guard(self, players)))
+    },
+    MADMAN("狂人", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
+        override fun firstNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction = NightAction.None
+        override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction = NightAction.None
     };
 
     abstract fun firstNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction

--- a/src/main/kotlin/Role.kt
+++ b/src/main/kotlin/Role.kt
@@ -1,6 +1,6 @@
 package org.example
 
-enum class Role(val displayName: String, val side: Side, val divineResult: DivineResult, val mediumResult: MediumResult) {
+enum class Role(val displayName: String, val side: Side, val divineResult: DivineResult, val mediumResult: MediumResult, val winningSide: Side = side) {
     WEREWOLF("人狼", Side.WEREWOLF, DivineResult.WEREWOLF, MediumResult.WEREWOLF) {
         override fun firstNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction = NightAction.None
         override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction {
@@ -36,7 +36,7 @@ enum class Role(val displayName: String, val side: Side, val divineResult: Divin
         override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction =
             NightAction.Guard(self.selectTarget(SelectionContext.Guard(self, players)))
     },
-    MADMAN("狂人", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
+    MADMAN("狂人", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF, Side.WEREWOLF) {
         override fun firstNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction = NightAction.None
         override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction = NightAction.None
     };
@@ -46,4 +46,6 @@ enum class Role(val displayName: String, val side: Side, val divineResult: Divin
 
     fun buildNightAction(self: Player, players: List<Player>, isFirstNight: Boolean, knowledge: List<GameEvent>): NightAction =
         if (isFirstNight) firstNightAction(self, players, knowledge) else normalNightAction(self, players, knowledge)
+
+    fun isWinner(winningSide: Side) = this.winningSide == winningSide
 }

--- a/src/main/kotlin/RoleAwareCpuPlayer.kt
+++ b/src/main/kotlin/RoleAwareCpuPlayer.kt
@@ -6,7 +6,7 @@ class RoleAwareCpuPlayer(val myRole: Role, override val name: String) : CpuPlaye
 
     private val strategy = setOf(
         SeerCpuStrategy(this), MediumCpuStrategy(this), WerewolfCpuStrategy(this),
-        HunterCpuStrategy(this), VillagerCpuStrategy(this)
+        HunterCpuStrategy(this), VillagerCpuStrategy(this), MadmanCpuStrategy(this)
     ).single { it.appliesTo() }
 
     override fun onReceive(event: GameEvent) { _knowledge.add(event) }

--- a/src/main/kotlin/RoleAwareCpuPlayer.kt
+++ b/src/main/kotlin/RoleAwareCpuPlayer.kt
@@ -10,6 +10,6 @@ class RoleAwareCpuPlayer(val myRole: Role, override val name: String) : CpuPlaye
     ).single { it.appliesTo() }
 
     override fun onReceive(event: GameEvent) { _knowledge.add(event) }
-    override fun discuss(players: List<Player>) = strategy.discuss()
+    override fun discuss(players: List<Player>) = strategy.discuss(players)
     override fun selectTarget(context: SelectionContext) = strategy.selectTarget(context)
 }

--- a/src/main/kotlin/RoleAwareCpuStrategy.kt
+++ b/src/main/kotlin/RoleAwareCpuStrategy.kt
@@ -7,7 +7,7 @@ abstract class RoleAwareCpuStrategy(
 ) {
     fun appliesTo() = self.myRole == targetRole
 
-    abstract fun discuss(): Statement
+    abstract fun discuss(players: List<Player>): Statement
 
     fun selectTarget(context: SelectionContext): Player {
         val candidates = context.candidates()

--- a/src/main/kotlin/SeerCpuStrategy.kt
+++ b/src/main/kotlin/SeerCpuStrategy.kt
@@ -2,7 +2,7 @@ package org.example
 
 class SeerCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.SEER, SeerVoting(self)) {
 
-    override fun discuss(): Statement {
+    override fun discuss(players: List<Player>): Statement {
         val next = nextUnreportedDivination() ?: return Statement.Plain("")
         return Statement.DivinationReport(self, next.target, next.result)
     }

--- a/src/main/kotlin/VillagerCpuStrategy.kt
+++ b/src/main/kotlin/VillagerCpuStrategy.kt
@@ -2,7 +2,7 @@ package org.example
 
 class VillagerCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.VILLAGER, CitizenVoting(self)) {
 
-    override fun discuss() = Statement.Plain("")
+    override fun discuss(players: List<Player>) = Statement.Plain("")
 
     override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
         candidates.random()

--- a/src/main/kotlin/WerewolfCpuStrategy.kt
+++ b/src/main/kotlin/WerewolfCpuStrategy.kt
@@ -3,7 +3,7 @@ package org.example
 class WerewolfCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.WEREWOLF, WerewolfVoting(self)) {
     private val query = KnowledgeQuery(self)
 
-    override fun discuss() = Statement.Plain("")
+    override fun discuss(players: List<Player>) = Statement.Plain("")
 
     override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
         when (context) {

--- a/src/test/kotlin/MadmanCpuStrategyTest.kt
+++ b/src/test/kotlin/MadmanCpuStrategyTest.kt
@@ -1,0 +1,62 @@
+package org.example
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class MadmanCpuStrategyTest {
+
+    private val madman = RoleAwareCpuPlayer(Role.MADMAN, "狂人")
+    private val player1 = ReceivingPlayer(Role.VILLAGER, "村人1")
+    private val player2 = ReceivingPlayer(Role.VILLAGER, "村人2")
+    private val allPlayers = AllPlayers(listOf(madman, player1, player2))
+
+    @Test
+    fun `fake seer reports an alive player as werewolf`() {
+        val strategy = MadmanCpuStrategy(madman, Role.SEER)
+        val result = strategy.discuss(listOf(madman, player1, player2))
+        assertTrue(result is Statement.DivinationReport)
+        assertEquals(DivineResult.WEREWOLF, result.result)
+        assertNotSame(madman, result.target)
+    }
+
+    @Test
+    fun `fake seer stays silent when all players already accused`() {
+        val strategy = MadmanCpuStrategy(madman, Role.SEER)
+        GameEvent.StatementMade.send(1, madman.name, Statement.DivinationReport(madman, player1, DivineResult.WEREWOLF), allPlayers)
+        GameEvent.StatementMade.send(1, madman.name, Statement.DivinationReport(madman, player2, DivineResult.WEREWOLF), allPlayers)
+
+        val result = strategy.discuss(listOf(madman, player1, player2))
+        assertTrue(result is Statement.Plain)
+    }
+
+    @Test
+    fun `fake medium reports executed player as not werewolf`() {
+        val strategy = MadmanCpuStrategy(madman, Role.MEDIUM)
+        GameEvent.PlayerExecuted.send(player1, allPlayers)
+
+        val result = strategy.discuss(listOf(madman, player2))
+        assertTrue(result is Statement.MediumReport)
+        assertEquals(MediumResult.NOT_WEREWOLF, result.result)
+        assertSame(player1, result.target)
+    }
+
+    @Test
+    fun `fake medium stays silent when no executions yet`() {
+        val strategy = MadmanCpuStrategy(madman, Role.MEDIUM)
+        val result = strategy.discuss(listOf(madman, player1, player2))
+        assertTrue(result is Statement.Plain)
+    }
+
+    @Test
+    fun `fake medium stays silent after all executed players already reported`() {
+        val strategy = MadmanCpuStrategy(madman, Role.MEDIUM)
+        GameEvent.PlayerExecuted.send(player1, allPlayers)
+        GameEvent.StatementMade.send(1, madman.name, Statement.MediumReport(madman, player1, MediumResult.NOT_WEREWOLF), allPlayers)
+
+        val result = strategy.discuss(listOf(madman, player2))
+        assertTrue(result is Statement.Plain)
+    }
+}

--- a/src/test/kotlin/OracleIsWinnerTest.kt
+++ b/src/test/kotlin/OracleIsWinnerTest.kt
@@ -1,0 +1,47 @@
+package org.example
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class OracleIsWinnerTest {
+
+    private fun oracle(vararg pairs: Pair<Player, Role>) = Oracle(mapOf(*pairs))
+    private fun player(role: Role) = NothingPlayer(role, "p")
+
+    @Test
+    fun `villager wins when citizen side wins`() {
+        val p = player(Role.VILLAGER)
+        assertTrue(oracle(p to Role.VILLAGER).isWinner(p, Side.CITIZEN))
+    }
+
+    @Test
+    fun `villager loses when werewolf side wins`() {
+        val p = player(Role.VILLAGER)
+        assertFalse(oracle(p to Role.VILLAGER).isWinner(p, Side.WEREWOLF))
+    }
+
+    @Test
+    fun `werewolf wins when werewolf side wins`() {
+        val p = player(Role.WEREWOLF)
+        assertTrue(oracle(p to Role.WEREWOLF).isWinner(p, Side.WEREWOLF))
+    }
+
+    @Test
+    fun `werewolf loses when citizen side wins`() {
+        val p = player(Role.WEREWOLF)
+        assertFalse(oracle(p to Role.WEREWOLF).isWinner(p, Side.CITIZEN))
+    }
+
+    @Test
+    fun `madman wins when werewolf side wins`() {
+        val p = player(Role.MADMAN)
+        assertTrue(oracle(p to Role.MADMAN).isWinner(p, Side.WEREWOLF))
+    }
+
+    @Test
+    fun `madman loses when citizen side wins`() {
+        val p = player(Role.MADMAN)
+        assertFalse(oracle(p to Role.MADMAN).isWinner(p, Side.CITIZEN))
+    }
+}


### PR DESCRIPTION
## Summary

狂人（MADMAN）役職を追加した。

- **#121**: `Role.MADMAN` 追加（市民陣営、占い/霊能結果は NOT_WEREWOLF、夜行動なし）。`CpuLodge` の村人1人を狂人に入れ替え
- **#122**: `Role.winningSide` プロパティと `Role.isWinner()` を追加。狂人は市民陣営だが人狼陣営勝利時に勝者となる
- **#123**: `MadmanCpuStrategy` の本実装。初期化時にランダムで偽占い師か偽霊能者かを選び、ゲームを通じてその役職を演じる。`RoleAwareCpuStrategy.discuss()` に `players` パラメータを追加

## Test plan

- [x] CI が通ること（`develop` へのPR作成時）
- [x] `OracleIsWinnerTest` で狂人の勝敗判定を網羅
- [x] `RoleAwareCPU` Lodge で実際に動作することを確認済み

Closes #120

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)