### PR TITLE
Introduce Choice to record player selections in a unified timeline

### DIFF
--- a/src/main/kotlin/Choice.kt
+++ b/src/main/kotlin/Choice.kt
@@ -1,0 +1,38 @@
+package org.example
+
+sealed class Choice(
+    val chooser: Player,
+    val context: SelectionContext,
+    val selected: Player,
+    private val intentForRecall: String,
+    val intentForChronicle: String,
+) : Recallable() {
+    init {
+        require(selected in context.candidates()) { "${selected.name} is not in candidates" }
+    }
+
+    override fun recall() = "[${context.title}] ${selected.name} [$intentForRecall]"
+    override fun chronicle() = "[${chooser.name}] [${context.title}] ${selected.name} [$intentForChronicle]"
+
+    companion object {
+        operator fun invoke(
+            chooser: Player,
+            context: SelectionContext,
+            selected: Player,
+            intent: String,
+        ): Choice = NormalChoice(chooser, context, selected, intent)
+    }
+}
+
+private class NormalChoice(
+    chooser: Player,
+    context: SelectionContext,
+    selected: Player,
+    intent: String,
+) : Choice(chooser, context, selected, intent, intent)
+
+class FallbackChoice(chooser: Player, context: SelectionContext) : Choice(
+    chooser, context, context.candidates().random(),
+    intentForRecall = "",
+    intentForChronicle = "回答取得に失敗したためランダム選択",
+)

