### PR TITLE
Introduce Recallable to unify GameEvent in a shared timeline

### DIFF
--- a/src/main/kotlin/CpuPlayer.kt
+++ b/src/main/kotlin/CpuPlayer.kt
@@ -1,5 +1,5 @@
 package org.example
 
 abstract class CpuPlayer(role: Role) : Player(role) {
-    override fun watchEpilogue(events: List<GameEvent>) = Unit
+    override fun watchEpilogue(memories: List<Recallable>) = Unit
 }

--- a/src/main/kotlin/CpuPlayer.kt
+++ b/src/main/kotlin/CpuPlayer.kt
@@ -1,5 +1,5 @@
 package org.example
 
 abstract class CpuPlayer(role: Role) : Player(role) {
-    override fun watchEpilogue(memories: List<Recallable>) = Unit
+    override fun watchEpilogue(chronicles: List<Recallable>) = Unit
 }

--- a/src/main/kotlin/GameEvent.kt
+++ b/src/main/kotlin/GameEvent.kt
@@ -3,12 +3,12 @@ package org.example
 // Each subclass must have a private constructor and a companion send() function
 // that creates and dispatches atomically. This ensures notification targets are
 // always defined explicitly at the point of creation.
-sealed class GameEvent {
-    val sequenceId: Long = System.nanoTime()
+sealed class GameEvent : Recallable() {
     abstract val title: String
     abstract fun body(): String
     protected abstract val recipients: Notifiable
-    val recipientName: String get() = recipients.recipientName
+    override fun recall() = "[${title}] ${body()}"
+    override fun chronicle() = "[${recipients.recipientName}] [${title}] ${body()}"
     protected fun dispatch() = recipients.receive(this)
     fun isPublicKnowledge(): Boolean = recipients is AllPlayers
 

--- a/src/main/kotlin/GameRecap.kt
+++ b/src/main/kotlin/GameRecap.kt
@@ -1,9 +1,9 @@
 package org.example
 
 class GameRecap(private val playerManager: PlayerManager, private val signal: GameOverSignal) {
-    fun events(): List<GameEvent> =
+    fun events(): List<Recallable> =
         playerManager.allPlayers
-            .flatMap { it.revealKnowledge(signal) }
+            .flatMap { it.reveal(signal) }
             .distinct()
             .sortedBy { it.sequenceId }
 }

--- a/src/main/kotlin/HumanPlayer.kt
+++ b/src/main/kotlin/HumanPlayer.kt
@@ -41,8 +41,8 @@ class HumanPlayer(role: Role, override val name: String, private val io: PlayerI
         return Statement.MediumReport(this, target, results[resultIdx])
     }
 
-    override fun watchEpilogue(memories: List<Recallable>) {
-        val content = memories.joinToString("\n") { "  ${it.chronicle()}" }
+    override fun watchEpilogue(chronicles: List<Recallable>) {
+        val content = chronicles.joinToString("\n") { "  ${it.chronicle()}" }
         io.sendMessage(name, "ゲーム振り返り", content)
     }
 }

--- a/src/main/kotlin/HumanPlayer.kt
+++ b/src/main/kotlin/HumanPlayer.kt
@@ -41,8 +41,8 @@ class HumanPlayer(role: Role, override val name: String, private val io: PlayerI
         return Statement.MediumReport(this, target, results[resultIdx])
     }
 
-    override fun watchEpilogue(events: List<GameEvent>) {
-        val content = events.joinToString("\n") { "  ${it.recipientName}: [${it.title}] ${it.body()}" }
+    override fun watchEpilogue(memories: List<Recallable>) {
+        val content = memories.joinToString("\n") { "  ${it.chronicle()}" }
         io.sendMessage(name, "ゲーム振り返り", content)
     }
 }

--- a/src/main/kotlin/Player.kt
+++ b/src/main/kotlin/Player.kt
@@ -3,10 +3,10 @@ package org.example
 abstract class Player(private val role: Role) : Notifiable {
     abstract val name: String
     override val recipientName: String get() = name
-    private val _knowledge: MutableList<GameEvent> = mutableListOf()
+    private val _memories: MutableList<Recallable> = mutableListOf()
 
     final override fun receive(event: GameEvent) {
-        _knowledge.add(event)
+        _memories.add(event)
         onReceive(event)
     }
 
@@ -18,12 +18,12 @@ abstract class Player(private val role: Role) : Notifiable {
         return statement
     }
     protected abstract fun buildStatement(context: DiscussionContext): Statement
-    abstract fun watchEpilogue(events: List<GameEvent>)
+    abstract fun watchEpilogue(memories: List<Recallable>)
 
-    // signal is a capability token: only callers who hold a GameOverSignal (i.e., after game over) can access knowledge
+    // signal is a capability token: only callers who hold a GameOverSignal (i.e., after game over) can access memories
     @Suppress("UnusedParameter")
-    fun revealKnowledge(signal: GameOverSignal): List<GameEvent> = _knowledge.toList()
+    fun reveal(signal: GameOverSignal): List<Recallable> = _memories.toList()
 
     fun buildNightAction(players: List<Player>, isFirstNight: Boolean): NightAction =
-        role.buildNightAction(this, players, isFirstNight, _knowledge.toList())
+        role.buildNightAction(this, players, isFirstNight, _memories.filterIsInstance<GameEvent>())
 }

--- a/src/main/kotlin/Player.kt
+++ b/src/main/kotlin/Player.kt
@@ -3,6 +3,9 @@ package org.example
 abstract class Player(private val role: Role) : Notifiable {
     abstract val name: String
     override val recipientName: String get() = name
+    // role and _memories are each player's private information and must not be visible to other players.
+    // protected would allow subclasses to access any Player instance's data without casting,
+    // breaking information asymmetry. Subclasses that need their own memories should manage a separate copy.
     private val _memories: MutableList<Recallable> = mutableListOf()
 
     final override fun receive(event: GameEvent) {

--- a/src/main/kotlin/Player.kt
+++ b/src/main/kotlin/Player.kt
@@ -21,7 +21,7 @@ abstract class Player(private val role: Role) : Notifiable {
         return statement
     }
     protected abstract fun buildStatement(context: DiscussionContext): Statement
-    abstract fun watchEpilogue(memories: List<Recallable>)
+    abstract fun watchEpilogue(chronicles: List<Recallable>)
 
     // signal is a capability token: only callers who hold a GameOverSignal (i.e., after game over) can access memories
     @Suppress("UnusedParameter")

--- a/src/main/kotlin/PocAiPlayer.kt
+++ b/src/main/kotlin/PocAiPlayer.kt
@@ -5,10 +5,10 @@ class PocAiPlayer(
     override val name: String,
     private val languageModel: LanguageModel,
 ) : Player(role) {
-    private val eventLog = mutableListOf<GameEvent>()
+    private val _myMemories = mutableListOf<Recallable>()
 
     override fun onReceive(event: GameEvent) {
-        eventLog.add(event)
+        _myMemories.add(event)
     }
 
     override fun buildStatement(context: DiscussionContext): Statement {
@@ -49,10 +49,10 @@ class PocAiPlayer(
         return candidates.random()
     }
 
-    override fun watchEpilogue(events: List<GameEvent>) {
+    override fun watchEpilogue(memories: List<Recallable>) {
         val instruction = buildString {
             appendLine("=== エピローグ（プレイヤー $name） ===")
-            events.forEach { appendLine("[${it.recipientName}] [${it.title}] ${it.body()}") }
+            memories.forEach { appendLine(it.chronicle()) }
             append("プレイヤーとして200文字以内でゲームの振り返りをしてください。")
         }
         prompt(instruction)
@@ -71,8 +71,8 @@ class PocAiPlayer(
             appendLine(gameDescription)
             appendLine()
             appendLine("【ここまでのゲームの流れ】")
-            if (eventLog.isEmpty()) appendLine("（なし）")
-            else eventLog.forEach { appendLine("[${it.title}] ${it.body()}") }
+            if (_myMemories.isEmpty()) appendLine("（なし）")
+            else _myMemories.forEach { appendLine(it.recall()) }
             append(SEPARATOR)
         }
         return languageModel.ask(fullPrompt)

--- a/src/main/kotlin/PocAiPlayer.kt
+++ b/src/main/kotlin/PocAiPlayer.kt
@@ -49,10 +49,10 @@ class PocAiPlayer(
         return candidates.random()
     }
 
-    override fun watchEpilogue(memories: List<Recallable>) {
+    override fun watchEpilogue(chronicles: List<Recallable>) {
         val instruction = buildString {
             appendLine("=== エピローグ（プレイヤー $name） ===")
-            memories.forEach { appendLine(it.chronicle()) }
+            chronicles.forEach { appendLine(it.chronicle()) }
             append("プレイヤーとして200文字以内でゲームの振り返りをしてください。")
         }
         prompt(instruction)

--- a/src/main/kotlin/Recallable.kt
+++ b/src/main/kotlin/Recallable.kt
@@ -1,0 +1,7 @@
+package org.example
+
+abstract class Recallable {
+    val sequenceId: Long = System.nanoTime()
+    abstract fun recall(): String
+    abstract fun chronicle(): String
+}

--- a/src/test/kotlin/EpilogueTest.kt
+++ b/src/test/kotlin/EpilogueTest.kt
@@ -9,7 +9,7 @@ class EpilogueTest {
     private class WatchingPlayer(role: Role, name: String) : ReceivingPlayer(role, name) {
         var gameOver: GameEvent.GameOver? = null
         var gameResult: GameEvent.GameResult? = null
-        var epilogueEvents: List<GameEvent>? = null
+        var epilogueEvents: List<Recallable>? = null
 
         override fun onReceive(event: GameEvent) {
             when (event) {
@@ -19,8 +19,8 @@ class EpilogueTest {
             }
         }
 
-        override fun watchEpilogue(events: List<GameEvent>) {
-            epilogueEvents = events
+        override fun watchEpilogue(memories: List<Recallable>) {
+            epilogueEvents = memories
         }
     }
 

--- a/src/test/kotlin/EpilogueTest.kt
+++ b/src/test/kotlin/EpilogueTest.kt
@@ -19,8 +19,8 @@ class EpilogueTest {
             }
         }
 
-        override fun watchEpilogue(memories: List<Recallable>) {
-            epilogueEvents = memories
+        override fun watchEpilogue(chronicles: List<Recallable>) {
+            epilogueEvents = chronicles
         }
     }
 

--- a/src/test/kotlin/GameRecapTest.kt
+++ b/src/test/kotlin/GameRecapTest.kt
@@ -1,6 +1,7 @@
 package org.example
 
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -57,8 +58,8 @@ class GameRecapTest {
 
         val events = GameRecap(pm, anySignal()).events()
         assertEquals(3, events.size)
-        assertEquals("V1", events[0].recipientName)
-        assertEquals("V2", events[1].recipientName)
+        assertContains(events[0].chronicle(), "V1")
+        assertContains(events[1].chronicle(), "V2")
         assertTrue(events[2] is GameEvent.TimeChanged)
     }
 }

--- a/src/test/kotlin/NothingPlayer.kt
+++ b/src/test/kotlin/NothingPlayer.kt
@@ -4,5 +4,5 @@ open class NothingPlayer(role: Role, override val name: String) : Player(role) {
     override fun buildStatement(context: DiscussionContext): Statement = error("buildStatement not expected")
     override fun onReceive(event: GameEvent) { error("onReceive not expected") }
     override fun selectTarget(context: SelectionContext): Player = error("selectTarget not expected")
-    override fun watchEpilogue(memories: List<Recallable>) { error("watchEpilogue not expected") }
+    override fun watchEpilogue(chronicles: List<Recallable>) { error("watchEpilogue not expected") }
 }

--- a/src/test/kotlin/NothingPlayer.kt
+++ b/src/test/kotlin/NothingPlayer.kt
@@ -4,5 +4,5 @@ open class NothingPlayer(role: Role, override val name: String) : Player(role) {
     override fun buildStatement(context: DiscussionContext): Statement = error("buildStatement not expected")
     override fun onReceive(event: GameEvent) { error("onReceive not expected") }
     override fun selectTarget(context: SelectionContext): Player = error("selectTarget not expected")
-    override fun watchEpilogue(events: List<GameEvent>) { error("watchEpilogue not expected") }
+    override fun watchEpilogue(memories: List<Recallable>) { error("watchEpilogue not expected") }
 }

--- a/src/test/kotlin/PocAiPlayerTest.kt
+++ b/src/test/kotlin/PocAiPlayerTest.kt
@@ -103,12 +103,12 @@ class PocAiPlayerTest {
     }
 
     @Test
-    fun `watchEpilogue prompt includes event recipientName, title, body and reflection instruction`() {
+    fun `watchEpilogue prompt includes chronicle of events and reflection instruction`() {
         val lm = FakeLanguageModel("")
         val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
         GameEvent.RoleAssigned.send(Role.VILLAGER, villager)
-        val events = villager.revealKnowledge(fakeCitizenWinSignal())
-        villager.watchEpilogue(events)
+        val memories = villager.reveal(fakeCitizenWinSignal())
+        villager.watchEpilogue(memories)
         assertContains(lm.prompts.first(), "Villager")
         assertContains(lm.prompts.first(), "役職通知")
         assertContains(lm.prompts.first(), "振り返り")


### PR DESCRIPTION
## Summary

- `Recallable` 抽象クラスを導入し、`sequenceId` / `recall()` / `chronicle()` を定義
- `GameEvent` が `Recallable` を継承し、`recall()` / `chronicle()` を実装
- `Player._memories` を `MutableList<Recallable>` に変更し、`reveal()` が `List<Recallable>` を返すように更新
- `GameRecap.events()` が `sequenceId` 順でソートされた `List<Recallable>` を返すように変更
- `watchEpilogue` のシグネチャを `List<Recallable>` に統一
- `Player.role` / `Player._memories` が `private` である理由をコメントで明文化

## Related

- #161

## Test plan

- [ ] `GameRecapTest` でイベントの重複排除・順序・収集が正しいことを確認
- [ ] `PocAiPlayerTest` でプロンプトにイベントが含まれること、エピローグに `chronicle()` が使われることを確認
- [ ] `EpilogueTest` で `watchEpilogue` に `List<Recallable>` が渡されることを確認

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)