### PR TITLE
Clarify Vote description to mention execution

### DIFF
--- a/src/main/kotlin/SelectionContext.kt
+++ b/src/main/kotlin/SelectionContext.kt
@@ -19,7 +19,7 @@ sealed class SelectionContext(val title: String, val description: String) {
     }
 
     class Vote(private val self: Player, private val players: List<Player>)
-        : SelectionContext("投票", "投票先を選んでください") {
+        : SelectionContext("投票", "処刑する人を選んでください") {
         override fun candidates() = players.filterNot { it === self }
     }
 }


### PR DESCRIPTION
## Summary

- `SelectionContext.Vote` の description を「投票先を選んでください」→「処刑する人を選んでください」に変更
- テストプレイで何に投票するかが伝わりにくいと判明したため

## Test plan

- [ ] `./gradlew check` が通ること

Related to #173

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)