### PR TITLE
Add PocAiPlayer for manual AI prompt testing

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -11,12 +11,13 @@ fun main() {
 }
 
 private fun getLodge(): Lodge {
-    println("Lodgeを選択してください: AllHuman / RollerCPU / RandomCPU / HonestCPU / RoleAwareCPU")
+    println("Lodgeを選択してください: AllHuman / RollerCPU / RandomCPU / HonestCPU / RoleAwareCPU / PocAI")
     return when (readLine()?.trim()) {
         "RollerCPU"   -> RollerCpuLodge
         "RandomCPU"   -> RandomCpuLodge
         "HonestCPU"   -> HonestCpuLodge
         "RoleAwareCPU" -> RoleAwareCpuLodge
+        "PocAI"       -> PocAiLodge
         else -> SmallLodge
     }
 }

--- a/src/main/kotlin/PocAiLodge.kt
+++ b/src/main/kotlin/PocAiLodge.kt
@@ -1,0 +1,11 @@
+package org.example
+
+object PocAiLodge : Lodge() {
+    override fun assignments(): List<Pair<Player, Role>> {
+        val roles = listOf(
+            Role.HUNTER, Role.VILLAGER, Role.MADMAN,
+            Role.WEREWOLF, Role.SEER, Role.MEDIUM, Role.WEREWOLF,
+        ).shuffled()
+        return roles.mapIndexed { i, role -> PocAiPlayer(role, "${i + 1}") to role }
+    }
+}

--- a/src/main/kotlin/PocAiPlayer.kt
+++ b/src/main/kotlin/PocAiPlayer.kt
@@ -1,0 +1,71 @@
+package org.example
+
+class PocAiPlayer(role: Role, override val name: String) : Player(role) {
+    private val eventLog = mutableListOf<GameEvent>()
+
+    override fun onReceive(event: GameEvent) {
+        eventLog.add(event)
+    }
+
+    override fun discuss(players: List<Player>): Statement {
+        printPrompt("50文字以内で発言してください")
+        return Statement.Plain(readLine()?.trim() ?: "")
+    }
+
+    override fun selectTarget(context: SelectionContext): Player {
+        val candidates = context.candidates()
+        val candidateNames = candidates.joinToString(", ") { it.name }
+        printPrompt("${context.title}：${context.description}（候補: $candidateNames）")
+        while (true) {
+            val input = readLine()?.trim() ?: ""
+            val target = candidates.firstOrNull { it.name == input }
+            if (target != null) return target
+            println("「$input」は候補にいません。再入力してください。")
+        }
+    }
+
+    override fun watchEpilogue(events: List<GameEvent>) {
+        println()
+        println("=== エピローグ（プレイヤー $name） ===")
+        events.forEach { println("[${it.title}] ${it.body()}") }
+    }
+
+    private fun printPrompt(instruction: String) {
+        println()
+        println(SEPARATOR)
+        println("AIプレイヤー $name へのプロンプト")
+        println(SEPARATOR)
+        println("【指示】")
+        println(instruction)
+        println()
+        println("【ゲームの説明】")
+        println(gameDescription)
+        println()
+        println("【ここまでのゲームの流れ】")
+        if (eventLog.isEmpty()) println("（なし）")
+        else eventLog.forEach { println("[${it.title}] ${it.body()}") }
+        println(SEPARATOR)
+        print("回答 > ")
+    }
+
+    companion object {
+        private const val SEPARATOR_WIDTH = 50
+        private val SEPARATOR = "=".repeat(SEPARATOR_WIDTH)
+    }
+
+    private val gameDescription = """
+プレイヤーは7人で、1~7の番号が付けられており、あなたは${name}です。
+このゲームでは、プレイヤーは人狼・村人などの役職を与えられ、役職ごとの勝利条件を満たすために行動します。
+大きな対立は「夜に村人を襲撃する人狼」と「昼の議論で人狼の疑いがあるものを絞り、投票で処刑して対抗する村人」です。
+人狼は「村人陣営と人狼陣営の人数が同数になれば勝利」です。
+村人陣営は「人狼陣営が全員死亡すれば勝利」です。
+
+村人陣営には村人のほかに以下の役職があります。
+「選択した他者一人の役職を毎晩知れる占い師」
+「前日に処刑したプレイヤーの役職を知れる霊能者」
+「毎晩他者一人を選んで護衛できる狩人（人狼の襲撃相手と護衛相手が一致した場合、襲撃が失敗します。）」
+人狼陣営は人狼だけですが、「人狼に味方し、人狼陣営の勝利が自らの勝利となる狂人」という役職があります。
+
+初期の役職配分は人狼2人・狂人1人・村人1人・占い師1人・霊能者1人・狩人1人です。
+    """.trimIndent()
+}

