### PR TITLE
Separate public statement from intent in buildStatement prompt

### DIFF
--- a/src/main/kotlin/PocAiPlayer.kt
+++ b/src/main/kotlin/PocAiPlayer.kt
@@ -8,8 +8,21 @@ class PocAiPlayer(role: Role, override val name: String) : Player(role) {
     }
 
     override fun buildStatement(context: DiscussionContext): Statement {
-        printPrompt("【${context.title}】${context.description}\n50文字以内で発言してください")
-        return Statement.Plain(readLine()?.trim() ?: "")
+        val instruction = """
+            【${context.title}】${context.description}
+
+            以下の形式で発言してください。
+            ゲーム上の発言（100文字以内）[発言の真意（100文字以内）]
+            例：占い師です。Aliceは白でした。[狂人として占い師を偽装し、信用を得るための発言]
+        """.trimIndent()
+        repeat(2) {
+            printPrompt(instruction)
+            val input = readLine()?.trim() ?: ""
+            val separatorIdx = input.indexOf("[").takeIf { it >= 0 }
+            if (separatorIdx != null) return Statement.Plain(input.substring(0, separatorIdx).trim())
+        }
+        // 2回失敗したため空文字を返す
+        return Statement.Plain("")
     }
 
     override fun selectTarget(context: SelectionContext): Player {

--- a/src/test/kotlin/PocAiPlayerTest.kt
+++ b/src/test/kotlin/PocAiPlayerTest.kt
@@ -26,11 +26,34 @@ class PocAiPlayerTest {
     }
 
     @Test
-    fun `discuss returns Plain statement from input`() {
+    fun `discuss extracts statement before bracket from input`() {
         val villager = PocAiPlayer(Role.VILLAGER, "Villager")
-        val (result, _) = withIO("hello\n") { villager.discuss(openContext()) }
+        val (result, _) = withIO("hello[真意]\n") { villager.discuss(openContext()) }
         assertIs<Statement.Plain>(result)
         assertEquals("hello", result.text())
+    }
+
+    @Test
+    fun `discuss retries when bracket is missing and returns empty string after two failures`() {
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager")
+        val (result, _) = withIO("no bracket\nno bracket\n") { villager.discuss(openContext()) }
+        assertIs<Statement.Plain>(result)
+        assertEquals("", result.text())
+    }
+
+    @Test
+    fun `discuss retries and succeeds on second input`() {
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager")
+        val (result, _) = withIO("no bracket\nhello[真意]\n") { villager.discuss(openContext()) }
+        assertIs<Statement.Plain>(result)
+        assertEquals("hello", result.text())
+    }
+
+    @Test
+    fun `discuss prompt includes format instruction`() {
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager")
+        val (_, output) = withIO("hello[真意]\n") { villager.discuss(openContext()) }
+        assertContains(output, "ゲーム上の発言（100文字以内）[発言の真意（100文字以内）]")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `buildStatement` の回答形式を「ゲーム上の発言（100文字以内）[発言の真意（100文字以内）]」に変更
- `[` より前の部分のみを `Statement.Plain` に渡すようパース
- 形式不正が2回続いた場合は空文字にフォールバック（全入力を使うと真意が発言に漏洩するため）

## Test plan

- [ ] `./gradlew check` が通ること
- [ ] テストプレイで演技の自然さが改善されるか確認する

Closes #170

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)