### PR TITLE
Use English names and expand PocAiLodge to 9 players

### DIFF
--- a/src/main/kotlin/PocAiLodge.kt
+++ b/src/main/kotlin/PocAiLodge.kt
@@ -1,11 +1,13 @@
 package org.example
 
 object PocAiLodge : Lodge() {
+    private val names = listOf("Alice", "Bob", "Charlie", "Dave", "Eve", "Frank", "Grace", "Heidi", "Ivan")
+
     override fun assignments(): List<Pair<Player, Role>> {
         val roles = listOf(
-            Role.HUNTER, Role.VILLAGER, Role.MADMAN,
+            Role.HUNTER, Role.VILLAGER, Role.VILLAGER, Role.VILLAGER, Role.MADMAN,
             Role.WEREWOLF, Role.SEER, Role.MEDIUM, Role.WEREWOLF,
         ).shuffled()
-        return roles.mapIndexed { i, role -> PocAiPlayer(role, "${i + 1}") to role }
+        return roles.mapIndexed { i, role -> PocAiPlayer(role, names[i]) to role }
     }
 }

--- a/src/main/kotlin/PocAiPlayer.kt
+++ b/src/main/kotlin/PocAiPlayer.kt
@@ -67,7 +67,7 @@ class PocAiPlayer(role: Role, override val name: String) : Player(role) {
 
     private val gameDescription = """
 あなたはプレイヤー${name}です。あなたの役職はゲームの流れの「役職通知」をご確認ください。
-役職構成：人狼2・狂人1・村人1・占い師1・霊能者1・狩人1（計7人）
+役職構成：人狼2・狂人1・村人3・占い師1・霊能者1・狩人1（計9人）
 
 【勝利条件】
 村人（村人・占い師・霊能者・狩人）：人狼が全員死亡すれば勝利


### PR DESCRIPTION
## Summary

- `PocAiLodge` のプレイヤー名を `"1"〜"7"` から英語名（Alice, Bob, Charlie, Dave, Eve, Frank, Grace, Heidi, Ivan）に変更
- 役職構成を7人から9人に拡大（VILLAGER を2つ追加）
- `PocAiPlayer.gameDescription` の役職構成説明を新構成に合わせて更新

## Test plan

- [ ] `./gradlew check` が通ること

Closes #171
Closes #172

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)