### PR TITLE
Add Instruction to give personality to AiPlayer

### DIFF
--- a/src/main/kotlin/werewolf/ai/AiPlayer.kt
+++ b/src/main/kotlin/werewolf/ai/AiPlayer.kt
@@ -16,8 +16,16 @@ class AiPlayer(
     role: Role,
     override val name: String,
     private val languageModel: LanguageModel,
+    vararg instructions: Instruction,
 ) : Player(role) {
     private val _myMemories = mutableListOf<Recallable>()
+
+    init {
+        instructions.forEach {
+            memorize(it)
+            _myMemories.add(it)
+        }
+    }
 
     override fun onReceive(event: GameEvent) {
         _myMemories.add(event)
@@ -108,6 +116,7 @@ class AiPlayer(
 
     private val gameDescription = """
 あなたはプレイヤー${name}です。あなたの役職はゲームの流れの「役職通知」をご確認ください。
+ゲームの流れの冒頭にある指示に従って行動してください。
 役職構成：人狼2・狂人1・村人3・占い師1・霊能者1・狩人1（計9人）
 
 【勝利条件】

--- a/src/main/kotlin/werewolf/ai/Instruction.kt
+++ b/src/main/kotlin/werewolf/ai/Instruction.kt
@@ -2,7 +2,7 @@ package werewolf.ai
 
 import werewolf.game.Recallable
 
-class Instruction(private val text: String) : Recallable() {
+class Instruction(private val recipientName: String, private val text: String) : Recallable() {
     override fun recall() = text
-    override fun chronicle() = "[指示] $text"
+    override fun chronicle() = "[$recipientName] [指示] $text"
 }

--- a/src/main/kotlin/werewolf/ai/Instruction.kt
+++ b/src/main/kotlin/werewolf/ai/Instruction.kt
@@ -1,0 +1,8 @@
+package werewolf.ai
+
+import werewolf.game.Recallable
+
+class Instruction(private val text: String) : Recallable() {
+    override fun recall() = text
+    override fun chronicle() = "[指示] $text"
+}

--- a/src/main/kotlin/werewolf/game/Player.kt
+++ b/src/main/kotlin/werewolf/game/Player.kt
@@ -30,6 +30,10 @@ abstract class Player(private val role: Role) : Notifiable {
     protected abstract fun speak(context: DiscussionContext): Claim
     abstract fun watchEpilogue(chronicles: List<Recallable>)
 
+    protected fun memorize(recallable: Recallable) {
+        _memories.add(recallable)
+    }
+
     // signal is a capability token: only callers who hold a GameOverSignal (i.e., after game over) can access memories
     @Suppress("UnusedParameter")
     fun reveal(signal: GameOverSignal): List<Recallable> = _memories.toList()

--- a/src/main/kotlin/werewolf/lodge/PocAiLodge.kt
+++ b/src/main/kotlin/werewolf/lodge/PocAiLodge.kt
@@ -27,7 +27,7 @@ object PocAiLodge : Lodge() {
             Role.WEREWOLF, Role.SEER, Role.MEDIUM, Role.WEREWOLF,
         ).shuffled()
         return roles.mapIndexed { i, role ->
-            AiPlayer(role, names[i], PocConsoleLanguageModel(), Instruction(personalities[i])) to role
+            AiPlayer(role, names[i], PocConsoleLanguageModel(), Instruction(names[i], personalities[i])) to role
         }
     }
 }

--- a/src/main/kotlin/werewolf/lodge/PocAiLodge.kt
+++ b/src/main/kotlin/werewolf/lodge/PocAiLodge.kt
@@ -3,16 +3,31 @@ package werewolf.lodge
 import werewolf.game.Player
 import werewolf.game.Role
 import werewolf.ai.AiPlayer
+import werewolf.ai.Instruction
 import werewolf.ai.PocConsoleLanguageModel
 
 object PocAiLodge : Lodge() {
     private val names = listOf("Alice", "Bob", "Charlie", "Dave", "Eve", "Frank", "Grace", "Heidi", "Ivan")
+
+    private val personalities = listOf(
+        "あなたは注意深いプレイヤーです。議論の流れとは逆の可能性を常に検討し、発言に活かしてください。",
+        "あなたは計算高いプレイヤーです。生存者数と推定人狼数から残り何回処刑できるかを考え、議論に活かしてください。",
+        "あなたは積極的なプレイヤーです。自分の意見をはっきり主張し、議論をリードしてください。",
+        "あなたは観察眼の鋭いプレイヤーです。他プレイヤーの発言の矛盾や不自然さに注目して議論してください。",
+        "あなたは慎重なプレイヤーです。確証のないことは断言せず、可能性として提示することを心がけてください。",
+        "あなたは感情的なプレイヤーです。直感を大切にし、勢いよく発言してください。",
+        "あなたは論理的なプレイヤーです。情報を整理して筋道立てた推理を展開してください。",
+        "あなたは協調的なプレイヤーです。他プレイヤーの意見を尊重しつつ、村全体の合意形成を意識してください。",
+        "あなたは疑い深いプレイヤーです。他プレイヤーの発言を鵜呑みにせず、動機や裏の意図を考えてください。",
+    )
 
     override fun assignments(): List<Pair<Player, Role>> {
         val roles = listOf(
             Role.HUNTER, Role.VILLAGER, Role.VILLAGER, Role.VILLAGER, Role.MADMAN,
             Role.WEREWOLF, Role.SEER, Role.MEDIUM, Role.WEREWOLF,
         ).shuffled()
-        return roles.mapIndexed { i, role -> AiPlayer(role, names[i], PocConsoleLanguageModel()) to role }
+        return roles.mapIndexed { i, role ->
+            AiPlayer(role, names[i], PocConsoleLanguageModel(), Instruction(personalities[i])) to role
+        }
     }
 }

--- a/src/test/kotlin/werewolf/AiPlayerTest.kt
+++ b/src/test/kotlin/werewolf/AiPlayerTest.kt
@@ -139,6 +139,22 @@ class AiPlayerTest {
     }
 
     @Test
+    fun `instruction appears in prompt`() {
+        val lm = FakeLanguageModel("[真意]")
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm, Instruction("慎重に行動してください。"))
+        villager.discuss(openContext())
+        assertContains(lm.prompts.first(), "慎重に行動してください。")
+    }
+
+    @Test
+    fun `instruction is included in reveal`() {
+        val lm = FakeLanguageModel()
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm, Instruction("慎重に行動してください。"))
+        val memories = villager.reveal(fakeCitizenWinSignal())
+        assertTrue(memories.any { it.chronicle().contains("慎重に行動してください。") })
+    }
+
+    @Test
     fun `watchEpilogue prompt includes chronicle of events and reflection instruction`() {
         val lm = FakeLanguageModel("")
         val villager = AiPlayer(Role.VILLAGER, "Villager", lm)

--- a/src/test/kotlin/werewolf/AiPlayerTest.kt
+++ b/src/test/kotlin/werewolf/AiPlayerTest.kt
@@ -141,7 +141,7 @@ class AiPlayerTest {
     @Test
     fun `instruction appears in prompt`() {
         val lm = FakeLanguageModel("[真意]")
-        val villager = AiPlayer(Role.VILLAGER, "Villager", lm, Instruction("慎重に行動してください。"))
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm, Instruction("Villager", "慎重に行動してください。"))
         villager.discuss(openContext())
         assertContains(lm.prompts.first(), "慎重に行動してください。")
     }
@@ -149,9 +149,17 @@ class AiPlayerTest {
     @Test
     fun `instruction is included in reveal`() {
         val lm = FakeLanguageModel()
-        val villager = AiPlayer(Role.VILLAGER, "Villager", lm, Instruction("慎重に行動してください。"))
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm, Instruction("Villager", "慎重に行動してください。"))
         val memories = villager.reveal(fakeCitizenWinSignal())
         assertTrue(memories.any { it.chronicle().contains("慎重に行動してください。") })
+    }
+
+    @Test
+    fun `instruction chronicle includes recipient name`() {
+        val lm = FakeLanguageModel()
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm, Instruction("Villager", "慎重に行動してください。"))
+        val memories = villager.reveal(fakeCitizenWinSignal())
+        assertTrue(memories.any { it.chronicle().contains("Villager") && it.chronicle().contains("慎重に行動してください。") })
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `Instruction: Recallable` を新設。テキストを保持し、`recall()` でプロンプトに、`chronicle()` でエピローグに出力
- `Player.memorize()` を追加（`protected`）。サブクラスが `_memories` に任意の `Recallable` を追加できるように
- `AiPlayer` のコンストラクタに `vararg instructions: Instruction` を追加。`_myMemories`（プロンプト用）と `_memories`（`reveal()` 用）の両方に追加
- `gameDescription` に「ゲームの流れの冒頭にある指示に従って行動してください。」を追加
- `PocAiLodge` で各プレイヤーに異なる個性の `Instruction` を付与

#166 の個性パラメータ部分に対応（役職別戦略アドバイスは別途対応予定）

## Test plan

- [x] `instruction appears in prompt`：指示テキストがプロンプトに含まれる
- [x] `instruction is included in reveal`：指示が `reveal()` の返却値に含まれる
- [x] `instruction chronicle includes recipient name`：`chronicle()` に受信者名が含まれる
- [x] `./gradlew check` 通過済み

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)