### PR TITLE
Introduce Claim to record player statements and intent in a unified timeline

### DIFF
--- a/src/main/kotlin/Claim.kt
+++ b/src/main/kotlin/Claim.kt
@@ -1,0 +1,38 @@
+package org.example
+
+sealed class Claim(
+    val speaker: Player,
+    val context: DiscussionContext,
+    val statement: Statement,
+    private val intentForRecall: String,
+    val intentForChronicle: String,
+) : Recallable() {
+    init {
+        require(statement.type in context.availableTypes) { "${statement.type} is not available in ${context.title}" }
+    }
+
+    override fun recall() = "[${context.title}] ${statement.text()} [$intentForRecall]"
+    override fun chronicle() = "[${speaker.name}] [${context.title}] ${statement.text()} [$intentForChronicle]"
+
+    companion object {
+        operator fun invoke(
+            speaker: Player,
+            context: DiscussionContext,
+            statement: Statement,
+            intent: String,
+        ): Claim = NormalClaim(speaker, context, statement, intent)
+    }
+}
+
+private class NormalClaim(
+    speaker: Player,
+    context: DiscussionContext,
+    statement: Statement,
+    intent: String,
+) : Claim(speaker, context, statement, intent, intent)
+
+class FallbackClaim(speaker: Player, context: DiscussionContext) : Claim(
+    speaker, context, Statement.Plain(""),
+    intentForRecall = "",
+    intentForChronicle = "回答取得に失敗したため空文字を返却",
+)

--- a/src/main/kotlin/HonestCpuPlayer.kt
+++ b/src/main/kotlin/HonestCpuPlayer.kt
@@ -8,9 +8,9 @@ class HonestCpuPlayer(role: Role, override val name: String) : CpuPlayer(role) {
         if (!event.isPublicKnowledge()) unspoken.add(event)
     }
 
