### PR TITLE
Add structured response format to PocAiPlayer selectTarget

### DIFF
--- a/src/main/kotlin/PocAiPlayer.kt
+++ b/src/main/kotlin/PocAiPlayer.kt
@@ -14,14 +14,24 @@ class PocAiPlayer(role: Role, override val name: String) : Player(role) {
 
     override fun selectTarget(context: SelectionContext): Player {
         val candidates = context.candidates()
-        val candidateNames = candidates.joinToString(", ") { it.name }
-        printPrompt("${context.title}：${context.description}（候補: $candidateNames）")
-        while (true) {
+        val candidateNames = candidates.joinToString("、") { it.name }
+        val instruction = """
+            ${context.title}：${context.description}
+
+            候補：$candidateNames
+
+            「候補名：選んだ理由」の形式で答えてください。
+            例：${candidates.first().name}：最も怪しいと思うため
+        """.trimIndent()
+        repeat(2) {
+            printPrompt(instruction)
             val input = readLine()?.trim() ?: ""
-            val target = candidates.firstOrNull { it.name == input }
+            val playerName = input.split("：", ":").first().trim()
+            val target = candidates.firstOrNull { it.name == playerName }
             if (target != null) return target
-            println("「$input」は候補にいません。再入力してください。")
         }
+        // 2回失敗したためランダムで選択
+        return candidates.random()
     }
 
     override fun watchEpilogue(events: List<GameEvent>) {

--- a/src/main/kotlin/PocAiPlayer.kt
+++ b/src/main/kotlin/PocAiPlayer.kt
@@ -20,7 +20,7 @@ class PocAiPlayer(role: Role, override val name: String) : Player(role) {
 
             候補：$candidateNames
 
-            「候補名：選んだ理由」の形式で答えてください。
+            「候補名：選んだ理由（200文字以内）」の形式で答えてください。
             例：${candidates.first().name}：最も怪しいと思うため
         """.trimIndent()
         repeat(2) {

--- a/src/test/kotlin/PocAiPlayerTest.kt
+++ b/src/test/kotlin/PocAiPlayerTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 class PocAiPlayerTest {
 
@@ -33,21 +34,39 @@ class PocAiPlayerTest {
     }
 
     @Test
-    fun `selectTarget returns matching player`() {
+    fun `selectTarget returns matching player from name-colon-reason format`() {
         val villager = PocAiPlayer(Role.VILLAGER, "Villager")
         val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
         val context = SelectionContext.Vote(villager, listOf(villager, wolf))
-        val (result, _) = withIO("Wolf\n") { villager.selectTarget(context) }
+        val (result, _) = withIO("Wolf：怪しいから\n") { villager.selectTarget(context) }
         assertEquals(wolf, result)
     }
 
     @Test
-    fun `selectTarget retries on invalid input then returns correct player`() {
+    fun `selectTarget retries when player name is not a candidate`() {
         val villager = PocAiPlayer(Role.VILLAGER, "Villager")
         val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
         val context = SelectionContext.Vote(villager, listOf(villager, wolf))
-        val (result, _) = withIO("Unknown\nWolf\n") { villager.selectTarget(context) }
+        val (result, _) = withIO("Unknown：理由\nWolf：怪しいから\n") { villager.selectTarget(context) }
         assertEquals(wolf, result)
+    }
+
+    @Test
+    fun `selectTarget falls back to random candidate after two invalid responses`() {
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager")
+        val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
+        val context = SelectionContext.Vote(villager, listOf(villager, wolf))
+        val (result, _) = withIO("Unknown：理由\nAlsoUnknown：理由\n") { villager.selectTarget(context) }
+        assertTrue(result in context.candidates())
+    }
+
+    @Test
+    fun `selectTarget prompt includes format instruction`() {
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager")
+        val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
+        val context = SelectionContext.Vote(villager, listOf(villager, wolf))
+        val (_, output) = withIO("Wolf：怪しいから\n") { villager.selectTarget(context) }
+        assertContains(output, "候補名：選んだ理由")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `selectTarget` の指示文に「候補名：選んだ理由」の回答形式を明記
- `：` または `:` で区切った先頭部分をプレイヤー名として解釈
- 無効な回答は1回リトライ、2回失敗したらランダム選択にフォールバック（API呼び出し料金の無制限増加を防止）

## Test plan

- [ ] `selectTarget returns matching player from name-colon-reason format`：新形式で正しく返ることを確認
- [ ] `selectTarget retries when player name is not a candidate`：1回失敗後に再プロンプトして成功することを確認
- [ ] `selectTarget falls back to random candidate after two invalid responses`：2回失敗後に候補内からランダム選択されることを確認
- [ ] `selectTarget prompt includes format instruction`：指示文に形式説明が含まれることを確認
- [ ] `./gradlew check` が通ることを確認

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)