### PR TITLE
Ask AI for reflection in PocAiPlayer watchEpilogue

### DIFF
--- a/src/main/kotlin/PocAiPlayer.kt
+++ b/src/main/kotlin/PocAiPlayer.kt
@@ -27,7 +27,9 @@ class PocAiPlayer(role: Role, override val name: String) : Player(role) {
     override fun watchEpilogue(events: List<GameEvent>) {
         println()
         println("=== エピローグ（プレイヤー $name） ===")
-        events.forEach { println("[${it.title}] ${it.body()}") }
+        events.forEach { println("[${it.recipientName}] [${it.title}] ${it.body()}") }
+        printPrompt("プレイヤーとして200文字以内でゲームの振り返りをしてください。")
+        readLine()
     }
 
     private fun printPrompt(instruction: String) {

--- a/src/test/kotlin/PocAiPlayerTest.kt
+++ b/src/test/kotlin/PocAiPlayerTest.kt
@@ -59,15 +59,16 @@ class PocAiPlayerTest {
     }
 
     @Test
-    fun `watchEpilogue prints event title and body`() {
+    fun `watchEpilogue prints event recipientName, title and body, then prompts for reflection`() {
         val villager = PocAiPlayer(Role.VILLAGER, "Villager")
         // ① 通常ルートでイベントを送る
         GameEvent.RoleAssigned.send(Role.VILLAGER, villager)
         // ② fakeのGameOverSignalでknowledgeを取り出す
         val events = villager.revealKnowledge(fakeCitizenWinSignal())
-        // ③ watchEpilogueに渡して出力を検証
-        val (_, output) = withIO("") { villager.watchEpilogue(events) }
+        // ③ watchEpilogueに渡して出力を検証（printPromptのreadLine分の入力を用意）
+        val (_, output) = withIO("\n") { villager.watchEpilogue(events) }
+        assertContains(output, "Villager")
         assertContains(output, "役職通知")
-        assertContains(output, "村人")
+        assertContains(output, "振り返り")
     }
 }


### PR DESCRIPTION
## Summary

- `watchEpilogue` の各イベント行に `recipientName` を追加 (Closes #164)
- エピローグ表示後に振り返りプロンプトを出力し、AIの入力を待つ

## Test plan

- [x] `./gradlew check` 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)