### PR TITLE
Standardize test player naming and document policy in TESTING.md

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -56,6 +56,13 @@ src/test/kotlin/
 
 パッケージは `org.example`（mainと同じ）を使用する。
 
+## テストプレイヤーの命名
+
+- name・変数名ともに英語表記とする
+- role名（enum名と一致しない略称も可: Wolf など）をデフォルトとする
+- 同じroleが複数いる場合はrole名（または頭文字）＋連番: V1, V2, Wolf1, Wolf2
+- テスト固有の事情でroleより適切な名前がある場合はこの限りでない（例: 処刑対象を Victim と名付ける、議論ログを読みやすくするために人名を使うなど）
+
 ## テストフレームワーク
 
 `kotlin("test")`（JUnit Platform経由）を使用する。`build.gradle.kts` に設定済み。

--- a/src/test/kotlin/ConclaveTest.kt
+++ b/src/test/kotlin/ConclaveTest.kt
@@ -38,10 +38,10 @@ class ConclaveTest {
 
     @Test
     fun `non-werewolf neither speaks nor listens`() {
-        val alpha = ScriptedPlayer(Role.WEREWOLF, "Alpha", listOf("r1a", "r2a", "r3a"))
-        val beta = ScriptedPlayer(Role.WEREWOLF, "Beta", listOf("r1b", "r2b", "r3b"))
+        val wolf1 = ScriptedPlayer(Role.WEREWOLF, "Wolf1", listOf("r1a", "r2a", "r3a"))
+        val wolf2 = ScriptedPlayer(Role.WEREWOLF, "Wolf2", listOf("r1b", "r2b", "r3b"))
         val villager = NothingPlayer(Role.VILLAGER, "Villager")
-        val setup = TestLodge(alpha to Role.WEREWOLF, beta to Role.WEREWOLF, villager to Role.VILLAGER).create()
+        val setup = TestLodge(wolf1 to Role.WEREWOLF, wolf2 to Role.WEREWOLF, villager to Role.VILLAGER).create()
 
         fixedOrderConclave(setup.oracle, setup.playerManager).conduct()
 
@@ -50,67 +50,67 @@ class ConclaveTest {
 
     @Test
     fun `dead werewolf listens but does not speak`() {
-        val alpha = ScriptedPlayer(Role.WEREWOLF, "Alpha", listOf("r1a", "r2a", "r3a"), receivesExecutionEvent = true)
-        val gamma = ScriptedPlayer(Role.WEREWOLF, "Gamma", listOf("r1g", "r2g", "r3g"), receivesExecutionEvent = true)
-        val beta = ScriptedPlayer(Role.WEREWOLF, "Beta", emptyList(), receivesExecutionEvent = true)
+        val wolf1 = ScriptedPlayer(Role.WEREWOLF, "Wolf1", listOf("r1a", "r2a", "r3a"), receivesExecutionEvent = true)
+        val wolf2 = ScriptedPlayer(Role.WEREWOLF, "Wolf2", listOf("r1g", "r2g", "r3g"), receivesExecutionEvent = true)
+        val wolf3 = ScriptedPlayer(Role.WEREWOLF, "Wolf3", emptyList(), receivesExecutionEvent = true)
         val v1 = ReceivingPlayer(Role.VILLAGER, "V1")
         val v2 = ReceivingPlayer(Role.VILLAGER, "V2")
         val v3 = ReceivingPlayer(Role.VILLAGER, "V3")
         val setup = TestLodge(
-            alpha to Role.WEREWOLF, gamma to Role.WEREWOLF, beta to Role.WEREWOLF,
+            wolf1 to Role.WEREWOLF, wolf2 to Role.WEREWOLF, wolf3 to Role.WEREWOLF,
             v1 to Role.VILLAGER, v2 to Role.VILLAGER, v3 to Role.VILLAGER,
         ).create()
-        setup.playerManager.execute(beta)
+        setup.playerManager.execute(wolf3)
 
         fixedOrderConclave(setup.oracle, setup.playerManager).conduct()
 
         assertEquals(listOf(
-            "Beta:heard:Alpha:r1a", "Beta:heard:Gamma:r1g",
-            "Beta:heard:Alpha:r2a", "Beta:heard:Gamma:r2g",
-            "Beta:heard:Alpha:r3a", "Beta:heard:Gamma:r3g",
-        ), beta.log)
+            "Wolf3:heard:Wolf1:r1a", "Wolf3:heard:Wolf2:r1g",
+            "Wolf3:heard:Wolf1:r2a", "Wolf3:heard:Wolf2:r2g",
+            "Wolf3:heard:Wolf1:r3a", "Wolf3:heard:Wolf2:r3g",
+        ), wolf3.log)
     }
 
     @Test
     fun `single werewolf does not speak`() {
-        val alpha = ScriptedPlayer(Role.WEREWOLF, "Alpha", emptyList())
-        val setup = TestLodge(alpha to Role.WEREWOLF).create()
+        val wolf1 = ScriptedPlayer(Role.WEREWOLF, "Wolf1", emptyList())
+        val setup = TestLodge(wolf1 to Role.WEREWOLF).create()
 
         fixedOrderConclave(setup.oracle, setup.playerManager).conduct()
 
-        assertEquals(emptyList(), alpha.log)
+        assertEquals(emptyList(), wolf1.log)
     }
 
     @Test
     fun `statements are delivered to all wolves in round order`() {
-        val alpha = ScriptedPlayer(Role.WEREWOLF, "Alpha", listOf("r1a", "r2a", "r3a"))
-        val beta = ScriptedPlayer(Role.WEREWOLF, "Beta", listOf("r1b", "r2b", "r3b"))
-        val setup = TestLodge(alpha to Role.WEREWOLF, beta to Role.WEREWOLF).create()
+        val wolf1 = ScriptedPlayer(Role.WEREWOLF, "Wolf1", listOf("r1a", "r2a", "r3a"))
+        val wolf2 = ScriptedPlayer(Role.WEREWOLF, "Wolf2", listOf("r1b", "r2b", "r3b"))
+        val setup = TestLodge(wolf1 to Role.WEREWOLF, wolf2 to Role.WEREWOLF).create()
 
         fixedOrderConclave(setup.oracle, setup.playerManager).conduct()
 
         assertEquals(listOf(
-            "Alpha:said:r1a",
-            "Alpha:heard:Alpha:r1a",
-            "Alpha:heard:Beta:r1b",
-            "Alpha:said:r2a",
-            "Alpha:heard:Alpha:r2a",
-            "Alpha:heard:Beta:r2b",
-            "Alpha:said:r3a",
-            "Alpha:heard:Alpha:r3a",
-            "Alpha:heard:Beta:r3b",
-        ), alpha.log)
+            "Wolf1:said:r1a",
+            "Wolf1:heard:Wolf1:r1a",
+            "Wolf1:heard:Wolf2:r1b",
+            "Wolf1:said:r2a",
+            "Wolf1:heard:Wolf1:r2a",
+            "Wolf1:heard:Wolf2:r2b",
+            "Wolf1:said:r3a",
+            "Wolf1:heard:Wolf1:r3a",
+            "Wolf1:heard:Wolf2:r3b",
+        ), wolf1.log)
 
         assertEquals(listOf(
-            "Beta:heard:Alpha:r1a",
-            "Beta:said:r1b",
-            "Beta:heard:Beta:r1b",
-            "Beta:heard:Alpha:r2a",
-            "Beta:said:r2b",
-            "Beta:heard:Beta:r2b",
-            "Beta:heard:Alpha:r3a",
-            "Beta:said:r3b",
-            "Beta:heard:Beta:r3b",
-        ), beta.log)
+            "Wolf2:heard:Wolf1:r1a",
+            "Wolf2:said:r1b",
+            "Wolf2:heard:Wolf2:r1b",
+            "Wolf2:heard:Wolf1:r2a",
+            "Wolf2:said:r2b",
+            "Wolf2:heard:Wolf2:r2b",
+            "Wolf2:heard:Wolf1:r3a",
+            "Wolf2:said:r3b",
+            "Wolf2:heard:Wolf2:r3b",
+        ), wolf2.log)
     }
 }

