### PR TITLE
Introduce LanguageModel interface to decouple PocAiPlayer from console IO

### DIFF
--- a/src/main/kotlin/ConsoleLanguageModel.kt
+++ b/src/main/kotlin/ConsoleLanguageModel.kt
@@ -1,0 +1,9 @@
+package org.example
+
+class ConsoleLanguageModel : LanguageModel {
+    override fun ask(prompt: String): String? {
+        println(prompt)
+        print("回答 > ")
+        return readLine()?.trim()
+    }
+}

--- a/src/main/kotlin/LanguageModel.kt
+++ b/src/main/kotlin/LanguageModel.kt
@@ -1,0 +1,5 @@
+package org.example
+
+interface LanguageModel {
+    fun ask(prompt: String): String?
+}

--- a/src/main/kotlin/PocAiLodge.kt
+++ b/src/main/kotlin/PocAiLodge.kt
@@ -8,6 +8,6 @@ object PocAiLodge : Lodge() {
             Role.HUNTER, Role.VILLAGER, Role.VILLAGER, Role.VILLAGER, Role.MADMAN,
             Role.WEREWOLF, Role.SEER, Role.MEDIUM, Role.WEREWOLF,
         ).shuffled()
-        return roles.mapIndexed { i, role -> PocAiPlayer(role, names[i]) to role }
+        return roles.mapIndexed { i, role -> PocAiPlayer(role, names[i], ConsoleLanguageModel()) to role }
     }
 }

--- a/src/main/kotlin/PocAiPlayer.kt
+++ b/src/main/kotlin/PocAiPlayer.kt
@@ -1,6 +1,10 @@
 package org.example
 
