### PR TITLE
Configure JaCoCo and wire coverage report into SonarCloud workflow

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -25,6 +25,8 @@ jobs:
         run: |
           chmod +x gradlew
           ./gradlew detekt
+      - name: Run tests and generate coverage report
+        run: ./gradlew test
       - name: SonarCloud analysis
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     kotlin("jvm") version "2.1.20"
     id("io.gitlab.arturbosch.detekt") version "1.23.8"
     id("org.sonarqube") version "5.1.0.4882"
+    jacoco
 }
 
 group = "org.example"
@@ -17,6 +18,15 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
 }
 kotlin {
     jvmToolchain(17)
@@ -47,5 +57,6 @@ sonar {
         property("sonar.sources", "src/main/kotlin")
         property("sonar.tests", "src/test/kotlin")
         property("sonar.kotlin.detekt.reportPaths", "build/reports/detekt/detekt.xml")
+        property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml")
     }
 }


### PR DESCRIPTION
## Summary

- `build.gradle.kts` に `jacoco` プラグインを追加
- `./gradlew test` 実行後に XML・HTML カバレッジレポートを自動生成
- `sonar.coverage.jacoco.xmlReportPaths` を設定し SonarCloud にカバレッジを連携
- `sonarcloud.yml` でソナー解析前にテストを実行するステップを追加

## Test plan

- [x] `./gradlew test` で `build/reports/jacoco/test/jacocoTestReport.xml` と `html/` が生成されることを確認

Closes #144

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)