--- a/src/test/kotlin/EpilogueTest.kt
+++ b/src/test/kotlin/EpilogueTest.kt
@@ -24,11 +24,6 @@ class EpilogueTest {
         }
     }
 
-    private fun fakeCitizenWinSignal(): GameOverSignal = try {
-        GameOverSignal.throwIfGameOver(AliveCounts(mapOf(Side.CITIZEN to 2, Side.WEREWOLF to 0)))
-        error("unreachable")
-    } catch (s: GameOverSignal) { s }
-
     @Test
     fun `GameOver is broadcast with winning side`() {
         val villager = WatchingPlayer(Role.VILLAGER, "Villager")

--- a/src/test/kotlin/PocAiPlayerTest.kt
+++ b/src/test/kotlin/PocAiPlayerTest.kt
@@ -1,0 +1,73 @@
+package org.example
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class PocAiPlayerTest {
+
+    private fun <T> withIO(input: String, block: () -> T): Pair<T, String> {
+        val originalIn = System.`in`
+        val originalOut = System.out
+        val buffer = ByteArrayOutputStream()
+        System.setIn(ByteArrayInputStream(input.toByteArray()))
+        System.setOut(PrintStream(buffer))
+        try {
+            return block() to buffer.toString()
+        } finally {
+            System.setIn(originalIn)
+            System.setOut(originalOut)
+        }
+    }
+
+    @Test
+    fun `discuss returns Plain statement from input`() {
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager")
+        val (result, _) = withIO("hello\n") { villager.discuss(emptyList()) }
+        assertIs<Statement.Plain>(result)
+        assertEquals("hello", result.text())
+    }
+
+    @Test
+    fun `selectTarget returns matching player`() {
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager")
+        val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
+        val context = SelectionContext.Vote(villager, listOf(villager, wolf))
+        val (result, _) = withIO("Wolf\n") { villager.selectTarget(context) }
+        assertEquals(wolf, result)
+    }
+
+    @Test
+    fun `selectTarget retries on invalid input then returns correct player`() {
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager")
+        val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
+        val context = SelectionContext.Vote(villager, listOf(villager, wolf))
+        val (result, _) = withIO("Unknown\nWolf\n") { villager.selectTarget(context) }
+        assertEquals(wolf, result)
+    }
+
+    @Test
+    fun `prompt includes received events in discuss output`() {
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager")
+        GameEvent.RoleAssigned.send(Role.VILLAGER, villager)
+        val (_, output) = withIO("\n") { villager.discuss(emptyList()) }
+        assertContains(output, "役職通知")
+    }
+
+    @Test
+    fun `watchEpilogue prints event title and body`() {
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager")
+        // ① 通常ルートでイベントを送る
+        GameEvent.RoleAssigned.send(Role.VILLAGER, villager)
+        // ② fakeのGameOverSignalでknowledgeを取り出す
+        val events = villager.revealKnowledge(fakeCitizenWinSignal())
+        // ③ watchEpilogueに渡して出力を検証
+        val (_, output) = withIO("") { villager.watchEpilogue(events) }
+        assertContains(output, "役職通知")
+        assertContains(output, "村人")
+    }
+}

--- a/src/test/kotlin/TestSignals.kt
+++ b/src/test/kotlin/TestSignals.kt
@@ -1,0 +1,6 @@
+package org.example
+
+fun fakeCitizenWinSignal(): GameOverSignal = try {
+    GameOverSignal.throwIfGameOver(AliveCounts(mapOf(Side.CITIZEN to 2, Side.WEREWOLF to 0)))
+    error("unreachable")
+} catch (s: GameOverSignal) { s }


### PR DESCRIPTION
## Summary

- `PocAiPlayer` を追加 (closes #159)
- `selectTarget` / `discuss` 呼び出し時にコンソールへ3段構成のプロンプトを出力する
  - 指示（context のタイトル・説明、または「50文字以内で発言してください」）
  - ゲームの説明（固定テキスト）
  - ここまでの GameEvent ログ
- ユーザーが AI に貼り付けた回答をコンソールへ入力することで進行する
- `PocAiLodge` を追加（全7プレイヤーが `PocAiPlayer`）
- `Main.kt` の Lodge 選択に `PocAI` を追加

## Test plan

- [x] `./gradlew check` 通過確認

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)