-class PocAiPlayer(role: Role, override val name: String) : Player(role) {
+class PocAiPlayer(
+    role: Role,
+    override val name: String,
+    private val languageModel: LanguageModel = ConsoleLanguageModel(),
+) : Player(role) {
     private val eventLog = mutableListOf<GameEvent>()
 
     override fun onReceive(event: GameEvent) {
@@ -16,8 +20,7 @@ class PocAiPlayer(role: Role, override val name: String) : Player(role) {
             例：占い師です。Aliceは白でした。[狂人として占い師を偽装し、信用を得るための発言]
         """.trimIndent()
         repeat(2) {
-            printPrompt(instruction)
-            val input = readLine()?.trim() ?: ""
+            val input = prompt(instruction) ?: ""
             val separatorIdx = input.indexOf("[").takeIf { it >= 0 }
             if (separatorIdx != null) return Statement.Plain(input.substring(0, separatorIdx).trim())
         }
@@ -37,8 +40,7 @@ class PocAiPlayer(role: Role, override val name: String) : Player(role) {
             例：${candidates.first().name}：最も怪しいと思うため
         """.trimIndent()
         repeat(2) {
-            printPrompt(instruction)
-            val input = readLine()?.trim() ?: ""
+            val input = prompt(instruction) ?: ""
             val playerName = input.split("：", ":").first().trim()
             val target = candidates.firstOrNull { it.name == playerName }
             if (target != null) return target
@@ -48,29 +50,32 @@ class PocAiPlayer(role: Role, override val name: String) : Player(role) {
     }
 
     override fun watchEpilogue(events: List<GameEvent>) {
-        println()
-        println("=== エピローグ（プレイヤー $name） ===")
-        events.forEach { println("[${it.recipientName}] [${it.title}] ${it.body()}") }
-        printPrompt("プレイヤーとして200文字以内でゲームの振り返りをしてください。")
-        readLine()
+        val instruction = buildString {
+            appendLine("=== エピローグ（プレイヤー $name） ===")
+            events.forEach { appendLine("[${it.recipientName}] [${it.title}] ${it.body()}") }
+            append("プレイヤーとして200文字以内でゲームの振り返りをしてください。")
+        }
+        prompt(instruction)
     }
 
-    private fun printPrompt(instruction: String) {
-        println()
-        println(SEPARATOR)
-        println("AIプレイヤー $name へのプロンプト")
-        println(SEPARATOR)
-        println("【指示】")
-        println(instruction)
-        println()
-        println("【ゲームの説明】")
-        println(gameDescription)
-        println()
-        println("【ここまでのゲームの流れ】")
-        if (eventLog.isEmpty()) println("（なし）")
-        else eventLog.forEach { println("[${it.title}] ${it.body()}") }
-        println(SEPARATOR)
-        print("回答 > ")
+    private fun prompt(instruction: String): String? {
+        val fullPrompt = buildString {
+            appendLine()
+            appendLine(SEPARATOR)
+            appendLine("AIプレイヤー $name へのプロンプト")
+            appendLine(SEPARATOR)
+            appendLine("【指示】")
+            appendLine(instruction)
+            appendLine()
+            appendLine("【ゲームの説明】")
+            appendLine(gameDescription)
+            appendLine()
+            appendLine("【ここまでのゲームの流れ】")
+            if (eventLog.isEmpty()) appendLine("（なし）")
+            else eventLog.forEach { appendLine("[${it.title}] ${it.body()}") }
+            append(SEPARATOR)
+        }
+        return languageModel.ask(fullPrompt)
     }
 
     companion object {

--- a/src/main/kotlin/PocAiPlayer.kt
+++ b/src/main/kotlin/PocAiPlayer.kt
@@ -3,7 +3,7 @@ package org.example
 class PocAiPlayer(
     role: Role,
     override val name: String,
-    private val languageModel: LanguageModel = ConsoleLanguageModel(),
+    private val languageModel: LanguageModel,
 ) : Player(role) {
     private val eventLog = mutableListOf<GameEvent>()
 

--- a/src/test/kotlin/PocAiPlayerTest.kt
+++ b/src/test/kotlin/PocAiPlayerTest.kt
@@ -1,8 +1,5 @@
 package org.example
 
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
-import java.io.PrintStream
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -11,106 +8,109 @@ import kotlin.test.assertTrue
 
 class PocAiPlayerTest {
 
-    private fun <T> withIO(input: String, block: () -> T): Pair<T, String> {
-        val originalIn = System.`in`
-        val originalOut = System.out
-        val buffer = ByteArrayOutputStream()
-        System.setIn(ByteArrayInputStream(input.toByteArray()))
-        System.setOut(PrintStream(buffer))
-        try {
-            return block() to buffer.toString()
-        } finally {
-            System.setIn(originalIn)
-            System.setOut(originalOut)
+    private class FakeLanguageModel(vararg responses: String) : LanguageModel {
+        private val responseQueue = ArrayDeque(responses.toList())
+        val prompts = mutableListOf<String>()
+
+        override fun ask(prompt: String): String? {
+            prompts.add(prompt)
+            return responseQueue.removeFirstOrNull()
         }
     }
 
     @Test
     fun `discuss extracts statement before bracket from input`() {
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", ConsoleLanguageModel())
-        val (result, _) = withIO("hello[真意]\n") { villager.discuss(openContext()) }
+        val lm = FakeLanguageModel("hello[真意]")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
+        val result = villager.discuss(openContext())
         assertIs<Statement.Plain>(result)
         assertEquals("hello", result.text())
     }
 
     @Test
     fun `discuss retries when bracket is missing and returns empty string after two failures`() {
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", ConsoleLanguageModel())
-        val (result, _) = withIO("no bracket\nno bracket\n") { villager.discuss(openContext()) }
+        val lm = FakeLanguageModel("no bracket", "no bracket")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
+        val result = villager.discuss(openContext())
         assertIs<Statement.Plain>(result)
         assertEquals("", result.text())
     }
 
     @Test
     fun `discuss retries and succeeds on second input`() {
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", ConsoleLanguageModel())
-        val (result, _) = withIO("no bracket\nhello[真意]\n") { villager.discuss(openContext()) }
+        val lm = FakeLanguageModel("no bracket", "hello[真意]")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
+        val result = villager.discuss(openContext())
         assertIs<Statement.Plain>(result)
         assertEquals("hello", result.text())
     }
 
     @Test
     fun `discuss prompt includes format instruction`() {
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", ConsoleLanguageModel())
-        val (_, output) = withIO("hello[真意]\n") { villager.discuss(openContext()) }
-        assertContains(output, "ゲーム上の発言（100文字以内）[発言の真意（100文字以内）]")
+        val lm = FakeLanguageModel("hello[真意]")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
+        villager.discuss(openContext())
+        assertContains(lm.prompts.first(), "ゲーム上の発言（100文字以内）[発言の真意（100文字以内）]")
     }
 
     @Test
     fun `selectTarget returns matching player from name-colon-reason format`() {
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", ConsoleLanguageModel())
+        val lm = FakeLanguageModel("Wolf：怪しいから")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
         val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
         val context = SelectionContext.Vote(villager, listOf(villager, wolf))
-        val (result, _) = withIO("Wolf：怪しいから\n") { villager.selectTarget(context) }
+        val result = villager.selectTarget(context)
         assertEquals(wolf, result)
     }
 
     @Test
     fun `selectTarget retries when player name is not a candidate`() {
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", ConsoleLanguageModel())
+        val lm = FakeLanguageModel("Unknown：理由", "Wolf：怪しいから")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
         val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
         val context = SelectionContext.Vote(villager, listOf(villager, wolf))
-        val (result, _) = withIO("Unknown：理由\nWolf：怪しいから\n") { villager.selectTarget(context) }
+        val result = villager.selectTarget(context)
         assertEquals(wolf, result)
     }
 
     @Test
     fun `selectTarget falls back to random candidate after two invalid responses`() {
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", ConsoleLanguageModel())
+        val lm = FakeLanguageModel("Unknown：理由", "AlsoUnknown：理由")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
         val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
         val context = SelectionContext.Vote(villager, listOf(villager, wolf))
-        val (result, _) = withIO("Unknown：理由\nAlsoUnknown：理由\n") { villager.selectTarget(context) }
+        val result = villager.selectTarget(context)
         assertTrue(result in context.candidates())
     }
 
     @Test
     fun `selectTarget prompt includes format instruction`() {
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", ConsoleLanguageModel())
+        val lm = FakeLanguageModel("Wolf：怪しいから")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
         val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
         val context = SelectionContext.Vote(villager, listOf(villager, wolf))
-        val (_, output) = withIO("Wolf：怪しいから\n") { villager.selectTarget(context) }
-        assertContains(output, "候補名：選んだ理由")
+        villager.selectTarget(context)
+        assertContains(lm.prompts.first(), "候補名：選んだ理由")
     }
 
     @Test
-    fun `prompt includes received events in discuss output`() {
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", ConsoleLanguageModel())
+    fun `prompt includes received events`() {
+        val lm = FakeLanguageModel("")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
         GameEvent.RoleAssigned.send(Role.VILLAGER, villager)
-        val (_, output) = withIO("\n") { villager.discuss(openContext()) }
-        assertContains(output, "役職通知")
+        villager.discuss(openContext())
+        assertContains(lm.prompts.first(), "役職通知")
     }
 
     @Test
-    fun `watchEpilogue prints event recipientName, title and body, then prompts for reflection`() {
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", ConsoleLanguageModel())
-        // ① 通常ルートでイベントを送る
+    fun `watchEpilogue prompt includes event recipientName, title, body and reflection instruction`() {
+        val lm = FakeLanguageModel("")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
         GameEvent.RoleAssigned.send(Role.VILLAGER, villager)
-        // ② fakeのGameOverSignalでknowledgeを取り出す
         val events = villager.revealKnowledge(fakeCitizenWinSignal())
-        // ③ watchEpilogueに渡して出力を検証（printPromptのreadLine分の入力を用意）
-        val (_, output) = withIO("\n") { villager.watchEpilogue(events) }
-        assertContains(output, "Villager")
-        assertContains(output, "役職通知")
-        assertContains(output, "振り返り")
+        villager.watchEpilogue(events)
+        assertContains(lm.prompts.first(), "Villager")
+        assertContains(lm.prompts.first(), "役職通知")
+        assertContains(lm.prompts.first(), "振り返り")
     }
 }

--- a/src/test/kotlin/PocAiPlayerTest.kt
+++ b/src/test/kotlin/PocAiPlayerTest.kt
@@ -27,7 +27,7 @@ class PocAiPlayerTest {
 
     @Test
     fun `discuss extracts statement before bracket from input`() {
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", ConsoleLanguageModel())
         val (result, _) = withIO("hello[真意]\n") { villager.discuss(openContext()) }
         assertIs<Statement.Plain>(result)
         assertEquals("hello", result.text())
@@ -35,7 +35,7 @@ class PocAiPlayerTest {
 
     @Test
     fun `discuss retries when bracket is missing and returns empty string after two failures`() {
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", ConsoleLanguageModel())
         val (result, _) = withIO("no bracket\nno bracket\n") { villager.discuss(openContext()) }
         assertIs<Statement.Plain>(result)
         assertEquals("", result.text())
@@ -43,7 +43,7 @@ class PocAiPlayerTest {
 
     @Test
     fun `discuss retries and succeeds on second input`() {
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", ConsoleLanguageModel())
         val (result, _) = withIO("no bracket\nhello[真意]\n") { villager.discuss(openContext()) }
         assertIs<Statement.Plain>(result)
         assertEquals("hello", result.text())
@@ -51,14 +51,14 @@ class PocAiPlayerTest {
 
     @Test
     fun `discuss prompt includes format instruction`() {
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", ConsoleLanguageModel())
         val (_, output) = withIO("hello[真意]\n") { villager.discuss(openContext()) }
         assertContains(output, "ゲーム上の発言（100文字以内）[発言の真意（100文字以内）]")
     }
 
     @Test
     fun `selectTarget returns matching player from name-colon-reason format`() {
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", ConsoleLanguageModel())
         val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
         val context = SelectionContext.Vote(villager, listOf(villager, wolf))
         val (result, _) = withIO("Wolf：怪しいから\n") { villager.selectTarget(context) }
@@ -67,7 +67,7 @@ class PocAiPlayerTest {
 
     @Test
     fun `selectTarget retries when player name is not a candidate`() {
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", ConsoleLanguageModel())
         val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
         val context = SelectionContext.Vote(villager, listOf(villager, wolf))
         val (result, _) = withIO("Unknown：理由\nWolf：怪しいから\n") { villager.selectTarget(context) }
@@ -76,7 +76,7 @@ class PocAiPlayerTest {
 
     @Test
     fun `selectTarget falls back to random candidate after two invalid responses`() {
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", ConsoleLanguageModel())
         val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
         val context = SelectionContext.Vote(villager, listOf(villager, wolf))
         val (result, _) = withIO("Unknown：理由\nAlsoUnknown：理由\n") { villager.selectTarget(context) }
@@ -85,7 +85,7 @@ class PocAiPlayerTest {
 
     @Test
     fun `selectTarget prompt includes format instruction`() {
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", ConsoleLanguageModel())
         val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
         val context = SelectionContext.Vote(villager, listOf(villager, wolf))
         val (_, output) = withIO("Wolf：怪しいから\n") { villager.selectTarget(context) }
@@ -94,7 +94,7 @@ class PocAiPlayerTest {
 
     @Test
     fun `prompt includes received events in discuss output`() {
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", ConsoleLanguageModel())
         GameEvent.RoleAssigned.send(Role.VILLAGER, villager)
         val (_, output) = withIO("\n") { villager.discuss(openContext()) }
         assertContains(output, "役職通知")
@@ -102,7 +102,7 @@ class PocAiPlayerTest {
 
     @Test
     fun `watchEpilogue prints event recipientName, title and body, then prompts for reflection`() {
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", ConsoleLanguageModel())
         // ① 通常ルートでイベントを送る
         GameEvent.RoleAssigned.send(Role.VILLAGER, villager)
         // ② fakeのGameOverSignalでknowledgeを取り出す


### PR DESCRIPTION
## Summary

- `LanguageModel` インターフェースを新規追加（`ask(prompt: String): String?`）
- `ConsoleLanguageModel` でコンソール実装（現状の `println`/`readLine()` 動作を移植）
- `PocAiPlayer` が `LanguageModel` を受け取り、`println`/`readLine()` を直接呼ばなくなった
- `PocAiLodge` が `ConsoleLanguageModel` を明示的に渡すよう更新
- `PocAiPlayerTest` を `FakeLanguageModel` ベースに書き換え、`System.in`/`System.out` の差し替えが不要になった

将来的に Claude / ChatGPT / Gemini の API 実装を `LanguageModel` として差し込むことができる。

## Test plan

- [x] `./gradlew check` が通ること

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)