### PR TITLE
Add pre-commit hook and README with setup instructions

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+./gradlew check

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# werewolf-smallstart
+
+Kotlin製の人狼ゲームエンジンです。
+
+## 目標
+
+- **環境非依存**: プレイヤーとのやり取りを `PlayerIO` 経由に統一することで、コンソール・Web・その他のフロントエンドへの差し替えを可能にする
+- **多様なプレイヤー**: 人間プレイヤーだけでなく、ルールベースのCPUや AIをプレイヤーとして参加させられる設計を目指す
+
+現時点ではコンソール上で動作する実装が含まれています。
+
+## セットアップ
+
+```bash
+git config core.hooksPath .githooks
+```
+
+pre-commit フックが有効になり、コミット前に `./gradlew check`（静的解析＋テスト）が自動実行されます。
+
+## 実行
+
+```bash
+./gradlew run
+```
+
+## テスト・静的解析
+
+```bash
+./gradlew check
+```
+
+## 開発フロー
+
+ブランチ戦略・PR・issue のルールは [`.github/WORKFLOW.md`](.github/WORKFLOW.md) を参照してください。
+
+テスト方針は [`docs/TESTING.md`](docs/TESTING.md) を参照してください。


### PR DESCRIPTION
## Summary

- `.githooks/pre-commit` を追加し、コミット前に `./gradlew check` が自動実行されるようにした (closes #150)
- `README.md` を追加。プロジェクトの目標・セットアップ手順（`git config core.hooksPath .githooks` を含む）・開発フローへの案内を記載

## 動作確認

以下の3パターンでコミットが阻止されることを確認済み:
- [x] コンパイルエラーがある場合
- [x] テストが失敗する場合
- [x] detekt エラー（末尾改行なし）がある場合

## セットアップ

このPRをマージ後、各開発者は以下を一度実行する必要があります:

```bash
git config core.hooksPath .githooks
```

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)