### PR TITLE
Add test to verify all Roles have a strategy in RoleAwareCpuPlayer

### DIFF
--- a/src/test/kotlin/RoleAwareCpuPlayerTest.kt
+++ b/src/test/kotlin/RoleAwareCpuPlayerTest.kt
@@ -110,6 +110,13 @@ class RoleAwareCpuPlayerTest {
     }
 
     @Test
+    fun `all roles have a strategy in RoleAwareCpuPlayer`() {
+        Role.entries.forEach { role ->
+            RoleAwareCpuPlayer(role, "test")
+        }
+    }
+
+    @Test
     fun `villager does not vote for player reported as not werewolf when other candidates exist`() {
         val seer = RoleAwareCpuPlayer(Role.SEER, "Seer")
         val villager = RoleAwareCpuPlayer(Role.VILLAGER, "Villager")


### PR DESCRIPTION
## Summary

- `RoleAwareCpuPlayer` の初期化時に全 `Role` に対応するストラテジーが存在することを検証するテストを追加した
- 対応するストラテジーが欠損している場合、`NoSuchElementException` が発生してテストが落ちることを確認済み

## Test plan

- [x] `all roles have a strategy in RoleAwareCpuPlayer` テストがパスすること
- [x] 一時的に未対応の Role を追加するとテストが落ちること

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)