### PR TITLE
Rename PocAiPlayer to AiPlayer and ConsoleLanguageModel to PocConsoleLanguageModel

### DIFF
--- a/src/main/kotlin/werewolf/ai/AiPlayer.kt
+++ b/src/main/kotlin/werewolf/ai/AiPlayer.kt
@@ -12,7 +12,7 @@ import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
 
-class PocAiPlayer(
+class AiPlayer(
     role: Role,
     override val name: String,
     private val languageModel: LanguageModel,

--- a/src/main/kotlin/werewolf/ai/PocConsoleLanguageModel.kt
+++ b/src/main/kotlin/werewolf/ai/PocConsoleLanguageModel.kt
@@ -1,7 +1,7 @@
 package werewolf.ai
 
 
-class ConsoleLanguageModel : LanguageModel {
+class PocConsoleLanguageModel : LanguageModel {
     override fun ask(prompt: String): String {
         println(prompt)
         print("回答 > ")

--- a/src/main/kotlin/werewolf/lodge/PocAiLodge.kt
+++ b/src/main/kotlin/werewolf/lodge/PocAiLodge.kt
@@ -2,8 +2,8 @@ package werewolf.lodge
 
 import werewolf.game.Player
 import werewolf.game.Role
-import werewolf.ai.ConsoleLanguageModel
-import werewolf.ai.PocAiPlayer
+import werewolf.ai.AiPlayer
+import werewolf.ai.PocConsoleLanguageModel
 
 object PocAiLodge : Lodge() {
     private val names = listOf("Alice", "Bob", "Charlie", "Dave", "Eve", "Frank", "Grace", "Heidi", "Ivan")
@@ -13,6 +13,6 @@ object PocAiLodge : Lodge() {
             Role.HUNTER, Role.VILLAGER, Role.VILLAGER, Role.VILLAGER, Role.MADMAN,
             Role.WEREWOLF, Role.SEER, Role.MEDIUM, Role.WEREWOLF,
         ).shuffled()
-        return roles.mapIndexed { i, role -> PocAiPlayer(role, names[i], ConsoleLanguageModel()) to role }
+        return roles.mapIndexed { i, role -> AiPlayer(role, names[i], PocConsoleLanguageModel()) to role }
     }
 }

--- a/src/test/kotlin/werewolf/AiPlayerTest.kt
+++ b/src/test/kotlin/werewolf/AiPlayerTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
-class PocAiPlayerTest {
+class AiPlayerTest {
 
     private class FakeLanguageModel(vararg responses: String) : LanguageModel {
         private val responseQueue = ArrayDeque(responses.toList())
@@ -24,7 +24,7 @@ class PocAiPlayerTest {
     @Test
     fun `discuss extracts statement before bracket from input`() {
         val lm = FakeLanguageModel("hello[真意]")
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm)
         val result = villager.discuss(openContext())
         assertIs<Statement.Plain>(result)
         assertEquals("hello", result.text())
@@ -33,7 +33,7 @@ class PocAiPlayerTest {
     @Test
     fun `discuss retries when bracket is missing and returns empty string after two failures`() {
         val lm = FakeLanguageModel("no bracket", "no bracket")
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm)
         val result = villager.discuss(openContext())
         assertIs<Statement.Plain>(result)
         assertEquals("", result.text())
@@ -42,7 +42,7 @@ class PocAiPlayerTest {
     @Test
     fun `discuss retries and succeeds on second input`() {
         val lm = FakeLanguageModel("no bracket", "hello[真意]")
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm)
         val result = villager.discuss(openContext())
         assertIs<Statement.Plain>(result)
         assertEquals("hello", result.text())
@@ -51,7 +51,7 @@ class PocAiPlayerTest {
     @Test
     fun `discuss prompt includes format instruction`() {
         val lm = FakeLanguageModel("hello[真意]")
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm)
         villager.discuss(openContext())
         assertContains(lm.prompts.first(), "ゲーム上の発言（100文字以内）[発言の真意（100文字以内）]")
     }
@@ -59,7 +59,7 @@ class PocAiPlayerTest {
     @Test
     fun `selectTarget returns matching player from name-colon-reason format`() {
         val lm = FakeLanguageModel("Wolf：怪しいから")
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm)
         val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
         val context = SelectionContext.Vote(villager, listOf(villager, wolf))
         val result = villager.selectTarget(context)
@@ -69,7 +69,7 @@ class PocAiPlayerTest {
     @Test
     fun `selectTarget retries when player name is not a candidate`() {
         val lm = FakeLanguageModel("Unknown：理由", "Wolf：怪しいから")
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm)
         val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
         val context = SelectionContext.Vote(villager, listOf(villager, wolf))
         val result = villager.selectTarget(context)
@@ -79,7 +79,7 @@ class PocAiPlayerTest {
     @Test
     fun `selectTarget falls back to random candidate after two invalid responses`() {
         val lm = FakeLanguageModel("Unknown：理由", "AlsoUnknown：理由")
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm)
         val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
         val context = SelectionContext.Vote(villager, listOf(villager, wolf))
         val result = villager.selectTarget(context)
@@ -89,7 +89,7 @@ class PocAiPlayerTest {
     @Test
     fun `selectTarget prompt includes format instruction`() {
         val lm = FakeLanguageModel("Wolf：怪しいから")
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm)
         val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
         val context = SelectionContext.Vote(villager, listOf(villager, wolf))
         villager.selectTarget(context)
@@ -99,7 +99,7 @@ class PocAiPlayerTest {
     @Test
     fun `prompt includes received events`() {
         val lm = FakeLanguageModel("[真意]")
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm)
         GameEvent.RoleAssigned.send(Role.VILLAGER, villager)
         villager.discuss(openContext())
         assertContains(lm.prompts.first(), "役職通知")
@@ -108,7 +108,7 @@ class PocAiPlayerTest {
     @Test
     fun `selectTarget retries when response has no separator`() {
         val lm = FakeLanguageModel("no separator", "Wolf：怪しいから")
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm)
         val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
         val context = SelectionContext.Vote(villager, listOf(villager, wolf))
         val result = villager.selectTarget(context)
@@ -118,7 +118,7 @@ class PocAiPlayerTest {
     @Test
     fun `choice recorded in memories appears in next prompt`() {
         val lm = FakeLanguageModel("Wolf：怪しいから", "hello[真意]")
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm)
         val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
         villager.selectTarget(SelectionContext.Vote(villager, listOf(villager, wolf)))
         villager.discuss(openContext())
@@ -129,7 +129,7 @@ class PocAiPlayerTest {
     @Test
     fun `claim recorded in memories appears in next prompt`() {
         val lm = FakeLanguageModel("hello[真意内容]", "Wolf：怪しいから")
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm)
         val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
         villager.discuss(openContext())
         villager.selectTarget(SelectionContext.Vote(villager, listOf(villager, wolf)))
@@ -141,7 +141,7 @@ class PocAiPlayerTest {
     @Test
     fun `watchEpilogue prompt includes chronicle of events and reflection instruction`() {
         val lm = FakeLanguageModel("")
-        val villager = PocAiPlayer(Role.VILLAGER, "Villager", lm)
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm)
         GameEvent.RoleAssigned.send(Role.VILLAGER, villager)
         val memories = villager.reveal(fakeCitizenWinSignal())
         villager.watchEpilogue(memories)


### PR DESCRIPTION
## Summary

- `PocAiPlayer` → `AiPlayer` にリネーム（ファイル名・クラス名・参照箇所）
- `ConsoleLanguageModel` → `PocConsoleLanguageModel` にリネーム（ファイル名・クラス名・参照箇所）

Closes #183

## Test plan

- [x] `./gradlew check` 通過確認済み

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)