-    override fun buildStatement(context: DiscussionContext): Statement {
-        if (unspoken.isEmpty()) return Statement.Plain("")
-        return Statement.Plain(unspoken.removeFirst().body())
+    override fun speak(context: DiscussionContext): Claim {
+        val statement = if (unspoken.isEmpty()) Statement.Plain("") else Statement.Plain(unspoken.removeFirst().body())
+        return Claim(this, context, statement, "受け取った非公開情報を順番に開示")
     }
 
     override fun choose(context: SelectionContext): Choice {

--- a/src/main/kotlin/HumanPlayer.kt
+++ b/src/main/kotlin/HumanPlayer.kt
@@ -8,13 +8,14 @@ class HumanPlayer(role: Role, override val name: String, private val io: PlayerI
         io.sendMessage(name, event.title, event.body())
     }
 
-    override fun buildStatement(context: DiscussionContext): Statement {
+    override fun speak(context: DiscussionContext): Claim {
         val type = selectType(context)
-        return when (type) {
+        val statement = when (type) {
             StatementType.PLAIN -> buildPlain(context)
             StatementType.DIVINATION_REPORT -> buildDivinationReport(context)
             StatementType.MEDIUM_REPORT -> buildMediumReport(context)
         }
+        return Claim(this, context, statement, "プレイヤーが発言")
     }
 
     private fun selectType(context: DiscussionContext): StatementType {

--- a/src/main/kotlin/Player.kt
+++ b/src/main/kotlin/Player.kt
@@ -22,11 +22,12 @@ abstract class Player(private val role: Role) : Notifiable {
     }
     protected abstract fun choose(context: SelectionContext): Choice
     fun discuss(context: DiscussionContext): Statement {
-        val statement = buildStatement(context)
-        require(statement.type in context.availableTypes)
-        return statement
+        val claim = speak(context)
+        require(claim.speaker === this) { "${claim.speaker.name} is not the speaking player" }
+        _memories.add(claim)
+        return claim.statement
     }
-    protected abstract fun buildStatement(context: DiscussionContext): Statement
+    protected abstract fun speak(context: DiscussionContext): Claim
     abstract fun watchEpilogue(chronicles: List<Recallable>)
 
     // signal is a capability token: only callers who hold a GameOverSignal (i.e., after game over) can access memories

--- a/src/main/kotlin/PocAiPlayer.kt
+++ b/src/main/kotlin/PocAiPlayer.kt
@@ -11,7 +11,7 @@ class PocAiPlayer(
         _myMemories.add(event)
     }
 
-    override fun buildStatement(context: DiscussionContext): Statement {
+    override fun speak(context: DiscussionContext): Claim {
         val instruction = """
             【${context.title}】${context.description}
 
@@ -20,12 +20,24 @@ class PocAiPlayer(
             例：占い師です。Aliceは白でした。[狂人として占い師を偽装し、信用を得るための発言]
         """.trimIndent()
         repeat(2) {
-            val input = prompt(instruction)
-            val separatorIdx = input.indexOf("[").takeIf { it >= 0 }
-            if (separatorIdx != null) return Statement.Plain(input.substring(0, separatorIdx).trim())
+            try {
+                val (text, intent) = parseSpeakResponse(prompt(instruction))
+                val claim = Claim(this, context, Statement.Plain(text), intent)
+                _myMemories.add(claim)
+                return claim
+            } catch (_: InvalidAiInputException) {
+                // AI応答が不正な形式のため、次のイテレーションでリトライする
+            }
         }
-        // 2回失敗したため空文字を返す
-        return Statement.Plain("")
+        return FallbackClaim(this, context)
+    }
+
+    private fun parseSpeakResponse(input: String): Pair<String, String> {
+        val separatorIdx = input.indexOf("[").takeIf { it >= 0 }
+            ?: throw InvalidAiInputException("「発言[真意]」の形式ではありません: $input")
+        val text = input.substring(0, separatorIdx).trim()
+        val intent = input.substring(separatorIdx + 1).removeSuffix("]").trim()
+        return text to intent
     }
 
     override fun choose(context: SelectionContext): Choice {

--- a/src/main/kotlin/RandomCpuPlayer.kt
+++ b/src/main/kotlin/RandomCpuPlayer.kt
@@ -2,6 +2,6 @@ package org.example
 
 class RandomCpuPlayer(role: Role, override val name: String) : CpuPlayer(role) {
     override fun choose(context: SelectionContext): Choice = Choice(this, context, context.candidates().random(), "ランダム選択")
-    override fun buildStatement(context: DiscussionContext): Statement = Statement.Plain("")
+    override fun speak(context: DiscussionContext): Claim = Claim(this, context, Statement.Plain(""), "発言戦略なし")
     override fun onReceive(event: GameEvent) { /* does not use received events */ }
 }

--- a/src/main/kotlin/RoleAwareCpuPlayer.kt
+++ b/src/main/kotlin/RoleAwareCpuPlayer.kt
@@ -10,6 +10,6 @@ class RoleAwareCpuPlayer(val myRole: Role, override val name: String) : CpuPlaye
     ).single { it.appliesTo() }
 
     override fun onReceive(event: GameEvent) { _knowledge.add(event) }
-    override fun buildStatement(context: DiscussionContext) = strategy.buildStatement(context)
+    override fun speak(context: DiscussionContext) = Claim(this, context, strategy.buildStatement(context), "役職戦略に基づく発言")
     override fun choose(context: SelectionContext) = Choice(this, context, strategy.selectTarget(context), "戦略による選択")
 }

--- a/src/main/kotlin/RollerCpuPlayer.kt
+++ b/src/main/kotlin/RollerCpuPlayer.kt
@@ -8,6 +8,6 @@ class RollerCpuPlayer(role: Role, override val name: String) : CpuPlayer(role) {
         return Choice(this, context, candidates[selectCount++ % candidates.size], "順番通りに選択")
     }
 
-    override fun buildStatement(context: DiscussionContext): Statement = Statement.Plain("")
+    override fun speak(context: DiscussionContext): Claim = Claim(this, context, Statement.Plain(""), "発言戦略なし")
     override fun onReceive(event: GameEvent) { /* does not use received events */ }
 }

--- a/src/test/kotlin/ClaimTest.kt
+++ b/src/test/kotlin/ClaimTest.kt
@@ -1,0 +1,52 @@
+package org.example
+
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+
+class ClaimTest {
+
+    @Test
+    fun `Claim throws when statement type is not available in context`() {
+        val speaker = NothingPlayer(Role.WEREWOLF, "Speaker")
+        val context = DiscussionContext.Conclave(1, 1, listOf(speaker), listOf(speaker))
+        val statement = Statement.DivinationReport(speaker, speaker, DivineResult.WEREWOLF)
+        assertFailsWith<IllegalArgumentException> {
+            Claim(speaker, context, statement, "意図")
+        }
+    }
+
+    @Test
+    fun `Claim does not throw when statement type is available`() {
+        val speaker = NothingPlayer(Role.VILLAGER, "Speaker")
+        val context = openContext(listOf(speaker))
+        assertNotNull(Claim(speaker, context, Statement.Plain("発言"), "意図"))
+    }
+
+    @Test
+    fun `recall returns context title, statement text, and intent in brackets`() {
+        val speaker = NothingPlayer(Role.VILLAGER, "Speaker")
+        val context = openContext(listOf(speaker))
+        val claim = Claim(speaker, context, Statement.Plain("発言内容"), "真意内容")
+        assertEquals("[議論] 発言内容 [真意内容]", claim.recall())
+    }
+
+    @Test
+    fun `chronicle returns speaker name, context title, statement text, and intent`() {
+        val speaker = NothingPlayer(Role.VILLAGER, "Speaker")
+        val context = openContext(listOf(speaker))
+        val claim = Claim(speaker, context, Statement.Plain("発言内容"), "真意内容")
+        assertEquals("[Speaker] [議論] 発言内容 [真意内容]", claim.chronicle())
+    }
+
+    @Test
+    fun `FallbackClaim has empty statement and failure reason in chronicle`() {
+        val speaker = NothingPlayer(Role.VILLAGER, "Speaker")
+        val context = openContext(listOf(speaker))
+        val claim = FallbackClaim(speaker, context)
+        assertEquals("", claim.statement.text())
+        assertContains(claim.intentForChronicle, "失敗")
+    }
+}

--- a/src/test/kotlin/ConclaveTest.kt
+++ b/src/test/kotlin/ConclaveTest.kt
@@ -16,10 +16,10 @@ class ConclaveTest {
         val log: List<String> get() = _log
         private var statementIndex = 0
 
-        override fun buildStatement(context: DiscussionContext): Statement {
+        override fun speak(context: DiscussionContext): Claim {
             val statement = statements[statementIndex++]
             _log.add("$name:said:$statement")
-            return Statement.Plain(statement)
+            return Claim(this, context, Statement.Plain(statement), "")
         }
 
         override fun onReceive(event: GameEvent) {

--- a/src/test/kotlin/DayPhaseTest.kt
+++ b/src/test/kotlin/DayPhaseTest.kt
@@ -11,9 +11,9 @@ class DayPhaseTest {
         role: Role, name: String, private val voteTarget: Player? = null
     ) : ReceivingPlayer(role, name) {
         var discussedCount = 0
-        override fun buildStatement(context: DiscussionContext): Statement {
+        override fun speak(context: DiscussionContext): Claim {
             discussedCount++
-            return Statement.Plain("")
+            return Claim(this, context, Statement.Plain(""), "")
         }
         override fun choose(context: SelectionContext): Choice =
             Choice(this, context, voteTarget?.takeIf { it in context.candidates() } ?: context.candidates().first(), "テスト用投票")

--- a/src/test/kotlin/DiscussionTest.kt
+++ b/src/test/kotlin/DiscussionTest.kt
@@ -15,10 +15,10 @@ class DiscussionTest {
         val log: List<String> get() = _log
         private var statementIndex = 0
 
-        override fun buildStatement(context: DiscussionContext): Statement {
+        override fun speak(context: DiscussionContext): Claim {
             val statement = statements[statementIndex++]
             _log.add("$name:said:$statement")
-            return Statement.Plain(statement)
+            return Claim(this, context, Statement.Plain(statement), "")
         }
 
         override fun onReceive(event: GameEvent) {

--- a/src/test/kotlin/NightPhaseTest.kt
+++ b/src/test/kotlin/NightPhaseTest.kt
@@ -22,7 +22,7 @@ class NightPhaseTest {
 
     private class ConclavingWolf(name: String) : ReceivingPlayer(Role.WEREWOLF, name) {
         val heardStatements = mutableListOf<GameEvent.WerewolfStatementMade>()
-        override fun buildStatement(context: DiscussionContext): Statement = Statement.Plain("")
+        override fun speak(context: DiscussionContext): Claim = Claim(this, context, Statement.Plain(""), "")
         override fun onReceive(event: GameEvent) {
             if (event is GameEvent.WerewolfStatementMade) heardStatements.add(event)
         }

--- a/src/test/kotlin/NothingPlayer.kt
+++ b/src/test/kotlin/NothingPlayer.kt
@@ -1,7 +1,7 @@
 package org.example
 
 open class NothingPlayer(role: Role, override val name: String) : Player(role) {
-    override fun buildStatement(context: DiscussionContext): Statement = error("buildStatement not expected")
+    override fun speak(context: DiscussionContext): Claim = error("speak not expected")
     override fun onReceive(event: GameEvent) { error("onReceive not expected") }
     override fun choose(context: SelectionContext): Choice = error("choose not expected")
     override fun watchEpilogue(chronicles: List<Recallable>) { error("watchEpilogue not expected") }

--- a/src/test/kotlin/PlayerTest.kt
+++ b/src/test/kotlin/PlayerTest.kt
@@ -18,6 +18,20 @@ class PlayerTest {
         override fun choose(context: SelectionContext): Choice = FallbackChoice(this, context)
     }
 
+    private class ArbitrarySpeakerSetter(
+        role: Role,
+        name: String,
+        private val speakerToSet: Player,
+    ) : NothingPlayer(role, name) {
+        override fun speak(context: DiscussionContext): Claim =
+            Claim(speakerToSet, context, Statement.Plain(""), "")
+    }
+
+    private class SpeakingPlayer(role: Role, name: String) : NothingPlayer(role, name) {
+        override fun speak(context: DiscussionContext): Claim =
+            Claim(this, context, Statement.Plain(""), "")
+    }
+
     @Test
     fun `selectTarget throws when choose returns a choice with wrong chooser`() {
         val otherPlayer = NothingPlayer(Role.VILLAGER, "OtherPlayer")
@@ -33,5 +47,20 @@ class PlayerTest {
         val context = SelectionContext.Vote(player, listOf(player, otherPlayer))
         player.selectTarget(context)
         assertTrue(player.reveal(fakeCitizenWinSignal()).any { it is Choice })
+    }
+
+    @Test
+    fun `discuss throws when speak returns a claim with wrong speaker`() {
+        val otherPlayer = NothingPlayer(Role.VILLAGER, "OtherPlayer")
+        val player = ArbitrarySpeakerSetter(Role.VILLAGER, "Player", speakerToSet = otherPlayer)
+        val context = openContext(listOf(player, otherPlayer))
+        assertFailsWith<IllegalArgumentException> { player.discuss(context) }
+    }
+
+    @Test
+    fun `discuss records claim in player memories`() {
+        val player = SpeakingPlayer(Role.VILLAGER, "Player")
+        player.discuss(openContext(listOf(player)))
+        assertTrue(player.reveal(fakeCitizenWinSignal()).any { it is Claim })
     }
 }

--- a/src/test/kotlin/PocAiPlayerTest.kt
+++ b/src/test/kotlin/PocAiPlayerTest.kt
@@ -124,6 +124,18 @@ class PocAiPlayerTest {
     }
 
     @Test
+    fun `claim recorded in memories appears in next prompt`() {
+        val lm = FakeLanguageModel("hello[真意内容]", "Wolf：怪しいから")
+        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
+        val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
+        villager.discuss(openContext())
+        villager.selectTarget(SelectionContext.Vote(villager, listOf(villager, wolf)))
+        assertContains(lm.prompts[1], "議論")
+        assertContains(lm.prompts[1], "hello")
+        assertContains(lm.prompts[1], "真意内容")
+    }
+
+    @Test
     fun `watchEpilogue prompt includes chronicle of events and reflection instruction`() {
         val lm = FakeLanguageModel("")
         val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)


### PR DESCRIPTION
## Summary

- `sealed class Claim` を新規追加。`Recallable` を継承し、誰が・どのコンテキストで・どんな発言を・なぜしたかを記録する
- `FallbackClaim` を同ファイルに定義。AI の応答取得失敗時に空文字を返し、`intentForChronicle` に失敗理由を持つ
- `Player.discuss` をテンプレートメソッド化。`abstract fun speak(): Claim` を呼び出し、`speaker === this` を検証した上で `_memories` に記録する
- 全 `Player` サブクラスの `buildStatement` → `speak` にリネームし、`Claim` を返すよう更新。各クラスの性質を真意として記録する
- `PocAiPlayer` は AI レスポンスから発言と真意を抽出して `Claim` を生成・`_myMemories` にも保存。`parseSpeakResponse` を切り出し `InvalidAiInputException` でリトライ制御

## Test plan

- [x] `./gradlew check` が通ること

## 関連

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)