### PR TITLE
Refactor AllPlayers constructor and remove Iterable, introduce TestLodge

### DIFF
--- a/src/main/kotlin/DayPhase.kt
+++ b/src/main/kotlin/DayPhase.kt
@@ -6,7 +6,7 @@ class DayPhase(
     private val nightNumber: Int
 ) : Phase {
     override fun proceed(): Phase {
-        OpenDiscussion(playerManager.players, playerManager.allPlayers).conduct()
+        OpenDiscussion(playerManager.players, AllPlayers(playerManager)).conduct()
         val votes = playerManager.players.map { it.selectTarget(SelectionContext.Vote(it, playerManager.players)) }
         val mostVoted = MajorityVoteResolver.resolveNonEmpty(votes)
         playerManager.execute(mostVoted)

--- a/src/main/kotlin/EndPhase.kt
+++ b/src/main/kotlin/EndPhase.kt
@@ -6,7 +6,7 @@ class EndPhase(
     private val signal: GameOverSignal
 ) : Phase {
     override fun proceed(): Phase {
-        GameEvent.GameOver.send(signal.winningSide, playerManager.allPlayers)
+        GameEvent.GameOver.send(signal.winningSide, AllPlayers(playerManager))
         playerManager.allPlayers.forEach { GameEvent.GameResult.send(oracle.isWinner(it, signal.winningSide), it) }
         showRecap()
         return this

--- a/src/main/kotlin/MorningPhase.kt
+++ b/src/main/kotlin/MorningPhase.kt
@@ -6,8 +6,8 @@ class MorningPhase(
     private val nightNumber: Int
 ) : Phase {
     override fun proceed(): Phase {
-        GameEvent.TimeChanged.send(TimeOfDay.Morning, playerManager.allPlayers)
-        GameEvent.MorningReport.send(playerManager.nightDeath, playerManager.allPlayers)
+        GameEvent.TimeChanged.send(TimeOfDay.Morning, AllPlayers(playerManager))
+        GameEvent.MorningReport.send(playerManager.nightDeath, AllPlayers(playerManager))
         playerManager.bury()
         return DayPhase(playerManager, oracle, nightNumber)
     }

--- a/src/main/kotlin/NightPhase.kt
+++ b/src/main/kotlin/NightPhase.kt
@@ -6,7 +6,7 @@ class NightPhase(
     private val nightNumber: Int
 ) : Phase {
     override fun proceed(): Phase {
-        GameEvent.TimeChanged.send(TimeOfDay.Night(nightNumber), playerManager.allPlayers)
+        GameEvent.TimeChanged.send(TimeOfDay.Night(nightNumber), AllPlayers(playerManager))
         Conclave(oracle, playerManager).conduct()
         val decisions = playerManager.players.map { it to it.buildNightAction(playerManager.players, nightNumber == 1) }
 

--- a/src/main/kotlin/Notifiable.kt
+++ b/src/main/kotlin/Notifiable.kt
@@ -5,7 +5,7 @@ interface Notifiable {
     fun receive(event: GameEvent)
 }
 
-class AllPlayers(playerManager: PlayerManager) : Notifiable, Iterable<Player> by playerManager.allPlayers {
+class AllPlayers(playerManager: PlayerManager) : Notifiable {
     private val players = playerManager.allPlayers
     override val recipientName = "全プレイヤー"
     override fun receive(event: GameEvent) = players.forEach { it.receive(event) }

--- a/src/main/kotlin/Notifiable.kt
+++ b/src/main/kotlin/Notifiable.kt
@@ -5,7 +5,8 @@ interface Notifiable {
     fun receive(event: GameEvent)
 }
 
-class AllPlayers(private val players: List<Player>) : Notifiable, Iterable<Player> by players {
+class AllPlayers(playerManager: PlayerManager) : Notifiable, Iterable<Player> by playerManager.allPlayers {
+    private val players = playerManager.allPlayers
     override val recipientName = "全プレイヤー"
     override fun receive(event: GameEvent) = players.forEach { it.receive(event) }
 }
@@ -13,5 +14,5 @@ class AllPlayers(private val players: List<Player>) : Notifiable, Iterable<Playe
 class Wolves(private val oracle: Oracle, private val playerManager: PlayerManager) : Notifiable {
     override val recipientName = "全人狼"
     override fun receive(event: GameEvent) =
-        oracle.werewolves(playerManager.allPlayers.toList()).forEach { it.receive(event) }
+        oracle.werewolves(playerManager.allPlayers).forEach { it.receive(event) }
 }

--- a/src/main/kotlin/PlayerManager.kt
+++ b/src/main/kotlin/PlayerManager.kt
@@ -7,7 +7,7 @@ class PlayerManager(players: List<Player>, private val oracle: Oracle) {
     private var _nightDeath: Player? = null
     val nightDeath: Player? get() = _nightDeath
     val players: List<Player> get() = _alivePlayers
-    val allPlayers get() = AllPlayers(_allPlayers)
+    val allPlayers: List<Player> get() = _allPlayers
 
     private fun checkWinner() {
         GameOverSignal.throwIfGameOver(oracle.aliveCounts(_alivePlayers))
@@ -23,12 +23,12 @@ class PlayerManager(players: List<Player>, private val oracle: Oracle) {
     }
 
     fun execute(mostVoted: Player) {
-        GameEvent.PlayerExecuted.send(mostVoted, allPlayers)
+        GameEvent.PlayerExecuted.send(mostVoted, AllPlayers(this))
         die(mostVoted)
     }
 
     fun kill(target: Player) {
-        GameEvent.PlayerAttacked.send(target, allPlayers)
+        GameEvent.PlayerAttacked.send(target, AllPlayers(this))
         _nightDeath = target
         die(target)
     }

--- a/src/test/kotlin/ConclaveTest.kt
+++ b/src/test/kotlin/ConclaveTest.kt
@@ -41,11 +41,9 @@ class ConclaveTest {
         val alpha = ScriptedPlayer(Role.WEREWOLF, "Alpha", listOf("r1a", "r2a", "r3a"))
         val beta = ScriptedPlayer(Role.WEREWOLF, "Beta", listOf("r1b", "r2b", "r3b"))
         val villager = NothingPlayer(Role.VILLAGER, "Villager")
-        val players = listOf(alpha, beta, villager)
-        val oracle = Oracle(mapOf(alpha to Role.WEREWOLF, beta to Role.WEREWOLF, villager to Role.VILLAGER))
-        val playerManager = PlayerManager(players, oracle)
+        val setup = TestLodge(alpha to Role.WEREWOLF, beta to Role.WEREWOLF, villager to Role.VILLAGER).create()
 
-        fixedOrderConclave(oracle, playerManager).conduct()
+        fixedOrderConclave(setup.oracle, setup.playerManager).conduct()
 
         // villager の discuss・onReceive が呼ばれた場合は NothingPlayer がエラーを投げる
     }
@@ -58,15 +56,13 @@ class ConclaveTest {
         val v1 = ReceivingPlayer(Role.VILLAGER, "V1")
         val v2 = ReceivingPlayer(Role.VILLAGER, "V2")
         val v3 = ReceivingPlayer(Role.VILLAGER, "V3")
-        val players = listOf(alpha, gamma, beta, v1, v2, v3)
-        val oracle = Oracle(mapOf(
+        val setup = TestLodge(
             alpha to Role.WEREWOLF, gamma to Role.WEREWOLF, beta to Role.WEREWOLF,
             v1 to Role.VILLAGER, v2 to Role.VILLAGER, v3 to Role.VILLAGER,
-        ))
-        val playerManager = PlayerManager(players, oracle)
-        playerManager.execute(beta)
+        ).create()
+        setup.playerManager.execute(beta)
 
-        fixedOrderConclave(oracle, playerManager).conduct()
+        fixedOrderConclave(setup.oracle, setup.playerManager).conduct()
 
         assertEquals(listOf(
             "Beta:heard:Alpha:r1a", "Beta:heard:Gamma:r1g",
@@ -78,11 +74,9 @@ class ConclaveTest {
     @Test
     fun `single werewolf does not speak`() {
         val alpha = ScriptedPlayer(Role.WEREWOLF, "Alpha", emptyList())
-        val wolves = listOf(alpha)
-        val oracle = Oracle(wolves.associateWith { Role.WEREWOLF })
-        val playerManager = PlayerManager(wolves, oracle)
+        val setup = TestLodge(alpha to Role.WEREWOLF).create()
 
-        fixedOrderConclave(oracle, playerManager).conduct()
+        fixedOrderConclave(setup.oracle, setup.playerManager).conduct()
 
         assertEquals(emptyList(), alpha.log)
     }
@@ -91,11 +85,9 @@ class ConclaveTest {
     fun `statements are delivered to all wolves in round order`() {
         val alpha = ScriptedPlayer(Role.WEREWOLF, "Alpha", listOf("r1a", "r2a", "r3a"))
         val beta = ScriptedPlayer(Role.WEREWOLF, "Beta", listOf("r1b", "r2b", "r3b"))
-        val wolves = listOf(alpha, beta)
-        val oracle = Oracle(wolves.associateWith { Role.WEREWOLF })
-        val playerManager = PlayerManager(wolves, oracle)
+        val setup = TestLodge(alpha to Role.WEREWOLF, beta to Role.WEREWOLF).create()
 
-        fixedOrderConclave(oracle, playerManager).conduct()
+        fixedOrderConclave(setup.oracle, setup.playerManager).conduct()
 
         assertEquals(listOf(
             "Alpha:said:r1a",

--- a/src/test/kotlin/DayPhaseTest.kt
+++ b/src/test/kotlin/DayPhaseTest.kt
@@ -1,0 +1,50 @@
+package org.example
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+
+class DayPhaseTest {
+
+    private class DayPlayer(
+        role: Role, name: String, private val voteTarget: Player? = null
+    ) : ReceivingPlayer(role, name) {
+        override fun discuss(players: List<Player>): Statement = Statement.Plain("")
+        override fun selectTarget(context: SelectionContext): Player =
+            voteTarget?.takeIf { it in context.candidates() } ?: context.candidates().first()
+    }
+
+    @Test
+    fun `most voted player is executed`() {
+        val victim = DayPlayer(Role.VILLAGER, "Victim")
+        val wolf = DayPlayer(Role.WEREWOLF, "Wolf", victim)
+        val v1 = DayPlayer(Role.VILLAGER, "V1", victim)
+        val v2 = DayPlayer(Role.VILLAGER, "V2", victim)
+        val v3 = DayPlayer(Role.VILLAGER, "V3", victim)
+        val setup = TestLodge(
+            wolf to Role.WEREWOLF,
+            victim to Role.VILLAGER, v1 to Role.VILLAGER, v2 to Role.VILLAGER, v3 to Role.VILLAGER,
+        ).create()
+
+        DayPhase(setup.playerManager, setup.oracle, 1).proceed()
+
+        assertFalse(setup.playerManager.players.contains(victim))
+    }
+
+    @Test
+    fun `returns NightPhase`() {
+        val victim = DayPlayer(Role.VILLAGER, "Victim")
+        val wolf = DayPlayer(Role.WEREWOLF, "Wolf", victim)
+        val v1 = DayPlayer(Role.VILLAGER, "V1", victim)
+        val v2 = DayPlayer(Role.VILLAGER, "V2", victim)
+        val v3 = DayPlayer(Role.VILLAGER, "V3", victim)
+        val setup = TestLodge(
+            wolf to Role.WEREWOLF,
+            victim to Role.VILLAGER, v1 to Role.VILLAGER, v2 to Role.VILLAGER, v3 to Role.VILLAGER,
+        ).create()
+
+        val next = DayPhase(setup.playerManager, setup.oracle, 1).proceed()
+
+        assertIs<NightPhase>(next)
+    }
+}

--- a/src/test/kotlin/DayPhaseTest.kt
+++ b/src/test/kotlin/DayPhaseTest.kt
@@ -3,15 +3,37 @@ package org.example
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 class DayPhaseTest {
 
     private class DayPlayer(
         role: Role, name: String, private val voteTarget: Player? = null
     ) : ReceivingPlayer(role, name) {
-        override fun discuss(players: List<Player>): Statement = Statement.Plain("")
+        var discussedCount = 0
+        override fun discuss(players: List<Player>): Statement {
+            discussedCount++
+            return Statement.Plain("")
+        }
         override fun selectTarget(context: SelectionContext): Player =
             voteTarget?.takeIf { it in context.candidates() } ?: context.candidates().first()
+    }
+
+    @Test
+    fun `each alive player discusses during daytime`() {
+        val victim = DayPlayer(Role.VILLAGER, "Victim")
+        val wolf = DayPlayer(Role.WEREWOLF, "Wolf", victim)
+        val v1 = DayPlayer(Role.VILLAGER, "V1", victim)
+        val v2 = DayPlayer(Role.VILLAGER, "V2", victim)
+        val v3 = DayPlayer(Role.VILLAGER, "V3", victim)
+        val setup = TestLodge(
+            wolf to Role.WEREWOLF,
+            victim to Role.VILLAGER, v1 to Role.VILLAGER, v2 to Role.VILLAGER, v3 to Role.VILLAGER,
+        ).create()
+
+        DayPhase(setup.playerManager, setup.oracle, 1).proceed()
+
+        assertTrue(wolf.discussedCount > 0)
     }
 
     @Test

--- a/src/test/kotlin/DiscussionTest.kt
+++ b/src/test/kotlin/DiscussionTest.kt
@@ -46,8 +46,9 @@ class DiscussionTest {
             "Aliceに投票します"
         ))
         val players = listOf(alice, bob)
+        val playerManager = TestLodge(alice to Role.VILLAGER, bob to Role.WEREWOLF).create().playerManager
 
-        fixedOrderDiscussion(players, AllPlayers(players)).conduct()
+        fixedOrderDiscussion(players, AllPlayers(playerManager)).conduct()
 
         assertEquals(listOf(
             "Alice:said:私はBobが怪しいと思う",
@@ -80,9 +81,9 @@ class DiscussionTest {
         val bob = ScriptedPlayer(Role.WEREWOLF, "Bob", listOf("人狼として発言します", "続けて発言します", "最終発言です"))
         val charlie = ScriptedPlayer(Role.VILLAGER, "Charlie", emptyList())
         val alivePlayers = listOf(alice, bob)
-        val allPlayers = listOf(alice, bob, charlie)
+        val playerManager = TestLodge(alice to Role.VILLAGER, bob to Role.WEREWOLF, charlie to Role.VILLAGER).create().playerManager
 
-        fixedOrderDiscussion(alivePlayers, AllPlayers(allPlayers)).conduct()
+        fixedOrderDiscussion(alivePlayers, AllPlayers(playerManager)).conduct()
 
         assertEquals(listOf(
             "Charlie:heard:Alice:村人として発言します",

--- a/src/test/kotlin/EndPhaseTest.kt
+++ b/src/test/kotlin/EndPhaseTest.kt
@@ -1,0 +1,66 @@
+package org.example
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class EndPhaseTest {
+
+    private class WatchingPlayer(role: Role, name: String) : ReceivingPlayer(role, name) {
+        var gameOver: GameEvent.GameOver? = null
+        var gameResult: GameEvent.GameResult? = null
+        var epilogueEvents: List<GameEvent>? = null
+
+        override fun onReceive(event: GameEvent) {
+            when (event) {
+                is GameEvent.GameOver -> gameOver = event
+                is GameEvent.GameResult -> gameResult = event
+                else -> {}
+            }
+        }
+
+        override fun watchEpilogue(events: List<GameEvent>) {
+            epilogueEvents = events
+        }
+    }
+
+    private fun fakeCitizenWinSignal(): GameOverSignal = try {
+        GameOverSignal.throwIfGameOver(AliveCounts(mapOf(Side.CITIZEN to 2, Side.WEREWOLF to 0)))
+        error("unreachable")
+    } catch (s: GameOverSignal) { s }
+
+    @Test
+    fun `GameOver is broadcast with winning side`() {
+        val villager = WatchingPlayer(Role.VILLAGER, "Villager")
+        val setup = TestLodge(villager to Role.VILLAGER).create()
+
+        EndPhase(setup.playerManager, setup.oracle, fakeCitizenWinSignal()).proceed()
+
+        assertEquals(Side.CITIZEN, villager.gameOver?.winnerSide)
+    }
+
+    @Test
+    fun `winner and loser receive correct GameResult`() {
+        val wolf = WatchingPlayer(Role.WEREWOLF, "Wolf")
+        val villager = WatchingPlayer(Role.VILLAGER, "Villager")
+        val setup = TestLodge(wolf to Role.WEREWOLF, villager to Role.VILLAGER).create()
+
+        EndPhase(setup.playerManager, setup.oracle, fakeCitizenWinSignal()).proceed()
+
+        assertEquals(false, wolf.gameResult?.isWinner)
+        assertEquals(true, villager.gameResult?.isWinner)
+    }
+
+    @Test
+    fun `watchEpilogue is called for all players`() {
+        val wolf = WatchingPlayer(Role.WEREWOLF, "Wolf")
+        val villager = WatchingPlayer(Role.VILLAGER, "Villager")
+        val setup = TestLodge(wolf to Role.WEREWOLF, villager to Role.VILLAGER).create()
+
+        EndPhase(setup.playerManager, setup.oracle, fakeCitizenWinSignal()).proceed()
+
+        assertNotNull(wolf.epilogueEvents)
+        assertNotNull(villager.epilogueEvents)
+    }
+}
+

--- a/src/test/kotlin/GameEventRoleAssignedTest.kt
+++ b/src/test/kotlin/GameEventRoleAssignedTest.kt
@@ -14,9 +14,8 @@ class GameEventRoleAssignedTest {
     fun `InitialPhase notifies each player of their assigned role`() {
         val villager = RecordingPlayer(Role.VILLAGER, "Alice")
         val werewolf = RecordingPlayer(Role.WEREWOLF, "Bob")
-        val players = listOf(villager, werewolf)
-        val oracle = Oracle(mapOf(villager to Role.VILLAGER, werewolf to Role.WEREWOLF))
-        InitialPhase(PlayerManager(players, oracle), oracle).proceed()
+        val setup = TestLodge(villager to Role.VILLAGER, werewolf to Role.WEREWOLF).create()
+        InitialPhase(setup.playerManager, setup.oracle).proceed()
 
         val villagerEvent = villager.received.single() as GameEvent.RoleAssigned
         assertEquals(Role.VILLAGER, villagerEvent.role)

--- a/src/test/kotlin/GameRecapTest.kt
+++ b/src/test/kotlin/GameRecapTest.kt
@@ -6,10 +6,8 @@ import kotlin.test.assertTrue
 
 class GameRecapTest {
 
-    private fun playerManager(vararg players: Player): PlayerManager {
-        val oracle = Oracle(players.associateWith { Role.VILLAGER })
-        return PlayerManager(players.toList(), oracle)
-    }
+    private fun playerManager(vararg players: Player): PlayerManager =
+        TestLodge(*players.map { it to Role.VILLAGER }.toTypedArray()).create().playerManager
 
     private fun anySignal(): GameOverSignal {
         return try {

--- a/src/test/kotlin/GameRecapTest.kt
+++ b/src/test/kotlin/GameRecapTest.kt
@@ -24,7 +24,7 @@ class GameRecapTest {
         val playerB = ReceivingPlayer(Role.VILLAGER, "B")
         val pm = playerManager(playerA, playerB)
 
-        GameEvent.TimeChanged.send(TimeOfDay.Night(1), pm.allPlayers)
+        GameEvent.TimeChanged.send(TimeOfDay.Night(1), AllPlayers(pm))
 
         val events = GameRecap(pm, anySignal()).events()
         assertEquals(1, events.size)
@@ -55,7 +55,7 @@ class GameRecapTest {
         // sortedBy後: [RoleAssigned(A), RoleAssigned(B), TimeChanged] ← 正しい順
         GameEvent.RoleAssigned.send(Role.VILLAGER, playerA)
         GameEvent.RoleAssigned.send(Role.VILLAGER, playerB)
-        GameEvent.TimeChanged.send(TimeOfDay.Night(1), pm.allPlayers)
+        GameEvent.TimeChanged.send(TimeOfDay.Night(1), AllPlayers(pm))
 
         val events = GameRecap(pm, anySignal()).events()
         assertEquals(3, events.size)

--- a/src/test/kotlin/LodgeTest.kt
+++ b/src/test/kotlin/LodgeTest.kt
@@ -12,7 +12,7 @@ class LodgeTest {
         val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
         val setup = TestLodge(villager to Role.VILLAGER, wolf to Role.WEREWOLF).create()
 
-        val players = setup.playerManager.allPlayers.toList()
+        val players = setup.playerManager.allPlayers
         assertSame(villager, players[0])
         assertSame(wolf, players[1])
         assertEquals(listOf(wolf), setup.oracle.werewolves(players))

--- a/src/test/kotlin/MadmanCpuStrategyTest.kt
+++ b/src/test/kotlin/MadmanCpuStrategyTest.kt
@@ -11,7 +11,9 @@ class MadmanCpuStrategyTest {
     private val madman = RoleAwareCpuPlayer(Role.MADMAN, "狂人")
     private val player1 = ReceivingPlayer(Role.VILLAGER, "村人1")
     private val player2 = ReceivingPlayer(Role.VILLAGER, "村人2")
-    private val allPlayers = AllPlayers(listOf(madman, player1, player2))
+    private val allPlayers = AllPlayers(
+        TestLodge(madman to Role.MADMAN, player1 to Role.VILLAGER, player2 to Role.VILLAGER).create().playerManager
+    )
 
     @Test
     fun `fake seer reports an alive player as werewolf`() {

--- a/src/test/kotlin/MorningPhaseTest.kt
+++ b/src/test/kotlin/MorningPhaseTest.kt
@@ -53,19 +53,20 @@ class MorningPhaseTest {
     }
 
     @Test
-    fun `nightDeath is cleared after proceed`() {
+    fun `nightDeath is cleared by bury as seen in consecutive MorningReports`() {
+        val observer = RecordingPlayer(Role.VILLAGER, "Observer")
         val villager1 = ReceivingPlayer(Role.VILLAGER, "V1")
         val villager2 = ReceivingPlayer(Role.VILLAGER, "V2")
-        val villager3 = ReceivingPlayer(Role.VILLAGER, "V3")
         val setup = TestLodge(
             ReceivingPlayer(Role.WEREWOLF, "Wolf") to Role.WEREWOLF,
-            villager1 to Role.VILLAGER, villager2 to Role.VILLAGER, villager3 to Role.VILLAGER,
+            observer to Role.VILLAGER, villager1 to Role.VILLAGER, villager2 to Role.VILLAGER,
         ).create()
         setup.playerManager.kill(villager1)
 
         MorningPhase(setup.playerManager, setup.oracle, 1).proceed()
+        MorningPhase(setup.playerManager, setup.oracle, 2).proceed()
 
-        assertNull(setup.playerManager.nightDeath)
+        assertEquals(villager1, observer.morningReports[0].victim)
+        assertNull(observer.morningReports[1].victim)
     }
 }
-

--- a/src/test/kotlin/MorningPhaseTest.kt
+++ b/src/test/kotlin/MorningPhaseTest.kt
@@ -1,0 +1,71 @@
+package org.example
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+class MorningPhaseTest {
+
+    private class RecordingPlayer(role: Role, name: String) : ReceivingPlayer(role, name) {
+        val morningReports = mutableListOf<GameEvent.MorningReport>()
+        override fun onReceive(event: GameEvent) {
+            if (event is GameEvent.MorningReport) morningReports.add(event)
+        }
+    }
+
+    @Test
+    fun `returns DayPhase`() {
+        val setup = TestLodge(
+            ReceivingPlayer(Role.WEREWOLF, "Wolf") to Role.WEREWOLF,
+            ReceivingPlayer(Role.VILLAGER, "Villager") to Role.VILLAGER,
+        ).create()
+
+        val next = MorningPhase(setup.playerManager, setup.oracle, 1).proceed()
+
+        assertIs<DayPhase>(next)
+    }
+
+    @Test
+    fun `MorningReport victim is null when no kill occurred`() {
+        val observer = RecordingPlayer(Role.VILLAGER, "Observer")
+        val setup = TestLodge(observer to Role.VILLAGER).create()
+
+        MorningPhase(setup.playerManager, setup.oracle, 1).proceed()
+
+        assertNull(observer.morningReports.single().victim)
+    }
+
+    @Test
+    fun `MorningReport victim is the killed player`() {
+        val observer = RecordingPlayer(Role.VILLAGER, "Observer")
+        val villager1 = ReceivingPlayer(Role.VILLAGER, "V1")
+        val villager2 = ReceivingPlayer(Role.VILLAGER, "V2")
+        val setup = TestLodge(
+            ReceivingPlayer(Role.WEREWOLF, "Wolf") to Role.WEREWOLF,
+            observer to Role.VILLAGER, villager1 to Role.VILLAGER, villager2 to Role.VILLAGER,
+        ).create()
+        setup.playerManager.kill(villager1)
+
+        MorningPhase(setup.playerManager, setup.oracle, 1).proceed()
+
+        assertEquals(villager1, observer.morningReports.single().victim)
+    }
+
+    @Test
+    fun `nightDeath is cleared after proceed`() {
+        val villager1 = ReceivingPlayer(Role.VILLAGER, "V1")
+        val villager2 = ReceivingPlayer(Role.VILLAGER, "V2")
+        val villager3 = ReceivingPlayer(Role.VILLAGER, "V3")
+        val setup = TestLodge(
+            ReceivingPlayer(Role.WEREWOLF, "Wolf") to Role.WEREWOLF,
+            villager1 to Role.VILLAGER, villager2 to Role.VILLAGER, villager3 to Role.VILLAGER,
+        ).create()
+        setup.playerManager.kill(villager1)
+
+        MorningPhase(setup.playerManager, setup.oracle, 1).proceed()
+
+        assertNull(setup.playerManager.nightDeath)
+    }
+}
+

--- a/src/test/kotlin/NightPhaseTest.kt
+++ b/src/test/kotlin/NightPhaseTest.kt
@@ -11,10 +11,23 @@ class NightPhaseTest {
 
     private class FixedTargetPlayer(
         role: Role, name: String, private val target: Player
-    ) : ReceivingPlayer(role, name) {
+    ) : RecordingPlayer(role, name) {
         override fun selectTarget(context: SelectionContext): Player {
             require(target in context.candidates()) { "fixed target '${target.name}' is not in candidates" }
             return target
+        }
+    }
+
+    private open class RecordingPlayer(role: Role, name: String) : ReceivingPlayer(role, name) {
+        val received = mutableListOf<GameEvent>()
+        override fun onReceive(event: GameEvent) { received.add(event) }
+    }
+
+    private class ConclavingWolf(name: String) : ReceivingPlayer(Role.WEREWOLF, name) {
+        val heardStatements = mutableListOf<GameEvent.WerewolfStatementMade>()
+        override fun discuss(players: List<Player>): Statement = Statement.Plain("")
+        override fun onReceive(event: GameEvent) {
+            if (event is GameEvent.WerewolfStatementMade) heardStatements.add(event)
         }
     }
 
@@ -65,4 +78,60 @@ class NightPhaseTest {
 
         assertNull(setup.playerManager.nightDeath)
     }
+
+    @Test
+    fun `wolves conduct conclave when multiple wolves are present`() {
+        val wolf1 = ConclavingWolf("Wolf1")
+        val wolf2 = ConclavingWolf("Wolf2")
+        val villager1 = ReceivingPlayer(Role.VILLAGER, "V1")
+        val villager2 = ReceivingPlayer(Role.VILLAGER, "V2")
+        val setup = TestLodge(
+            wolf1 to Role.WEREWOLF, wolf2 to Role.WEREWOLF,
+            villager1 to Role.VILLAGER, villager2 to Role.VILLAGER,
+        ).create()
+
+        NightPhase(setup.playerManager, setup.oracle, 1).proceed()
+
+        assertTrue(wolf1.heardStatements.isNotEmpty())
+    }
+
+    @Test
+    fun `seer receives divination result for chosen player`() {
+        val villager1 = ReceivingPlayer(Role.VILLAGER, "V1")
+        val villager2 = ReceivingPlayer(Role.VILLAGER, "V2")
+        val villager3 = ReceivingPlayer(Role.VILLAGER, "V3")
+        val wolf = FixedTargetPlayer(Role.WEREWOLF, "Wolf", villager1)
+        val seer = FixedTargetPlayer(Role.SEER, "Seer", villager1)
+        val setup = TestLodge(
+            wolf to Role.WEREWOLF, seer to Role.SEER,
+            villager1 to Role.VILLAGER, villager2 to Role.VILLAGER, villager3 to Role.VILLAGER,
+        ).create()
+
+        NightPhase(setup.playerManager, setup.oracle, 2).proceed()
+
+        val divined = seer.received.filterIsInstance<GameEvent.Divined>()
+        assertEquals(1, divined.size)
+        assertEquals(villager1, divined.single().target)
+    }
+
+    @Test
+    fun `medium receives medium result for executed player`() {
+        val villager1 = ReceivingPlayer(Role.VILLAGER, "V1")
+        val villager2 = ReceivingPlayer(Role.VILLAGER, "V2")
+        val villager3 = ReceivingPlayer(Role.VILLAGER, "V3")
+        val wolf = FixedTargetPlayer(Role.WEREWOLF, "Wolf", villager2)
+        val medium = RecordingPlayer(Role.MEDIUM, "Medium")
+        val setup = TestLodge(
+            wolf to Role.WEREWOLF, medium to Role.MEDIUM,
+            villager1 to Role.VILLAGER, villager2 to Role.VILLAGER, villager3 to Role.VILLAGER,
+        ).create()
+        setup.playerManager.execute(villager1)
+
+        NightPhase(setup.playerManager, setup.oracle, 2).proceed()
+
+        val revealed = medium.received.filterIsInstance<GameEvent.MediumRevealed>()
+        assertEquals(1, revealed.size)
+        assertEquals(villager1, revealed.single().target)
+    }
 }
+

--- a/src/test/kotlin/NightPhaseTest.kt
+++ b/src/test/kotlin/NightPhaseTest.kt
@@ -1,0 +1,68 @@
+package org.example
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class NightPhaseTest {
+
+    private class FixedTargetPlayer(
+        role: Role, name: String, private val target: Player
+    ) : ReceivingPlayer(role, name) {
+        override fun selectTarget(context: SelectionContext): Player {
+            require(target in context.candidates()) { "fixed target '${target.name}' is not in candidates" }
+            return target
+        }
+    }
+
+    @Test
+    fun `wolf attack kills target and sets nightDeath`() {
+        val villager1 = ReceivingPlayer(Role.VILLAGER, "V1")
+        val villager2 = ReceivingPlayer(Role.VILLAGER, "V2")
+        val villager3 = ReceivingPlayer(Role.VILLAGER, "V3")
+        val wolf = FixedTargetPlayer(Role.WEREWOLF, "Wolf", villager1)
+        val setup = TestLodge(
+            wolf to Role.WEREWOLF,
+            villager1 to Role.VILLAGER, villager2 to Role.VILLAGER, villager3 to Role.VILLAGER,
+        ).create()
+
+        val next = NightPhase(setup.playerManager, setup.oracle, 2).proceed()
+
+        assertIs<MorningPhase>(next)
+        assertEquals(villager1, setup.playerManager.nightDeath)
+        assertFalse(setup.playerManager.players.contains(villager1))
+        assertTrue(setup.playerManager.allPlayers.contains(villager1))
+    }
+
+    @Test
+    fun `guard prevents wolf attack`() {
+        val villager = ReceivingPlayer(Role.VILLAGER, "Villager")
+        val extra = ReceivingPlayer(Role.VILLAGER, "Extra")
+        val wolf = FixedTargetPlayer(Role.WEREWOLF, "Wolf", villager)
+        val hunter = FixedTargetPlayer(Role.HUNTER, "Hunter", villager)
+        val setup = TestLodge(
+            wolf to Role.WEREWOLF, hunter to Role.HUNTER,
+            villager to Role.VILLAGER, extra to Role.VILLAGER,
+        ).create()
+
+        NightPhase(setup.playerManager, setup.oracle, 2).proceed()
+
+        assertNull(setup.playerManager.nightDeath)
+        assertTrue(setup.playerManager.players.contains(villager))
+    }
+
+    @Test
+    fun `wolf does not attack on first night`() {
+        val wolf = ReceivingPlayer(Role.WEREWOLF, "Wolf")
+        val villager1 = ReceivingPlayer(Role.VILLAGER, "V1")
+        val villager2 = ReceivingPlayer(Role.VILLAGER, "V2")
+        val setup = TestLodge(wolf to Role.WEREWOLF, villager1 to Role.VILLAGER, villager2 to Role.VILLAGER).create()
+
+        NightPhase(setup.playerManager, setup.oracle, 1).proceed()
+
+        assertNull(setup.playerManager.nightDeath)
+    }
+}

--- a/src/test/kotlin/NothingPlayer.kt
+++ b/src/test/kotlin/NothingPlayer.kt
@@ -4,5 +4,5 @@ open class NothingPlayer(role: Role, override val name: String) : Player(role) {
     override fun discuss(players: List<Player>): Statement = error("discuss not expected")
     override fun onReceive(event: GameEvent) { error("onReceive not expected") }
     override fun selectTarget(context: SelectionContext): Player = error("selectTarget not expected")
-    override fun watchEpilogue(events: List<GameEvent>) = error("watchEpilogue not expected")
+    override fun watchEpilogue(events: List<GameEvent>) { error("watchEpilogue not expected") }
 }

--- a/src/test/kotlin/RoleAwareCpuPlayerTest.kt
+++ b/src/test/kotlin/RoleAwareCpuPlayerTest.kt
@@ -11,8 +11,8 @@ class RoleAwareCpuPlayerTest {
     fun `seer reports divination result as DivinationReport`() {
         val seer = RoleAwareCpuPlayer(Role.SEER, "Seer")
         val villager = NothingPlayer(Role.VILLAGER, "Villager")
-        val oracle = Oracle(mapOf(seer to Role.SEER, villager to Role.VILLAGER))
-        oracle.divine(seer, villager)
+        val setup = TestLodge(seer to Role.SEER, villager to Role.VILLAGER).create()
+        setup.oracle.divine(seer, villager)
 
         val statement = seer.discuss(emptyList())
 
@@ -27,8 +27,8 @@ class RoleAwareCpuPlayerTest {
         val seer = RoleAwareCpuPlayer(Role.SEER, "Seer")
         val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
         val villager = NothingPlayer(Role.VILLAGER, "Villager")
-        val oracle = Oracle(mapOf(seer to Role.SEER, wolf to Role.WEREWOLF, villager to Role.VILLAGER))
-        oracle.divine(seer, villager)
+        val setup = TestLodge(seer to Role.SEER, wolf to Role.WEREWOLF, villager to Role.VILLAGER).create()
+        setup.oracle.divine(seer, villager)
 
         repeat(100) {
             val voted = seer.selectTarget(SelectionContext.Vote(seer, listOf(seer, wolf, villager)))
@@ -56,8 +56,8 @@ class RoleAwareCpuPlayerTest {
     fun `medium reports medium result as MediumReport`() {
         val medium = RoleAwareCpuPlayer(Role.MEDIUM, "Medium")
         val villager = NothingPlayer(Role.VILLAGER, "Villager")
-        val oracle = Oracle(mapOf(medium to Role.MEDIUM, villager to Role.VILLAGER))
-        oracle.mediumReveal(medium, villager)
+        val setup = TestLodge(medium to Role.MEDIUM, villager to Role.VILLAGER).create()
+        setup.oracle.mediumReveal(medium, villager)
 
         val statement = medium.discuss(emptyList())
 

--- a/src/test/kotlin/RoleAwareCpuPlayerTest.kt
+++ b/src/test/kotlin/RoleAwareCpuPlayerTest.kt
@@ -41,9 +41,9 @@ class RoleAwareCpuPlayerTest {
         val seer = RoleAwareCpuPlayer(Role.SEER, "Seer")
         val villager = RoleAwareCpuPlayer(Role.VILLAGER, "Villager")
         val wolf = ReceivingPlayer(Role.WEREWOLF, "Wolf")
-        val oracle = Oracle(mapOf(seer to Role.SEER, villager to Role.VILLAGER, wolf to Role.WEREWOLF))
-        val allPlayers = AllPlayers(listOf(seer, villager, wolf))
-        oracle.divine(seer, wolf)
+        val setup = TestLodge(seer to Role.SEER, villager to Role.VILLAGER, wolf to Role.WEREWOLF).create()
+        val allPlayers = AllPlayers(setup.playerManager)
+        setup.oracle.divine(seer, wolf)
         GameEvent.StatementMade.send(1, seer.name, seer.discuss(emptyList()), allPlayers)
 
         repeat(100) {
@@ -72,7 +72,7 @@ class RoleAwareCpuPlayerTest {
         val wolf = RoleAwareCpuPlayer(Role.WEREWOLF, "Wolf")
         val seer = ReceivingPlayer(Role.SEER, "Seer")
         val villager = ReceivingPlayer(Role.VILLAGER, "Villager")
-        val allPlayers = AllPlayers(listOf(wolf, seer, villager))
+        val allPlayers = AllPlayers(TestLodge(wolf to Role.WEREWOLF, seer to Role.SEER, villager to Role.VILLAGER).create().playerManager)
         GameEvent.StatementMade.send(1, seer.name, Statement.DivinationReport(seer, villager, DivineResult.NOT_WEREWOLF), allPlayers)
 
         repeat(100) {
@@ -86,7 +86,7 @@ class RoleAwareCpuPlayerTest {
         val hunter = RoleAwareCpuPlayer(Role.HUNTER, "Hunter")
         val seer = ReceivingPlayer(Role.SEER, "Seer")
         val villager = ReceivingPlayer(Role.VILLAGER, "Villager")
-        val allPlayers = AllPlayers(listOf(hunter, seer, villager))
+        val allPlayers = AllPlayers(TestLodge(hunter to Role.HUNTER, seer to Role.SEER, villager to Role.VILLAGER).create().playerManager)
         GameEvent.StatementMade.send(1, seer.name, Statement.DivinationReport(seer, villager, DivineResult.NOT_WEREWOLF), allPlayers)
 
         repeat(100) {
@@ -100,7 +100,7 @@ class RoleAwareCpuPlayerTest {
         val wolf = RoleAwareCpuPlayer(Role.WEREWOLF, "Wolf")
         val seer = ReceivingPlayer(Role.SEER, "Seer")
         val villager = ReceivingPlayer(Role.VILLAGER, "Villager")
-        val allPlayers = AllPlayers(listOf(wolf, seer, villager))
+        val allPlayers = AllPlayers(TestLodge(wolf to Role.WEREWOLF, seer to Role.SEER, villager to Role.VILLAGER).create().playerManager)
         GameEvent.StatementMade.send(1, seer.name, Statement.DivinationReport(seer, villager, DivineResult.NOT_WEREWOLF), allPlayers)
 
         repeat(100) {
@@ -122,9 +122,9 @@ class RoleAwareCpuPlayerTest {
         val villager = RoleAwareCpuPlayer(Role.VILLAGER, "Villager")
         val innocent = ReceivingPlayer(Role.VILLAGER, "Innocent")
         val wolf = ReceivingPlayer(Role.WEREWOLF, "Wolf")
-        val oracle = Oracle(mapOf(seer to Role.SEER, villager to Role.VILLAGER, innocent to Role.VILLAGER, wolf to Role.WEREWOLF))
-        val allPlayers = AllPlayers(listOf(seer, villager, innocent, wolf))
-        oracle.divine(seer, innocent)
+        val setup = TestLodge(seer to Role.SEER, villager to Role.VILLAGER, innocent to Role.VILLAGER, wolf to Role.WEREWOLF).create()
+        val allPlayers = AllPlayers(setup.playerManager)
+        setup.oracle.divine(seer, innocent)
         GameEvent.StatementMade.send(1, seer.name, seer.discuss(emptyList()), allPlayers)
 
         repeat(100) {

--- a/src/test/kotlin/RoleMediumNightActionTest.kt
+++ b/src/test/kotlin/RoleMediumNightActionTest.kt
@@ -27,7 +27,8 @@ class RoleMediumNightActionTest {
     fun `reveals executed player when not yet revealed`() {
         val medium = ReceivingPlayer(Role.MEDIUM, "Medium")
         val villager = ReceivingPlayer(Role.VILLAGER, "Villager")
-        GameEvent.PlayerExecuted.send(villager, AllPlayers(listOf(medium, villager)))
+        val allPlayers = AllPlayers(TestLodge(medium to Role.MEDIUM, villager to Role.VILLAGER).create().playerManager)
+        GameEvent.PlayerExecuted.send(villager, allPlayers)
 
         val action = medium.buildNightAction(listOf(medium), isFirstNight = false)
 
@@ -38,7 +39,8 @@ class RoleMediumNightActionTest {
     fun `returns None when executed player is already revealed`() {
         val medium = ReceivingPlayer(Role.MEDIUM, "Medium")
         val villager = ReceivingPlayer(Role.VILLAGER, "Villager")
-        GameEvent.PlayerExecuted.send(villager, AllPlayers(listOf(medium, villager)))
+        val allPlayers = AllPlayers(TestLodge(medium to Role.MEDIUM, villager to Role.VILLAGER).create().playerManager)
+        GameEvent.PlayerExecuted.send(villager, allPlayers)
         GameEvent.MediumRevealed.send(villager, MediumResult.NOT_WEREWOLF, medium)
 
         val action = medium.buildNightAction(listOf(medium), isFirstNight = false)
@@ -51,7 +53,7 @@ class RoleMediumNightActionTest {
         val medium = ReceivingPlayer(Role.MEDIUM, "Medium")
         val villager1 = ReceivingPlayer(Role.VILLAGER, "V1")
         val villager2 = ReceivingPlayer(Role.VILLAGER, "V2")
-        val allPlayers = AllPlayers(listOf(medium, villager1, villager2))
+        val allPlayers = AllPlayers(TestLodge(medium to Role.MEDIUM, villager1 to Role.VILLAGER, villager2 to Role.VILLAGER).create().playerManager)
         GameEvent.PlayerExecuted.send(villager1, allPlayers)
         GameEvent.PlayerExecuted.send(villager2, allPlayers)
 
@@ -65,7 +67,7 @@ class RoleMediumNightActionTest {
         val medium = ReceivingPlayer(Role.MEDIUM, "Medium")
         val villager1 = ReceivingPlayer(Role.VILLAGER, "V1")
         val villager2 = ReceivingPlayer(Role.VILLAGER, "V2")
-        val allPlayers = AllPlayers(listOf(medium, villager1, villager2))
+        val allPlayers = AllPlayers(TestLodge(medium to Role.MEDIUM, villager1 to Role.VILLAGER, villager2 to Role.VILLAGER).create().playerManager)
         GameEvent.PlayerExecuted.send(villager1, allPlayers)
         GameEvent.MediumRevealed.send(villager1, MediumResult.NOT_WEREWOLF, medium)
         GameEvent.PlayerExecuted.send(villager2, allPlayers)


### PR DESCRIPTION
## 概要

- `AllPlayers` のコンストラクタを `PlayerManager` 受け取りに変更し、`List<Player>` による誤構築を防止
- `AllPlayers` から `Iterable<Player>` を除去し、通知ルーティングの責務に限定
- `TestLodge` を導入し、テストで `Oracle` + `PlayerManager` を手動構築している箇所を一掃

## 変更内容

- `Notifiable.kt`: `AllPlayers(playerManager: PlayerManager)` に変更、`Iterable<Player>` を除去
- `ConclaveTest.kt` / `GameEventRoleAssignedTest.kt` / `GameRecapTest.kt` / `RoleAwareCpuPlayerTest.kt`: `Oracle` 直接生成を `TestLodge` 経由に置き換え

Closes #89
Closes #90
Closes #149

🤖 Claude: