### PR TITLE
Add AnthropicLanguageModel and AnthropicLodge

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ repositories {
 
 dependencies {
     implementation("com.google.genai:google-genai:1.53.0")
+    implementation("com.anthropic:anthropic-java:2.27.0")
     testImplementation(kotlin("test"))
     testImplementation("com.tngtech.archunit:archunit-junit5:1.3.0")
 }

--- a/src/main/kotlin/werewolf/Main.kt
+++ b/src/main/kotlin/werewolf/Main.kt
@@ -4,6 +4,7 @@ import werewolf.game.GameOverSignal
 import werewolf.phase.Epilogue
 import werewolf.phase.InitialPhase
 import werewolf.phase.Phase
+import werewolf.lodge.AnthropicLodge
 import werewolf.lodge.GeminiLodge
 import werewolf.lodge.HonestCpuLodge
 import werewolf.lodge.Lodge
@@ -24,7 +25,7 @@ fun main() {
 }
 
 private fun getLodge(): Lodge {
-    println("Lodgeを選択してください: AllHuman / RollerCPU / RandomCPU / HonestCPU / RoleAwareCPU / PocAI / Gemini")
+    println("Lodgeを選択してください: AllHuman / RollerCPU / RandomCPU / HonestCPU / RoleAwareCPU / PocAI / Gemini / Anthropic")
     return when (readLine()?.trim()) {
         "RollerCPU"    -> RollerCpuLodge
         "RandomCPU"    -> RandomCpuLodge
@@ -32,6 +33,7 @@ private fun getLodge(): Lodge {
         "RoleAwareCPU" -> RoleAwareCpuLodge
         "PocAI"        -> PocAiLodge
         "Gemini"       -> GeminiLodge
+        "Anthropic"    -> AnthropicLodge
         else           -> SmallLodge
     }
 }

--- a/src/main/kotlin/werewolf/ai/AnthropicLanguageModel.kt
+++ b/src/main/kotlin/werewolf/ai/AnthropicLanguageModel.kt
@@ -1,0 +1,43 @@
+package werewolf.ai
+
+import com.anthropic.client.AnthropicClient
+import com.anthropic.client.okhttp.AnthropicOkHttpClient
+import com.anthropic.models.messages.CacheControlEphemeral
+import com.anthropic.models.messages.MessageCreateParams
+import com.anthropic.models.messages.TextBlockParam
+
+class AnthropicLanguageModel(
+    private val model: String = DEFAULT_MODEL,
+) : LanguageModel {
+    private val client: AnthropicClient = AnthropicOkHttpClient.fromEnv()
+
+    override fun ask(system: String, user: String): String {
+        val params = MessageCreateParams.builder()
+            .model(model)
+            .maxTokens(MAX_TOKENS)
+            .systemOfTextBlockParams(listOf(
+                TextBlockParam.builder()
+                    .text(system)
+                    .cacheControl(CacheControlEphemeral.builder().build())
+                    .build()
+            ))
+            .addUserMessage(user)
+            .build()
+        // Catch broadly and swallow cause to prevent API key leakage via exception messages or URLs
+        @Suppress("TooGenericExceptionCaught", "SwallowedException")
+        return try {
+            client.messages().create(params).content()
+                .mapNotNull { it.text().orElse(null) }
+                .joinToString("") { it.text() }
+        } catch (e: Exception) {
+            throw AnthropicApiException("Anthropic API call failed: ${e.javaClass.simpleName}")
+        }
+    }
+
+    class AnthropicApiException(message: String) : Exception(message)
+
+    companion object {
+        private const val DEFAULT_MODEL = "claude-haiku-4-5"
+        private const val MAX_TOKENS = 16000L
+    }
+}

--- a/src/main/kotlin/werewolf/lodge/AnthropicLodge.kt
+++ b/src/main/kotlin/werewolf/lodge/AnthropicLodge.kt
@@ -16,7 +16,7 @@ object AnthropicLodge : Lodge() {
             Role.HUNTER, Role.VILLAGER, Role.VILLAGER, Role.VILLAGER, Role.MADMAN,
             Role.WEREWOLF, Role.SEER, Role.MEDIUM, Role.WEREWOLF,
         ).shuffled()
-        val human = HumanPlayer(roles[0], "You", ConsolePlayerIO()) to roles[0]
+        val human = HumanPlayer(roles[0], "Ivan", ConsolePlayerIO()) to roles[0]
         val aiPlayers = roles.drop(1).mapIndexed { i, role -> AiPlayer(role, aiNames[i], languageModel) to role }
         return listOf(human) + aiPlayers
     }

--- a/src/main/kotlin/werewolf/lodge/AnthropicLodge.kt
+++ b/src/main/kotlin/werewolf/lodge/AnthropicLodge.kt
@@ -1,0 +1,23 @@
+package werewolf.lodge
+
+import werewolf.ai.AiPlayer
+import werewolf.ai.AnthropicLanguageModel
+import werewolf.game.Player
+import werewolf.game.Role
+import werewolf.human.ConsolePlayerIO
+import werewolf.human.HumanPlayer
+
+object AnthropicLodge : Lodge() {
+    private val aiNames = listOf("Alice", "Bob", "Charlie", "Dave", "Eve", "Frank", "Grace", "Heidi")
+
+    override fun assignments(): List<Pair<Player, Role>> {
+        val languageModel = AnthropicLanguageModel()
+        val roles = listOf(
+            Role.HUNTER, Role.VILLAGER, Role.VILLAGER, Role.VILLAGER, Role.MADMAN,
+            Role.WEREWOLF, Role.SEER, Role.MEDIUM, Role.WEREWOLF,
+        ).shuffled()
+        val human = HumanPlayer(roles[0], "You", ConsolePlayerIO()) to roles[0]
+        val aiPlayers = roles.drop(1).mapIndexed { i, role -> AiPlayer(role, aiNames[i], languageModel) to role }
+        return listOf(human) + aiPlayers
+    }
+}

--- a/src/main/kotlin/werewolf/lodge/GeminiLodge.kt
+++ b/src/main/kotlin/werewolf/lodge/GeminiLodge.kt
@@ -16,7 +16,7 @@ object GeminiLodge : Lodge() {
             Role.HUNTER, Role.VILLAGER, Role.VILLAGER, Role.VILLAGER, Role.MADMAN,
             Role.WEREWOLF, Role.SEER, Role.MEDIUM, Role.WEREWOLF,
         ).shuffled()
-        val human = HumanPlayer(roles[0], "You", ConsolePlayerIO()) to roles[0]
+        val human = HumanPlayer(roles[0], "Ivan", ConsolePlayerIO()) to roles[0]
         val aiPlayers = roles.drop(1).mapIndexed { i, role -> AiPlayer(role, aiNames[i], languageModel) to role }
         return listOf(human) + aiPlayers
     }


### PR DESCRIPTION
## Summary

- `AnthropicLanguageModel` を追加。Anthropic Java SDK を使って Claude API を呼び出す
  - システムプロンプトにプロンプトキャッシュを設定
  - 例外をラップして API キー漏洩を防止
- `AnthropicLodge` を追加。HumanPlayer 1名 + AiPlayer 8名の構成
- Lodge 選択肢に `Anthropic` を追加
- `GeminiLodge` の人間プレイヤー名を "You" → "Ivan" に統一（AI がプロンプト中の "You" を自分への呼びかけと誤認するのを防ぐ）

Closes #190

## Test plan

- [x] `./gradlew check` 通過済み

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)