--- a/src/main/kotlin/ConsoleLanguageModel.kt
+++ b/src/main/kotlin/ConsoleLanguageModel.kt
@@ -1,9 +1,9 @@
 package org.example
 
 class ConsoleLanguageModel : LanguageModel {
-    override fun ask(prompt: String): String? {
+    override fun ask(prompt: String): String {
         println(prompt)
         print("回答 > ")
-        return readLine()?.trim()
+        return readLine()?.trim() ?: ""
     }
 }

--- a/src/main/kotlin/HonestCpuPlayer.kt
+++ b/src/main/kotlin/HonestCpuPlayer.kt
@@ -13,8 +13,8 @@ class HonestCpuPlayer(role: Role, override val name: String) : CpuPlayer(role) {
         return Statement.Plain(unspoken.removeFirst().body())
     }
 
-    override fun selectTarget(context: SelectionContext): Player {
+    override fun choose(context: SelectionContext): Choice {
         val candidates = context.candidates()
-        return candidates[selectCount++ % candidates.size]
+        return Choice(this, context, candidates[selectCount++ % candidates.size], "順番通りに選択")
     }
 }

--- a/src/main/kotlin/HumanPlayer.kt
+++ b/src/main/kotlin/HumanPlayer.kt
@@ -1,8 +1,8 @@
 package org.example
 
 class HumanPlayer(role: Role, override val name: String, private val io: PlayerIO) : Player(role) {
-    override fun selectTarget(context: SelectionContext): Player =
-        io.promptPlayer(name, context.title, context.description, context.candidates())
+    override fun choose(context: SelectionContext): Choice =
+        Choice(this, context, io.promptPlayer(name, context.title, context.description, context.candidates()), "プレイヤーが選択")
 
     override fun onReceive(event: GameEvent) {
         io.sendMessage(name, event.title, event.body())

--- a/src/main/kotlin/LanguageModel.kt
+++ b/src/main/kotlin/LanguageModel.kt
@@ -1,5 +1,5 @@
 package org.example
 
 interface LanguageModel {
-    fun ask(prompt: String): String?
+    fun ask(prompt: String): String
 }

--- a/src/main/kotlin/Player.kt
+++ b/src/main/kotlin/Player.kt
@@ -14,7 +14,13 @@ abstract class Player(private val role: Role) : Notifiable {
     }
 
     protected abstract fun onReceive(event: GameEvent)
-    abstract fun selectTarget(context: SelectionContext): Player
+    fun selectTarget(context: SelectionContext): Player {
+        val choice = choose(context)
+        require(choice.chooser === this) { "${choice.chooser.name} is not the choosing player" }
+        _memories.add(choice)
+        return choice.selected
+    }
+    protected abstract fun choose(context: SelectionContext): Choice
     fun discuss(context: DiscussionContext): Statement {
         val statement = buildStatement(context)
         require(statement.type in context.availableTypes)

--- a/src/main/kotlin/PocAiPlayer.kt
+++ b/src/main/kotlin/PocAiPlayer.kt
@@ -28,26 +28,36 @@ class PocAiPlayer(
         return Statement.Plain("")
     }
 
-    override fun selectTarget(context: SelectionContext): Player {
+    override fun choose(context: SelectionContext): Choice {
         val candidates = context.candidates()
-        val candidateNames = candidates.joinToString("、") { it.name }
         val instruction = """
             ${context.title}：${context.description}
 
-            候補：$candidateNames
+            候補：${candidates.joinToString("、") { it.name }}
 
             「候補名：選んだ理由（200文字以内）」の形式で答えてください。
             例：${candidates.first().name}：最も怪しいと思うため
         """.trimIndent()
         repeat(2) {
-            val input = prompt(instruction) ?: ""
-            val playerName = input.split("：", ":").first().trim()
-            val target = candidates.firstOrNull { it.name == playerName }
-            if (target != null) return target
+            try {
+                val (target, intent) = parseChoiceResponse(prompt(instruction) ?: "", candidates)
+                val choice = Choice(this, context, target, intent)
+                _myMemories.add(choice)
+                return choice
+            } catch (_: IllegalAiInputException) { }
         }
-        // 2回失敗したためランダムで選択
-        return candidates.random()
+        return FallbackChoice(this, context)
     }
+
+    private fun parseChoiceResponse(input: String, candidates: List<Player>): Pair<Player, String> {
+        val (targetString, intent) = input.split("：", ":", limit = 2).takeIf { it.size == 2 }
+            ?: throw IllegalAiInputException("「ターゲット：理由」の形式ではありません: $input")
+        val target = candidates.firstOrNull { it.name == targetString.trim() }
+            ?: throw IllegalAiInputException("候補に存在しないターゲットです: ${targetString.trim()}")
+        return target to intent.trim()
+    }
+
+    private class IllegalAiInputException(message: String) : Exception(message)
 
     override fun watchEpilogue(chronicles: List<Recallable>) {
         val instruction = buildString {

--- a/src/main/kotlin/PocAiPlayer.kt
+++ b/src/main/kotlin/PocAiPlayer.kt
@@ -20,7 +20,7 @@ class PocAiPlayer(
             例：占い師です。Aliceは白でした。[狂人として占い師を偽装し、信用を得るための発言]
         """.trimIndent()
         repeat(2) {
-            val input = prompt(instruction) ?: ""
+            val input = prompt(instruction)
             val separatorIdx = input.indexOf("[").takeIf { it >= 0 }
             if (separatorIdx != null) return Statement.Plain(input.substring(0, separatorIdx).trim())
         }
@@ -40,24 +40,26 @@ class PocAiPlayer(
         """.trimIndent()
         repeat(2) {
             try {
-                val (target, intent) = parseChoiceResponse(prompt(instruction) ?: "", candidates)
+                val (target, intent) = parseChoiceResponse(prompt(instruction), candidates)
                 val choice = Choice(this, context, target, intent)
                 _myMemories.add(choice)
                 return choice
-            } catch (_: IllegalAiInputException) { }
+            } catch (_: InvalidAiInputException) {
+                // AI応答が不正な形式のため、次のイテレーションでリトライする
+            }
         }
         return FallbackChoice(this, context)
     }
 
     private fun parseChoiceResponse(input: String, candidates: List<Player>): Pair<Player, String> {
         val (targetString, intent) = input.split("：", ":", limit = 2).takeIf { it.size == 2 }
-            ?: throw IllegalAiInputException("「ターゲット：理由」の形式ではありません: $input")
+            ?: throw InvalidAiInputException("「ターゲット：理由」の形式ではありません: $input")
         val target = candidates.firstOrNull { it.name == targetString.trim() }
-            ?: throw IllegalAiInputException("候補に存在しないターゲットです: ${targetString.trim()}")
+            ?: throw InvalidAiInputException("候補に存在しないターゲットです: ${targetString.trim()}")
         return target to intent.trim()
     }
 
-    private class IllegalAiInputException(message: String) : Exception(message)
+    private class InvalidAiInputException(message: String) : Exception(message)
 
     override fun watchEpilogue(chronicles: List<Recallable>) {
         val instruction = buildString {
@@ -68,7 +70,7 @@ class PocAiPlayer(
         prompt(instruction)
     }
 
-    private fun prompt(instruction: String): String? {
+    private fun prompt(instruction: String): String {
         val fullPrompt = buildString {
             appendLine()
             appendLine(SEPARATOR)

--- a/src/main/kotlin/RandomCpuPlayer.kt
+++ b/src/main/kotlin/RandomCpuPlayer.kt
@@ -1,7 +1,7 @@
 package org.example
 
 class RandomCpuPlayer(role: Role, override val name: String) : CpuPlayer(role) {
-    override fun selectTarget(context: SelectionContext): Player = context.candidates().random()
+    override fun choose(context: SelectionContext): Choice = Choice(this, context, context.candidates().random(), "ランダム選択")
     override fun buildStatement(context: DiscussionContext): Statement = Statement.Plain("")
     override fun onReceive(event: GameEvent) { /* does not use received events */ }
 }

--- a/src/main/kotlin/RoleAwareCpuPlayer.kt
+++ b/src/main/kotlin/RoleAwareCpuPlayer.kt
@@ -11,5 +11,5 @@ class RoleAwareCpuPlayer(val myRole: Role, override val name: String) : CpuPlaye
 
     override fun onReceive(event: GameEvent) { _knowledge.add(event) }
     override fun buildStatement(context: DiscussionContext) = strategy.buildStatement(context)
-    override fun selectTarget(context: SelectionContext) = strategy.selectTarget(context)
+    override fun choose(context: SelectionContext) = Choice(this, context, strategy.selectTarget(context), "戦略による選択")
 }

--- a/src/main/kotlin/RollerCpuPlayer.kt
+++ b/src/main/kotlin/RollerCpuPlayer.kt
@@ -3,9 +3,9 @@ package org.example
 class RollerCpuPlayer(role: Role, override val name: String) : CpuPlayer(role) {
     private var selectCount = 0
 
-    override fun selectTarget(context: SelectionContext): Player {
+    override fun choose(context: SelectionContext): Choice {
         val candidates = context.candidates()
-        return candidates[selectCount++ % candidates.size]
+        return Choice(this, context, candidates[selectCount++ % candidates.size], "順番通りに選択")
     }
 
     override fun buildStatement(context: DiscussionContext): Statement = Statement.Plain("")

--- a/src/test/kotlin/ChoiceTest.kt
+++ b/src/test/kotlin/ChoiceTest.kt
@@ -1,0 +1,27 @@
+package org.example
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+
+class ChoiceTest {
+
+    @Test
+    fun `Choice throws when selected is not in candidates`() {
+        val chooser = NothingPlayer(Role.VILLAGER, "Chooser")
+        val selectable = NothingPlayer(Role.VILLAGER, "Selectable")
+        val outsider = NothingPlayer(Role.VILLAGER, "Outsider")
+        val context = SelectionContext.Vote(chooser, listOf(chooser, selectable))
+        assertFailsWith<IllegalArgumentException> {
+            Choice(chooser, context, outsider, "理由")
+        }
+    }
+
+    @Test
+    fun `Choice does not throw when selected is in candidates`() {
+        val chooser = NothingPlayer(Role.VILLAGER, "Chooser")
+        val selectable = NothingPlayer(Role.VILLAGER, "Selectable")
+        val context = SelectionContext.Vote(chooser, listOf(chooser, selectable))
+        assertNotNull(Choice(chooser, context, selectable, "理由"))
+    }
+}

--- a/src/test/kotlin/DayPhaseTest.kt
+++ b/src/test/kotlin/DayPhaseTest.kt
@@ -15,8 +15,8 @@ class DayPhaseTest {
             discussedCount++
             return Statement.Plain("")
         }
-        override fun selectTarget(context: SelectionContext): Player =
-            voteTarget?.takeIf { it in context.candidates() } ?: context.candidates().first()
+        override fun choose(context: SelectionContext): Choice =
+            Choice(this, context, voteTarget?.takeIf { it in context.candidates() } ?: context.candidates().first(), "テスト用投票")
     }
 
     @Test

--- a/src/test/kotlin/EpilogueTest.kt
+++ b/src/test/kotlin/EpilogueTest.kt
@@ -2,14 +2,18 @@ package org.example
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class EpilogueTest {
 
-    private class WatchingPlayer(role: Role, name: String) : ReceivingPlayer(role, name) {
+    private class ChoosingWatchingPlayer(role: Role, name: String) : WatchingPlayer(role, name) {
+        override fun choose(context: SelectionContext): Choice = FallbackChoice(this, context)
+    }
+
+    private open class WatchingPlayer(role: Role, name: String) : ReceivingPlayer(role, name) {
         var gameOver: GameEvent.GameOver? = null
         var gameResult: GameEvent.GameResult? = null
-        var epilogueEvents: List<Recallable>? = null
+        val watchedEvents: MutableList<Recallable> = mutableListOf()
 
         override fun onReceive(event: GameEvent) {
             when (event) {
@@ -20,7 +24,7 @@ class EpilogueTest {
         }
 
         override fun watchEpilogue(chronicles: List<Recallable>) {
-            epilogueEvents = chronicles
+            watchedEvents.addAll(chronicles)
         }
     }
 
@@ -54,7 +58,21 @@ class EpilogueTest {
 
         Epilogue(setup.playerManager, setup.oracle, fakeCitizenWinSignal()).perform()
 
-        assertNotNull(wolf.epilogueEvents)
-        assertNotNull(villager.epilogueEvents)
+        assertTrue(wolf.watchedEvents.isNotEmpty())
+        assertTrue(villager.watchedEvents.isNotEmpty())
+    }
+
+    @Test
+    fun `choice made by player appears in epilogue chronicles`() {
+        val wolf = WatchingPlayer(Role.WEREWOLF, "Wolf")
+        val chooser = ChoosingWatchingPlayer(Role.VILLAGER, "Chooser")
+        val setup = TestLodge(wolf to Role.WEREWOLF, chooser to Role.VILLAGER).create()
+        val signal = fakeCitizenWinSignal()
+
+        chooser.selectTarget(SelectionContext.Vote(chooser, setup.playerManager.players))
+
+        Epilogue(setup.playerManager, setup.oracle, signal).perform()
+
+        assertTrue(chooser.watchedEvents.any { it is Choice })
     }
 }

--- a/src/test/kotlin/NightPhaseTest.kt
+++ b/src/test/kotlin/NightPhaseTest.kt
@@ -12,10 +12,7 @@ class NightPhaseTest {
     private class FixedTargetPlayer(
         role: Role, name: String, private val target: Player
     ) : RecordingPlayer(role, name) {
-        override fun selectTarget(context: SelectionContext): Player {
-            require(target in context.candidates()) { "fixed target '${target.name}' is not in candidates" }
-            return target
-        }
+        override fun choose(context: SelectionContext): Choice = Choice(this, context, target, "固定ターゲット")
     }
 
     private open class RecordingPlayer(role: Role, name: String) : ReceivingPlayer(role, name) {

--- a/src/test/kotlin/NothingPlayer.kt
+++ b/src/test/kotlin/NothingPlayer.kt
@@ -3,6 +3,6 @@ package org.example
 open class NothingPlayer(role: Role, override val name: String) : Player(role) {
     override fun buildStatement(context: DiscussionContext): Statement = error("buildStatement not expected")
     override fun onReceive(event: GameEvent) { error("onReceive not expected") }
-    override fun selectTarget(context: SelectionContext): Player = error("selectTarget not expected")
+    override fun choose(context: SelectionContext): Choice = error("choose not expected")
     override fun watchEpilogue(chronicles: List<Recallable>) { error("watchEpilogue not expected") }
 }

--- a/src/test/kotlin/PlayerTest.kt
+++ b/src/test/kotlin/PlayerTest.kt
@@ -1,0 +1,37 @@
+package org.example
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class PlayerTest {
+
+    private class ArbitraryChooserSetter(
+        role: Role,
+        name: String,
+        private val chooserToSet: Player,
+    ) : NothingPlayer(role, name) {
+        override fun choose(context: SelectionContext): Choice = FallbackChoice(chooserToSet, context)
+    }
+
+    private class ChoosingPlayer(role: Role, name: String) : NothingPlayer(role, name) {
+        override fun choose(context: SelectionContext): Choice = FallbackChoice(this, context)
+    }
+
+    @Test
+    fun `selectTarget throws when choose returns a choice with wrong chooser`() {
+        val otherPlayer = NothingPlayer(Role.VILLAGER, "OtherPlayer")
+        val player = ArbitraryChooserSetter(Role.VILLAGER, "Player", chooserToSet = otherPlayer)
+        val context = SelectionContext.Vote(player, listOf(player, otherPlayer))
+        assertFailsWith<IllegalArgumentException> { player.selectTarget(context) }
+    }
+
+    @Test
+    fun `selectTarget records choice in player memories`() {
+        val otherPlayer = NothingPlayer(Role.VILLAGER, "OtherPlayer")
+        val player = ChoosingPlayer(Role.VILLAGER, "Player")
+        val context = SelectionContext.Vote(player, listOf(player, otherPlayer))
+        player.selectTarget(context)
+        assertTrue(player.reveal(fakeCitizenWinSignal()).any { it is Choice })
+    }
+}

--- a/src/test/kotlin/PocAiPlayerTest.kt
+++ b/src/test/kotlin/PocAiPlayerTest.kt
@@ -12,9 +12,9 @@ class PocAiPlayerTest {
         private val responseQueue = ArrayDeque(responses.toList())
         val prompts = mutableListOf<String>()
 
-        override fun ask(prompt: String): String? {
+        override fun ask(prompt: String): String {
             prompts.add(prompt)
-            return responseQueue.removeFirstOrNull()
+            return responseQueue.removeFirst()
         }
     }
 
@@ -95,11 +95,32 @@ class PocAiPlayerTest {
 
     @Test
     fun `prompt includes received events`() {
-        val lm = FakeLanguageModel("")
+        val lm = FakeLanguageModel("[真意]")
         val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
         GameEvent.RoleAssigned.send(Role.VILLAGER, villager)
         villager.discuss(openContext())
         assertContains(lm.prompts.first(), "役職通知")
+    }
+
+    @Test
+    fun `selectTarget retries when response has no separator`() {
+        val lm = FakeLanguageModel("no separator", "Wolf：怪しいから")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
+        val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
+        val context = SelectionContext.Vote(villager, listOf(villager, wolf))
+        val result = villager.selectTarget(context)
+        assertEquals(wolf, result)
+    }
+
+    @Test
+    fun `choice recorded in memories appears in next prompt`() {
+        val lm = FakeLanguageModel("Wolf：怪しいから", "hello[真意]")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
+        val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
+        villager.selectTarget(SelectionContext.Vote(villager, listOf(villager, wolf)))
+        villager.discuss(openContext())
+        assertContains(lm.prompts[1], "投票")
+        assertContains(lm.prompts[1], "Wolf")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `sealed class Choice` を新規追加。`Recallable` を継承し、誰が・どのコンテキストで・誰を・なぜ選んだかを記録する
- `FallbackChoice` を同ファイルに定義。AI の回答取得失敗時にランダム選択し、`intentForRecall` を空・`intentForChronicle` に失敗理由を持つ
- `Player.selectTarget` をテンプレートメソッド化。`abstract fun choose(): Choice` を呼び出し、`chooser === this` を検証した上で `_memories` に記録する
- 全 `Player` サブクラスの `selectTarget` → `choose` にリネームし、`Choice` を返すよう更新
- `PocAiPlayer` は AI レスポンスから選択先と真意を抽出して `Choice` を生成・`_myMemories` にも保存。`parseChoiceResponse` を切り出し `IllegalAiInputException` でリトライ制御
- `FixedTargetPlayer` の手動 `require` を削除（`Choice.init` で検証するため）

## Test plan

- [ ] `./gradlew check` が通ること

## 関連

- #161
- #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)