--- a/src/test/kotlin/GameRecapTest.kt
+++ b/src/test/kotlin/GameRecapTest.kt
@@ -18,9 +18,9 @@ class GameRecapTest {
 
     @Test
     fun `public events appear only once even when received by multiple players`() {
-        val playerA = ReceivingPlayer(Role.VILLAGER, "A")
-        val playerB = ReceivingPlayer(Role.VILLAGER, "B")
-        val pm = playerManager(playerA, playerB)
+        val v1 = ReceivingPlayer(Role.VILLAGER, "V1")
+        val v2 = ReceivingPlayer(Role.VILLAGER, "V2")
+        val pm = playerManager(v1, v2)
 
         GameEvent.TimeChanged.send(TimeOfDay.Night(1), AllPlayers(pm))
 
@@ -30,12 +30,12 @@ class GameRecapTest {
 
     @Test
     fun `private events from each player are all collected`() {
-        val playerA = ReceivingPlayer(Role.VILLAGER, "A")
-        val playerB = ReceivingPlayer(Role.VILLAGER, "B")
-        val pm = playerManager(playerA, playerB)
+        val v1 = ReceivingPlayer(Role.VILLAGER, "V1")
+        val v2 = ReceivingPlayer(Role.VILLAGER, "V2")
+        val pm = playerManager(v1, v2)
 
-        GameEvent.RoleAssigned.send(Role.VILLAGER, playerA)
-        GameEvent.RoleAssigned.send(Role.VILLAGER, playerB)
+        GameEvent.RoleAssigned.send(Role.VILLAGER, v1)
+        GameEvent.RoleAssigned.send(Role.VILLAGER, v2)
 
         val events = GameRecap(pm, anySignal()).events()
         assertEquals(2, events.size)
@@ -43,22 +43,22 @@ class GameRecapTest {
 
     @Test
     fun `events are sorted by creation order across players`() {
-        val playerA = ReceivingPlayer(Role.VILLAGER, "A")
-        val playerB = ReceivingPlayer(Role.VILLAGER, "B")
-        val pm = playerManager(playerA, playerB)
+        val v1 = ReceivingPlayer(Role.VILLAGER, "V1")
+        val v2 = ReceivingPlayer(Role.VILLAGER, "V2")
+        val pm = playerManager(v1, v2)
 
         // 作成順: RoleAssigned(A) → RoleAssigned(B) → TimeChanged(全員)
         // flatMap後: [RoleAssigned(A), TimeChanged, RoleAssigned(B), TimeChanged]
         // distinct後: [RoleAssigned(A), TimeChanged, RoleAssigned(B)] ← ソートなしでは誤順
         // sortedBy後: [RoleAssigned(A), RoleAssigned(B), TimeChanged] ← 正しい順
-        GameEvent.RoleAssigned.send(Role.VILLAGER, playerA)
-        GameEvent.RoleAssigned.send(Role.VILLAGER, playerB)
+        GameEvent.RoleAssigned.send(Role.VILLAGER, v1)
+        GameEvent.RoleAssigned.send(Role.VILLAGER, v2)
         GameEvent.TimeChanged.send(TimeOfDay.Night(1), AllPlayers(pm))
 
         val events = GameRecap(pm, anySignal()).events()
         assertEquals(3, events.size)
-        assertEquals("A", events[0].recipientName)
-        assertEquals("B", events[1].recipientName)
+        assertEquals("V1", events[0].recipientName)
+        assertEquals("V2", events[1].recipientName)
         assertTrue(events[2] is GameEvent.TimeChanged)
     }
 }

--- a/src/test/kotlin/MadmanCpuStrategyTest.kt
+++ b/src/test/kotlin/MadmanCpuStrategyTest.kt
@@ -8,17 +8,17 @@ import kotlin.test.assertTrue
 
 class MadmanCpuStrategyTest {
 
-    private val madman = RoleAwareCpuPlayer(Role.MADMAN, "狂人")
-    private val player1 = ReceivingPlayer(Role.VILLAGER, "村人1")
-    private val player2 = ReceivingPlayer(Role.VILLAGER, "村人2")
+    private val madman = RoleAwareCpuPlayer(Role.MADMAN, "Madman")
+    private val v1 = ReceivingPlayer(Role.VILLAGER, "V1")
+    private val v2 = ReceivingPlayer(Role.VILLAGER, "V2")
     private val allPlayers = AllPlayers(
-        TestLodge(madman to Role.MADMAN, player1 to Role.VILLAGER, player2 to Role.VILLAGER).create().playerManager
+        TestLodge(madman to Role.MADMAN, v1 to Role.VILLAGER, v2 to Role.VILLAGER).create().playerManager
     )
 
     @Test
     fun `fake seer reports an alive player as werewolf`() {
         val strategy = MadmanCpuStrategy(madman, Role.SEER)
-        val result = strategy.discuss(listOf(madman, player1, player2))
+        val result = strategy.discuss(listOf(madman, v1, v2))
         assertTrue(result is Statement.DivinationReport)
         assertEquals(DivineResult.WEREWOLF, result.result)
         assertNotSame(madman, result.target)
@@ -27,38 +27,38 @@ class MadmanCpuStrategyTest {
     @Test
     fun `fake seer stays silent when all players already accused`() {
         val strategy = MadmanCpuStrategy(madman, Role.SEER)
-        GameEvent.StatementMade.send(1, madman.name, Statement.DivinationReport(madman, player1, DivineResult.WEREWOLF), allPlayers)
-        GameEvent.StatementMade.send(1, madman.name, Statement.DivinationReport(madman, player2, DivineResult.WEREWOLF), allPlayers)
+        GameEvent.StatementMade.send(1, madman.name, Statement.DivinationReport(madman, v1, DivineResult.WEREWOLF), allPlayers)
+        GameEvent.StatementMade.send(1, madman.name, Statement.DivinationReport(madman, v2, DivineResult.WEREWOLF), allPlayers)
 
-        val result = strategy.discuss(listOf(madman, player1, player2))
+        val result = strategy.discuss(listOf(madman, v1, v2))
         assertTrue(result is Statement.Plain)
     }
 
     @Test
     fun `fake medium reports executed player as not werewolf`() {
         val strategy = MadmanCpuStrategy(madman, Role.MEDIUM)
-        GameEvent.PlayerExecuted.send(player1, allPlayers)
+        GameEvent.PlayerExecuted.send(v1, allPlayers)
 
-        val result = strategy.discuss(listOf(madman, player2))
+        val result = strategy.discuss(listOf(madman, v2))
         assertTrue(result is Statement.MediumReport)
         assertEquals(MediumResult.NOT_WEREWOLF, result.result)
-        assertSame(player1, result.target)
+        assertSame(v1, result.target)
     }
 
     @Test
     fun `fake medium stays silent when no executions yet`() {
         val strategy = MadmanCpuStrategy(madman, Role.MEDIUM)
-        val result = strategy.discuss(listOf(madman, player1, player2))
+        val result = strategy.discuss(listOf(madman, v1, v2))
         assertTrue(result is Statement.Plain)
     }
 
     @Test
     fun `fake medium stays silent after all executed players already reported`() {
         val strategy = MadmanCpuStrategy(madman, Role.MEDIUM)
-        GameEvent.PlayerExecuted.send(player1, allPlayers)
-        GameEvent.StatementMade.send(1, madman.name, Statement.MediumReport(madman, player1, MediumResult.NOT_WEREWOLF), allPlayers)
+        GameEvent.PlayerExecuted.send(v1, allPlayers)
+        GameEvent.StatementMade.send(1, madman.name, Statement.MediumReport(madman, v1, MediumResult.NOT_WEREWOLF), allPlayers)
 
-        val result = strategy.discuss(listOf(madman, player2))
+        val result = strategy.discuss(listOf(madman, v2))
         assertTrue(result is Statement.Plain)
     }
 }

--- a/src/test/kotlin/OracleIsWinnerTest.kt
+++ b/src/test/kotlin/OracleIsWinnerTest.kt
@@ -7,41 +7,41 @@ import kotlin.test.assertTrue
 class OracleIsWinnerTest {
 
     private fun oracle(vararg pairs: Pair<Player, Role>) = Oracle(mapOf(*pairs))
-    private fun player(role: Role) = NothingPlayer(role, "p")
+    private fun player(role: Role) = NothingPlayer(role, role.name)
 
     @Test
     fun `villager wins when citizen side wins`() {
-        val p = player(Role.VILLAGER)
-        assertTrue(oracle(p to Role.VILLAGER).isWinner(p, Side.CITIZEN))
+        val villager = player(Role.VILLAGER)
+        assertTrue(oracle(villager to Role.VILLAGER).isWinner(villager, Side.CITIZEN))
     }
 
     @Test
     fun `villager loses when werewolf side wins`() {
-        val p = player(Role.VILLAGER)
-        assertFalse(oracle(p to Role.VILLAGER).isWinner(p, Side.WEREWOLF))
+        val villager = player(Role.VILLAGER)
+        assertFalse(oracle(villager to Role.VILLAGER).isWinner(villager, Side.WEREWOLF))
     }
 
     @Test
     fun `werewolf wins when werewolf side wins`() {
-        val p = player(Role.WEREWOLF)
-        assertTrue(oracle(p to Role.WEREWOLF).isWinner(p, Side.WEREWOLF))
+        val wolf = player(Role.WEREWOLF)
+        assertTrue(oracle(wolf to Role.WEREWOLF).isWinner(wolf, Side.WEREWOLF))
     }
 
     @Test
     fun `werewolf loses when citizen side wins`() {
-        val p = player(Role.WEREWOLF)
-        assertFalse(oracle(p to Role.WEREWOLF).isWinner(p, Side.CITIZEN))
+        val wolf = player(Role.WEREWOLF)
+        assertFalse(oracle(wolf to Role.WEREWOLF).isWinner(wolf, Side.CITIZEN))
     }
 
     @Test
     fun `madman wins when werewolf side wins`() {
-        val p = player(Role.MADMAN)
-        assertTrue(oracle(p to Role.MADMAN).isWinner(p, Side.WEREWOLF))
+        val madman = player(Role.MADMAN)
+        assertTrue(oracle(madman to Role.MADMAN).isWinner(madman, Side.WEREWOLF))
     }
 
     @Test
     fun `madman loses when citizen side wins`() {
-        val p = player(Role.MADMAN)
-        assertFalse(oracle(p to Role.MADMAN).isWinner(p, Side.CITIZEN))
+        val madman = player(Role.MADMAN)
+        assertFalse(oracle(madman to Role.MADMAN).isWinner(madman, Side.CITIZEN))
     }
 }


### PR DESCRIPTION
## Summary

- テストプレイヤーの命名をプロジェクト方針に統一 (closes #153)
- `docs/TESTING.md` に命名方針のセクションを追加

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `MadmanCpuStrategyTest.kt` | `"狂人"` → `"Madman"`, `"村人1/2"` → `"V1/V2"`, 変数名も統一 |
| `ConclaveTest.kt` | `"Alpha/Beta/Gamma"` → `"Wolf1/Wolf2/Wolf3"`, 変数名も統一。`dead werewolf` テストの宣言順を Wolf1→Wolf2→Wolf3 に修正 |
| `GameRecapTest.kt` | `"A/B"` → `"V1/V2"`, 変数名も統一 |
| `OracleIsWinnerTest.kt` | `"p"` → `role.name`, 変数名を role に合わせて `villager`/`wolf`/`madman` に統一 |
| `docs/TESTING.md` | テストプレイヤーの命名方針セクションを追加 |

## Test plan

- [x] `./gradlew check` 通過確認

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)