### PR TITLE
Introduce DiscussionContext and make Player.discuss final

### DIFF
--- a/src/main/kotlin/Conclave.kt
+++ b/src/main/kotlin/Conclave.kt
@@ -1,9 +1,15 @@
 package org.example
 
-open class Conclave(oracle: Oracle, playerManager: PlayerManager) :
-    Discussion<Wolves>(oracle.werewolves(playerManager.players), Wolves(oracle, playerManager)) {
+open class Conclave(oracle: Oracle, playerManager: PlayerManager, day: Int) :
+    Discussion<Wolves>(
+        oracle.werewolves(playerManager.players),
+        Wolves(oracle, playerManager),
+        day,
+        playerManager.allPlayers,
+    ) {
     override val rounds = 3
     override fun speakingOrder(speakers: List<Player>) = speakers.shuffled()
     override fun sendStatement(round: Int, speakerName: String, statement: Statement, recipients: Wolves) =
         GameEvent.WerewolfStatementMade.send(round, speakerName, statement.text(), recipients)
+    override fun buildContext(round: Int) = DiscussionContext.Conclave(round, day, speakers, allPlayers)
 }

--- a/src/main/kotlin/ConsolePlayerIO.kt
+++ b/src/main/kotlin/ConsolePlayerIO.kt
@@ -6,7 +6,7 @@ class ConsolePlayerIO : PlayerIO {
         println(content)
     }
 
-    override fun prompt(playerName: String, title: String, content: String, candidates: List<Player>): Player {
+    override fun promptPlayer(playerName: String, title: String, content: String, candidates: List<Player>): Player {
         while (true) {
             sendMessage(playerName, title, "$content: ${candidates.joinToString(", ") { it.name }}")
             val input = readLine() ?: ""
@@ -19,5 +19,15 @@ class ConsolePlayerIO : PlayerIO {
     override fun promptFreeText(playerName: String, title: String, content: String): String {
         sendMessage(playerName, title, content)
         return readLine() ?: ""
+    }
+
+    override fun promptChoice(playerName: String, title: String, content: String, options: List<String>): Int {
+        while (true) {
+            sendMessage(playerName, title, content)
+            options.forEachIndexed { i, option -> println("${i + 1}: $option") }
+            val input = readLine()?.toIntOrNull()
+            if (input != null && input in 1..options.size) return input - 1
+            println("1〜${options.size}の数字を入力してください。")
+        }
     }
 }

--- a/src/main/kotlin/DayPhase.kt
+++ b/src/main/kotlin/DayPhase.kt
@@ -6,7 +6,7 @@ class DayPhase(
     private val nightNumber: Int
 ) : Phase {
     override fun proceed(): Phase {
-        OpenDiscussion(playerManager.players, AllPlayers(playerManager)).conduct()
+        OpenDiscussion(playerManager, nightNumber).conduct()
         val votes = playerManager.players.map { it.selectTarget(SelectionContext.Vote(it, playerManager.players)) }
         val mostVoted = MajorityVoteResolver.resolveNonEmpty(votes)
         playerManager.execute(mostVoted)

--- a/src/main/kotlin/Discussion.kt
+++ b/src/main/kotlin/Discussion.kt
@@ -1,28 +1,38 @@
 package org.example
 
 abstract class Discussion<R : Notifiable>(
-    private val speakers: List<Player>,
-    private val recipients: R
+    protected val speakers: List<Player>,
+    private val recipients: R,
+    protected val day: Int,
+    protected val allPlayers: List<Player>,
 ) {
     protected abstract val rounds: Int
     protected abstract fun speakingOrder(speakers: List<Player>): List<Player>
     protected abstract fun sendStatement(round: Int, speakerName: String, statement: Statement, recipients: R)
+    protected abstract fun buildContext(round: Int): DiscussionContext
 
     fun conduct() {
         if (speakers.size <= 1) return
         val order = speakingOrder(speakers)
         repeat(rounds) { index ->
             order.forEach { speaker ->
-                val statement = speaker.discuss(speakers)
+                val statement = speaker.discuss(buildContext(index + 1))
                 sendStatement(index + 1, speaker.name, statement, recipients)
             }
         }
     }
 }
 
-open class OpenDiscussion(speakers: List<Player>, allPlayers: AllPlayers) : Discussion<AllPlayers>(speakers, allPlayers) {
+open class OpenDiscussion(playerManager: PlayerManager, day: Int) :
+    Discussion<AllPlayers>(
+        playerManager.players,
+        AllPlayers(playerManager),
+        day,
+        playerManager.allPlayers,
+    ) {
     override val rounds = 3
     override fun speakingOrder(speakers: List<Player>) = speakers.shuffled()
     override fun sendStatement(round: Int, speakerName: String, statement: Statement, recipients: AllPlayers) =
         GameEvent.StatementMade.send(round, speakerName, statement, recipients)
+    override fun buildContext(round: Int) = DiscussionContext.Open(round, day, speakers, allPlayers)
 }

--- a/src/main/kotlin/DiscussionContext.kt
+++ b/src/main/kotlin/DiscussionContext.kt
@@ -1,0 +1,33 @@
+package org.example
+
+sealed class DiscussionContext {
+    abstract val round: Int
+    abstract val day: Int
+    abstract val players: List<Player>
+    abstract val allPlayers: List<Player>
+    abstract val title: String
+    abstract val description: String
+    abstract val availableTypes: Set<StatementType>
+
+    data class Open(
+        override val round: Int,
+        override val day: Int,
+        override val players: List<Player>,
+        override val allPlayers: List<Player>,
+    ) : DiscussionContext() {
+        override val title = "議論"
+        override val description = "全プレイヤーに向けた議論です。"
+        override val availableTypes = StatementType.entries.toSet()
+    }
+
+    data class Conclave(
+        override val round: Int,
+        override val day: Int,
+        override val players: List<Player>,
+        override val allPlayers: List<Player>,
+    ) : DiscussionContext() {
+        override val title = "密談"
+        override val description = "この会話は人狼にしか聞こえません。"
+        override val availableTypes = setOf(StatementType.PLAIN)
+    }
+}

--- a/src/main/kotlin/HonestCpuPlayer.kt
+++ b/src/main/kotlin/HonestCpuPlayer.kt
@@ -8,7 +8,7 @@ class HonestCpuPlayer(role: Role, override val name: String) : CpuPlayer(role) {
         if (!event.isPublicKnowledge()) unspoken.add(event)
     }
 
-    override fun discuss(players: List<Player>): Statement {
+    override fun buildStatement(context: DiscussionContext): Statement {
         if (unspoken.isEmpty()) return Statement.Plain("")
         return Statement.Plain(unspoken.removeFirst().body())
     }

--- a/src/main/kotlin/HumanPlayer.kt
+++ b/src/main/kotlin/HumanPlayer.kt
@@ -2,14 +2,44 @@ package org.example
 
 class HumanPlayer(role: Role, override val name: String, private val io: PlayerIO) : Player(role) {
     override fun selectTarget(context: SelectionContext): Player =
-        io.prompt(name, context.title, context.description, context.candidates())
+        io.promptPlayer(name, context.title, context.description, context.candidates())
 
     override fun onReceive(event: GameEvent) {
         io.sendMessage(name, event.title, event.body())
     }
 
-    override fun discuss(players: List<Player>): Statement =
-        Statement.Plain(io.promptFreeText(name, "議論", "発言してください"))
+    override fun buildStatement(context: DiscussionContext): Statement {
+        val type = selectType(context)
+        return when (type) {
+            StatementType.PLAIN -> buildPlain(context)
+            StatementType.DIVINATION_REPORT -> buildDivinationReport(context)
+            StatementType.MEDIUM_REPORT -> buildMediumReport(context)
+        }
+    }
+
+    private fun selectType(context: DiscussionContext): StatementType {
+        val types = StatementType.entries.filter { it in context.availableTypes }
+        if (types.size == 1) return types.first()
+        val idx = io.promptChoice(name, context.title, context.description, types.map { it.displayName })
+        return types[idx]
+    }
+
+    private fun buildPlain(context: DiscussionContext): Statement =
+        Statement.Plain(io.promptFreeText(name, context.title, "発言してください"))
+
+    private fun buildDivinationReport(context: DiscussionContext): Statement {
+        val target = io.promptPlayer(name, "占い報告 - 対象", "誰の占い結果を報告しますか？", context.allPlayers.filter { it !== this })
+        val results = DivineResult.entries
+        val resultIdx = io.promptChoice(name, "占い報告 - 結果", "占い結果を選んでください", results.map { it.displayName })
+        return Statement.DivinationReport(this, target, results[resultIdx])
+    }
+
+    private fun buildMediumReport(context: DiscussionContext): Statement {
+        val target = io.promptPlayer(name, "霊媒報告 - 対象", "誰の霊媒結果を報告しますか？", context.allPlayers.filter { it !== this })
+        val results = MediumResult.entries
+        val resultIdx = io.promptChoice(name, "霊媒報告 - 結果", "霊媒結果を選んでください", results.map { it.displayName })
+        return Statement.MediumReport(this, target, results[resultIdx])
+    }
 
     override fun watchEpilogue(events: List<GameEvent>) {
         val content = events.joinToString("\n") { "  ${it.recipientName}: [${it.title}] ${it.body()}" }

--- a/src/main/kotlin/HunterCpuStrategy.kt
+++ b/src/main/kotlin/HunterCpuStrategy.kt
@@ -3,7 +3,7 @@ package org.example
 class HunterCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.HUNTER, CitizenVoting(self)) {
     private val query = KnowledgeQuery(self)
 
-    override fun discuss(players: List<Player>) = Statement.Plain("")
+    override fun buildStatement(context: DiscussionContext) = Statement.Plain("")
 
     override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
         when (context) {

--- a/src/main/kotlin/MadmanCpuStrategy.kt
+++ b/src/main/kotlin/MadmanCpuStrategy.kt
@@ -5,19 +5,22 @@ class MadmanCpuStrategy(
     private val impersonating: Role = listOf(Role.SEER, Role.MEDIUM).random(),
 ) : RoleAwareCpuStrategy(self, Role.MADMAN, WerewolfVoting(self)) {
 
-    override fun discuss(players: List<Player>): Statement =
-        if (impersonating == Role.SEER) fakeSeerDiscuss(players) else fakeMediumDiscuss()
+    override fun buildStatement(context: DiscussionContext): Statement {
+        if (context.round > 1) return Statement.Plain("")
+        return if (impersonating == Role.SEER) fakeSeerStatement(context) else fakeMediumStatement()
+    }
 
     override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
         candidates.random()
 
-    private fun fakeSeerDiscuss(players: List<Player>): Statement {
-        val target = players.filter { it !== self && it !in accusedByMe() }.randomOrNull()
+    private fun fakeSeerStatement(context: DiscussionContext): Statement {
+        val result = if (context.day == 1) DivineResult.NOT_WEREWOLF else DivineResult.WEREWOLF
+        val target = context.players.filter { it !== self && it !in accusedByMe() }.randomOrNull()
             ?: return Statement.Plain("")
-        return Statement.DivinationReport(self, target, DivineResult.WEREWOLF)
+        return Statement.DivinationReport(self, target, result)
     }
 
-    private fun fakeMediumDiscuss(): Statement {
+    private fun fakeMediumStatement(): Statement {
         val target = self.knowledge.filterIsInstance<GameEvent.PlayerExecuted>()
             .map { it.executed }
             .firstOrNull { it !in fakeMediumedByMe() }

--- a/src/main/kotlin/MediumCpuStrategy.kt
+++ b/src/main/kotlin/MediumCpuStrategy.kt
@@ -2,7 +2,7 @@ package org.example
 
 class MediumCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.MEDIUM, CitizenVoting(self)) {
 
-    override fun discuss(players: List<Player>): Statement {
+    override fun buildStatement(context: DiscussionContext): Statement {
         val next = nextUnreportedReveal() ?: return Statement.Plain("")
         return Statement.MediumReport(self, next.target, next.result)
     }

--- a/src/main/kotlin/NightPhase.kt
+++ b/src/main/kotlin/NightPhase.kt
@@ -7,7 +7,7 @@ class NightPhase(
 ) : Phase {
     override fun proceed(): Phase {
         GameEvent.TimeChanged.send(TimeOfDay.Night(nightNumber), AllPlayers(playerManager))
-        Conclave(oracle, playerManager).conduct()
+        Conclave(oracle, playerManager, nightNumber).conduct()
         val decisions = playerManager.players.map { it to it.buildNightAction(playerManager.players, nightNumber == 1) }
 
         val attacks = decisions.map { it.second }.filterIsInstance<NightAction.Attack>()

--- a/src/main/kotlin/Player.kt
+++ b/src/main/kotlin/Player.kt
@@ -12,7 +12,12 @@ abstract class Player(private val role: Role) : Notifiable {
 
     protected abstract fun onReceive(event: GameEvent)
     abstract fun selectTarget(context: SelectionContext): Player
-    abstract fun discuss(players: List<Player>): Statement
+    fun discuss(context: DiscussionContext): Statement {
+        val statement = buildStatement(context)
+        require(statement.type in context.availableTypes)
+        return statement
+    }
+    protected abstract fun buildStatement(context: DiscussionContext): Statement
     abstract fun watchEpilogue(events: List<GameEvent>)
 
     // signal is a capability token: only callers who hold a GameOverSignal (i.e., after game over) can access knowledge

--- a/src/main/kotlin/PlayerIO.kt
+++ b/src/main/kotlin/PlayerIO.kt
@@ -2,6 +2,7 @@ package org.example
 
 interface PlayerIO {
     fun sendMessage(playerName: String, title: String, content: String)
-    fun prompt(playerName: String, title: String, content: String, candidates: List<Player>): Player
+    fun promptPlayer(playerName: String, title: String, content: String, candidates: List<Player>): Player
     fun promptFreeText(playerName: String, title: String, content: String): String
+    fun promptChoice(playerName: String, title: String, content: String, options: List<String>): Int
 }

--- a/src/main/kotlin/PocAiPlayer.kt
+++ b/src/main/kotlin/PocAiPlayer.kt
@@ -7,8 +7,8 @@ class PocAiPlayer(role: Role, override val name: String) : Player(role) {
         eventLog.add(event)
     }
 
-    override fun discuss(players: List<Player>): Statement {
-        printPrompt("50文字以内で発言してください")
+    override fun buildStatement(context: DiscussionContext): Statement {
+        printPrompt("【${context.title}】${context.description}\n50文字以内で発言してください")
         return Statement.Plain(readLine()?.trim() ?: "")
     }
 

--- a/src/main/kotlin/RandomCpuPlayer.kt
+++ b/src/main/kotlin/RandomCpuPlayer.kt
@@ -2,6 +2,6 @@ package org.example
 
 class RandomCpuPlayer(role: Role, override val name: String) : CpuPlayer(role) {
     override fun selectTarget(context: SelectionContext): Player = context.candidates().random()
-    override fun discuss(players: List<Player>): Statement = Statement.Plain("")
+    override fun buildStatement(context: DiscussionContext): Statement = Statement.Plain("")
     override fun onReceive(event: GameEvent) { /* does not use received events */ }
 }

--- a/src/main/kotlin/RoleAwareCpuPlayer.kt
+++ b/src/main/kotlin/RoleAwareCpuPlayer.kt
@@ -10,6 +10,6 @@ class RoleAwareCpuPlayer(val myRole: Role, override val name: String) : CpuPlaye
     ).single { it.appliesTo() }
 
     override fun onReceive(event: GameEvent) { _knowledge.add(event) }
-    override fun discuss(players: List<Player>) = strategy.discuss(players)
+    override fun buildStatement(context: DiscussionContext) = strategy.buildStatement(context)
     override fun selectTarget(context: SelectionContext) = strategy.selectTarget(context)
 }

--- a/src/main/kotlin/RoleAwareCpuStrategy.kt
+++ b/src/main/kotlin/RoleAwareCpuStrategy.kt
@@ -7,7 +7,7 @@ abstract class RoleAwareCpuStrategy(
 ) {
     fun appliesTo() = self.myRole == targetRole
 
-    abstract fun discuss(players: List<Player>): Statement
+    abstract fun buildStatement(context: DiscussionContext): Statement
 
     fun selectTarget(context: SelectionContext): Player {
         val candidates = context.candidates()

--- a/src/main/kotlin/RollerCpuPlayer.kt
+++ b/src/main/kotlin/RollerCpuPlayer.kt
@@ -8,6 +8,6 @@ class RollerCpuPlayer(role: Role, override val name: String) : CpuPlayer(role) {
         return candidates[selectCount++ % candidates.size]
     }
 
-    override fun discuss(players: List<Player>): Statement = Statement.Plain("")
+    override fun buildStatement(context: DiscussionContext): Statement = Statement.Plain("")
     override fun onReceive(event: GameEvent) { /* does not use received events */ }
 }

--- a/src/main/kotlin/SeerCpuStrategy.kt
+++ b/src/main/kotlin/SeerCpuStrategy.kt
@@ -2,7 +2,7 @@ package org.example
 
 class SeerCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.SEER, SeerVoting(self)) {
 
-    override fun discuss(players: List<Player>): Statement {
+    override fun buildStatement(context: DiscussionContext): Statement {
         val next = nextUnreportedDivination() ?: return Statement.Plain("")
         return Statement.DivinationReport(self, next.target, next.result)
     }

--- a/src/main/kotlin/Statement.kt
+++ b/src/main/kotlin/Statement.kt
@@ -1,17 +1,21 @@
 package org.example
 
 sealed class Statement {
+    abstract val type: StatementType
     abstract fun text(): String
 
     data class Plain(private val content: String) : Statement() {
+        override val type = StatementType.PLAIN
         override fun text() = content
     }
 
     data class DivinationReport(val claimant: Player, val target: Player, val result: DivineResult) : Statement() {
+        override val type = StatementType.DIVINATION_REPORT
         override fun text() = "${target.name} は「${result.displayName}」です。"
     }
 
     data class MediumReport(val claimant: Player, val target: Player, val result: MediumResult) : Statement() {
+        override val type = StatementType.MEDIUM_REPORT
         override fun text() = "${target.name} は「${result.displayName}」です。"
     }
 }

--- a/src/main/kotlin/StatementType.kt
+++ b/src/main/kotlin/StatementType.kt
@@ -1,0 +1,7 @@
+package org.example
+
+enum class StatementType(val displayName: String) {
+    PLAIN("発言する"),
+    DIVINATION_REPORT("占い結果を報告する"),
+    MEDIUM_REPORT("霊媒結果を報告する"),
+}

--- a/src/main/kotlin/VillagerCpuStrategy.kt
+++ b/src/main/kotlin/VillagerCpuStrategy.kt
@@ -2,7 +2,7 @@ package org.example
 
 class VillagerCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.VILLAGER, CitizenVoting(self)) {
 
-    override fun discuss(players: List<Player>) = Statement.Plain("")
+    override fun buildStatement(context: DiscussionContext) = Statement.Plain("")
 
     override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
         candidates.random()

--- a/src/main/kotlin/WerewolfCpuStrategy.kt
+++ b/src/main/kotlin/WerewolfCpuStrategy.kt
@@ -3,7 +3,7 @@ package org.example
 class WerewolfCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.WEREWOLF, WerewolfVoting(self)) {
     private val query = KnowledgeQuery(self)
 
-    override fun discuss(players: List<Player>) = Statement.Plain("")
+    override fun buildStatement(context: DiscussionContext) = Statement.Plain("")
 
     override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
         when (context) {

--- a/src/test/kotlin/ConclaveTest.kt
+++ b/src/test/kotlin/ConclaveTest.kt
@@ -16,7 +16,7 @@ class ConclaveTest {
         val log: List<String> get() = _log
         private var statementIndex = 0
 
-        override fun discuss(players: List<Player>): Statement {
+        override fun buildStatement(context: DiscussionContext): Statement {
             val statement = statements[statementIndex++]
             _log.add("$name:said:$statement")
             return Statement.Plain(statement)
@@ -32,7 +32,7 @@ class ConclaveTest {
     }
 
     private fun fixedOrderConclave(oracle: Oracle, playerManager: PlayerManager) =
-        object : Conclave(oracle, playerManager) {
+        object : Conclave(oracle, playerManager, 1) {
             override fun speakingOrder(speakers: List<Player>) = speakers
         }
 

--- a/src/test/kotlin/DayPhaseTest.kt
+++ b/src/test/kotlin/DayPhaseTest.kt
@@ -11,7 +11,7 @@ class DayPhaseTest {
         role: Role, name: String, private val voteTarget: Player? = null
     ) : ReceivingPlayer(role, name) {
         var discussedCount = 0
-        override fun discuss(players: List<Player>): Statement {
+        override fun buildStatement(context: DiscussionContext): Statement {
             discussedCount++
             return Statement.Plain("")
         }

--- a/src/test/kotlin/DiscussionTest.kt
+++ b/src/test/kotlin/DiscussionTest.kt
@@ -8,28 +8,30 @@ class DiscussionTest {
     private class ScriptedPlayer(
         role: Role,
         name: String,
-        private val statements: List<String>
+        private val statements: List<String>,
+        private val receivesExecutionEvent: Boolean = false,
     ) : NothingPlayer(role, name) {
         private val _log = mutableListOf<String>()
         val log: List<String> get() = _log
         private var statementIndex = 0
 
-        override fun discuss(players: List<Player>): Statement {
+        override fun buildStatement(context: DiscussionContext): Statement {
             val statement = statements[statementIndex++]
             _log.add("$name:said:$statement")
             return Statement.Plain(statement)
         }
 
         override fun onReceive(event: GameEvent) {
-            when (event) {
-                is GameEvent.StatementMade -> _log.add("$name:heard:${event.speakerName}:${event.statement.text()}")
+            when {
+                event is GameEvent.StatementMade -> _log.add("$name:heard:${event.speakerName}:${event.statement.text()}")
+                receivesExecutionEvent && event is GameEvent.PlayerExecuted -> {}
                 else -> error("unexpected event in discussion test: $event")
             }
         }
     }
 
-    private fun fixedOrderDiscussion(alivePlayers: List<Player>, allPlayers: AllPlayers) =
-        object : OpenDiscussion(alivePlayers, allPlayers) {
+    private fun fixedOrderDiscussion(playerManager: PlayerManager) =
+        object : OpenDiscussion(playerManager, 1) {
             override fun speakingOrder(speakers: List<Player>) = speakers
         }
 
@@ -45,10 +47,9 @@ class DiscussionTest {
             "Aliceこそ怪しい",
             "Aliceに投票します"
         ))
-        val players = listOf(alice, bob)
         val playerManager = TestLodge(alice to Role.VILLAGER, bob to Role.WEREWOLF).create().playerManager
 
-        fixedOrderDiscussion(players, AllPlayers(playerManager)).conduct()
+        fixedOrderDiscussion(playerManager).conduct()
 
         assertEquals(listOf(
             "Alice:said:私はBobが怪しいと思う",
@@ -77,21 +78,27 @@ class DiscussionTest {
 
     @Test
     fun `dead players receive all statements without speaking`() {
-        val alice = ScriptedPlayer(Role.VILLAGER, "Alice", listOf("村人として発言します", "続けて発言します", "最終発言です"))
-        val bob = ScriptedPlayer(Role.WEREWOLF, "Bob", listOf("人狼として発言します", "続けて発言します", "最終発言です"))
-        val charlie = ScriptedPlayer(Role.VILLAGER, "Charlie", emptyList())
-        val alivePlayers = listOf(alice, bob)
-        val playerManager = TestLodge(alice to Role.VILLAGER, bob to Role.WEREWOLF, charlie to Role.VILLAGER).create().playerManager
+        val alice = ScriptedPlayer(Role.VILLAGER, "Alice", listOf("村人として発言します", "続けて発言します", "最終発言です"), receivesExecutionEvent = true)
+        val bob = ScriptedPlayer(Role.WEREWOLF, "Bob", listOf("人狼として発言します", "続けて発言します", "最終発言です"), receivesExecutionEvent = true)
+        val charlie = ScriptedPlayer(Role.VILLAGER, "Charlie", listOf("同じく疑っています", "まだ様子見です", "最終判断します"), receivesExecutionEvent = true)
+        val victim = ScriptedPlayer(Role.VILLAGER, "Victim", emptyList(), receivesExecutionEvent = true)
+        val playerManager = TestLodge(
+            alice to Role.VILLAGER, bob to Role.WEREWOLF, charlie to Role.VILLAGER, victim to Role.VILLAGER
+        ).create().playerManager
+        playerManager.execute(victim)
 
-        fixedOrderDiscussion(alivePlayers, AllPlayers(playerManager)).conduct()
+        fixedOrderDiscussion(playerManager).conduct()
 
         assertEquals(listOf(
-            "Charlie:heard:Alice:村人として発言します",
-            "Charlie:heard:Bob:人狼として発言します",
-            "Charlie:heard:Alice:続けて発言します",
-            "Charlie:heard:Bob:続けて発言します",
-            "Charlie:heard:Alice:最終発言です",
-            "Charlie:heard:Bob:最終発言です",
-        ), charlie.log)
+            "Victim:heard:Alice:村人として発言します",
+            "Victim:heard:Bob:人狼として発言します",
+            "Victim:heard:Charlie:同じく疑っています",
+            "Victim:heard:Alice:続けて発言します",
+            "Victim:heard:Bob:続けて発言します",
+            "Victim:heard:Charlie:まだ様子見です",
+            "Victim:heard:Alice:最終発言です",
+            "Victim:heard:Bob:最終発言です",
+            "Victim:heard:Charlie:最終判断します",
+        ), victim.log)
     }
 }

--- a/src/test/kotlin/MadmanCpuStrategyTest.kt
+++ b/src/test/kotlin/MadmanCpuStrategyTest.kt
@@ -16,12 +16,28 @@ class MadmanCpuStrategyTest {
     )
 
     @Test
-    fun `fake seer reports an alive player as werewolf`() {
+    fun `fake seer reports NOT_WEREWOLF on first day`() {
         val strategy = MadmanCpuStrategy(madman, Role.SEER)
-        val result = strategy.discuss(listOf(madman, v1, v2))
+        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2), day = 1))
+        assertTrue(result is Statement.DivinationReport)
+        assertEquals(DivineResult.NOT_WEREWOLF, result.result)
+        assertNotSame(madman, result.target)
+    }
+
+    @Test
+    fun `fake seer reports WEREWOLF from second day onwards`() {
+        val strategy = MadmanCpuStrategy(madman, Role.SEER)
+        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2), day = 2))
         assertTrue(result is Statement.DivinationReport)
         assertEquals(DivineResult.WEREWOLF, result.result)
         assertNotSame(madman, result.target)
+    }
+
+    @Test
+    fun `fake seer stays silent from round 2 onwards`() {
+        val strategy = MadmanCpuStrategy(madman, Role.SEER)
+        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2), round = 2))
+        assertTrue(result is Statement.Plain)
     }
 
     @Test
@@ -30,7 +46,7 @@ class MadmanCpuStrategyTest {
         GameEvent.StatementMade.send(1, madman.name, Statement.DivinationReport(madman, v1, DivineResult.WEREWOLF), allPlayers)
         GameEvent.StatementMade.send(1, madman.name, Statement.DivinationReport(madman, v2, DivineResult.WEREWOLF), allPlayers)
 
-        val result = strategy.discuss(listOf(madman, v1, v2))
+        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2)))
         assertTrue(result is Statement.Plain)
     }
 
@@ -39,7 +55,7 @@ class MadmanCpuStrategyTest {
         val strategy = MadmanCpuStrategy(madman, Role.MEDIUM)
         GameEvent.PlayerExecuted.send(v1, allPlayers)
 
-        val result = strategy.discuss(listOf(madman, v2))
+        val result = strategy.buildStatement(openContext(listOf(madman, v2)))
         assertTrue(result is Statement.MediumReport)
         assertEquals(MediumResult.NOT_WEREWOLF, result.result)
         assertSame(v1, result.target)
@@ -48,7 +64,15 @@ class MadmanCpuStrategyTest {
     @Test
     fun `fake medium stays silent when no executions yet`() {
         val strategy = MadmanCpuStrategy(madman, Role.MEDIUM)
-        val result = strategy.discuss(listOf(madman, v1, v2))
+        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2)))
+        assertTrue(result is Statement.Plain)
+    }
+
+    @Test
+    fun `fake medium stays silent from round 2 onwards`() {
+        val strategy = MadmanCpuStrategy(madman, Role.MEDIUM)
+        GameEvent.PlayerExecuted.send(v1, allPlayers)
+        val result = strategy.buildStatement(openContext(listOf(madman, v2), round = 2))
         assertTrue(result is Statement.Plain)
     }
 
@@ -58,7 +82,7 @@ class MadmanCpuStrategyTest {
         GameEvent.PlayerExecuted.send(v1, allPlayers)
         GameEvent.StatementMade.send(1, madman.name, Statement.MediumReport(madman, v1, MediumResult.NOT_WEREWOLF), allPlayers)
 
-        val result = strategy.discuss(listOf(madman, v2))
+        val result = strategy.buildStatement(openContext(listOf(madman, v2)))
         assertTrue(result is Statement.Plain)
     }
 }

--- a/src/test/kotlin/NightPhaseTest.kt
+++ b/src/test/kotlin/NightPhaseTest.kt
@@ -25,7 +25,7 @@ class NightPhaseTest {
 
     private class ConclavingWolf(name: String) : ReceivingPlayer(Role.WEREWOLF, name) {
         val heardStatements = mutableListOf<GameEvent.WerewolfStatementMade>()
-        override fun discuss(players: List<Player>): Statement = Statement.Plain("")
+        override fun buildStatement(context: DiscussionContext): Statement = Statement.Plain("")
         override fun onReceive(event: GameEvent) {
             if (event is GameEvent.WerewolfStatementMade) heardStatements.add(event)
         }

--- a/src/test/kotlin/NothingPlayer.kt
+++ b/src/test/kotlin/NothingPlayer.kt
@@ -1,7 +1,7 @@
 package org.example
 
 open class NothingPlayer(role: Role, override val name: String) : Player(role) {
-    override fun discuss(players: List<Player>): Statement = error("discuss not expected")
+    override fun buildStatement(context: DiscussionContext): Statement = error("buildStatement not expected")
     override fun onReceive(event: GameEvent) { error("onReceive not expected") }
     override fun selectTarget(context: SelectionContext): Player = error("selectTarget not expected")
     override fun watchEpilogue(events: List<GameEvent>) { error("watchEpilogue not expected") }

--- a/src/test/kotlin/PocAiPlayerTest.kt
+++ b/src/test/kotlin/PocAiPlayerTest.kt
@@ -27,7 +27,7 @@ class PocAiPlayerTest {
     @Test
     fun `discuss returns Plain statement from input`() {
         val villager = PocAiPlayer(Role.VILLAGER, "Villager")
-        val (result, _) = withIO("hello\n") { villager.discuss(emptyList()) }
+        val (result, _) = withIO("hello\n") { villager.discuss(openContext()) }
         assertIs<Statement.Plain>(result)
         assertEquals("hello", result.text())
     }
@@ -54,7 +54,7 @@ class PocAiPlayerTest {
     fun `prompt includes received events in discuss output`() {
         val villager = PocAiPlayer(Role.VILLAGER, "Villager")
         GameEvent.RoleAssigned.send(Role.VILLAGER, villager)
-        val (_, output) = withIO("\n") { villager.discuss(emptyList()) }
+        val (_, output) = withIO("\n") { villager.discuss(openContext()) }
         assertContains(output, "役職通知")
     }
 

--- a/src/test/kotlin/RoleAwareCpuPlayerTest.kt
+++ b/src/test/kotlin/RoleAwareCpuPlayerTest.kt
@@ -14,7 +14,7 @@ class RoleAwareCpuPlayerTest {
         val setup = TestLodge(seer to Role.SEER, villager to Role.VILLAGER).create()
         setup.oracle.divine(seer, villager)
 
-        val statement = seer.discuss(emptyList())
+        val statement = seer.discuss(openContext())
 
         val report = assertIs<Statement.DivinationReport>(statement)
         assertEquals(seer, report.claimant)
@@ -44,7 +44,7 @@ class RoleAwareCpuPlayerTest {
         val setup = TestLodge(seer to Role.SEER, villager to Role.VILLAGER, wolf to Role.WEREWOLF).create()
         val allPlayers = AllPlayers(setup.playerManager)
         setup.oracle.divine(seer, wolf)
-        GameEvent.StatementMade.send(1, seer.name, seer.discuss(emptyList()), allPlayers)
+        GameEvent.StatementMade.send(1, seer.name, seer.discuss(openContext()), allPlayers)
 
         repeat(100) {
             val voted = villager.selectTarget(SelectionContext.Vote(villager, listOf(seer, villager, wolf)))
@@ -59,7 +59,7 @@ class RoleAwareCpuPlayerTest {
         val setup = TestLodge(medium to Role.MEDIUM, villager to Role.VILLAGER).create()
         setup.oracle.mediumReveal(medium, villager)
 
-        val statement = medium.discuss(emptyList())
+        val statement = medium.discuss(openContext())
 
         val report = assertIs<Statement.MediumReport>(statement)
         assertEquals(medium, report.claimant)
@@ -125,7 +125,7 @@ class RoleAwareCpuPlayerTest {
         val setup = TestLodge(seer to Role.SEER, villager to Role.VILLAGER, innocent to Role.VILLAGER, wolf to Role.WEREWOLF).create()
         val allPlayers = AllPlayers(setup.playerManager)
         setup.oracle.divine(seer, innocent)
-        GameEvent.StatementMade.send(1, seer.name, seer.discuss(emptyList()), allPlayers)
+        GameEvent.StatementMade.send(1, seer.name, seer.discuss(openContext()), allPlayers)
 
         repeat(100) {
             val voted = villager.selectTarget(SelectionContext.Vote(villager, listOf(seer, villager, innocent, wolf)))

--- a/src/test/kotlin/TestFactories.kt
+++ b/src/test/kotlin/TestFactories.kt
@@ -4,3 +4,9 @@ fun fakeCitizenWinSignal(): GameOverSignal = try {
     GameOverSignal.throwIfGameOver(AliveCounts(mapOf(Side.CITIZEN to 2, Side.WEREWOLF to 0)))
     error("unreachable")
 } catch (s: GameOverSignal) { s }
+
+fun openContext(
+    players: List<Player> = emptyList(),
+    round: Int = 1,
+    day: Int = 1,
+) = DiscussionContext.Open(round, day, players, players)


### PR DESCRIPTION
## Summary

- `StatementType` enum と `Statement.type` プロパティを追加
- `DiscussionContext` sealed class（`Open` / `Conclave`）を追加。`title`・`description`・`availableTypes` を型安全に渡せるようにした
- `Player.discuss` を final 化し `availableTypes` のバリデーションを追加、`buildStatement` を abstract として切り出し
- `PlayerIO.promptChoice` を追加、`ConsolePlayerIO` で実装
- `HumanPlayer.buildStatement` で発言タイプ選択・`DivinationReport` / `MediumReport` のプロンプトに対応
- `MadmanCpuStrategy`：1フェーズ1報告制限（round > 1 → 沈黙）、初日は白出し（NOT_WEREWOLF）
- `OpenDiscussion` が `PlayerManager` を受け取るよう変更し `Conclave` と統一。Conclave 中の HumanPlayer プロンプトが「密談」タイトルで表示されるようになった（closes #87）
- `TestSignals` → `TestFactories` にリネーム、`openContext()` ヘルパーを追加

## Test plan

- [x] `./gradlew check` が通ることを確認
- [x] `DiscussionTest`：`OpenDiscussion` 継承のまま dead player テストが通ることを確認
- [x] `MadmanCpuStrategyTest`：day=1 で NOT_WEREWOLF、day=2 で WEREWOLF、round=2 で沈黙のテストが追加されていることを確認

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)