### PR TITLE
Simplify ConsolePlayerIO display to single-line format

### DIFF
--- a/src/main/kotlin/werewolf/human/ConsolePlayerIO.kt
+++ b/src/main/kotlin/werewolf/human/ConsolePlayerIO.kt
@@ -3,14 +3,13 @@ package werewolf.human
 import werewolf.game.Player
 
 class ConsolePlayerIO : PlayerIO {
-    override fun sendMessage(playerName: String, title: String, content: String) {
-        println("=== ${playerName}：${title} ===")
-        println(content)
+    override fun sendMessage(title: String, content: String) {
+        println("[$title] $content")
     }
 
-    override fun promptPlayer(playerName: String, title: String, content: String, candidates: List<Player>): Player {
+    override fun promptPlayer(title: String, content: String, candidates: List<Player>): Player {
         while (true) {
-            sendMessage(playerName, title, "$content: ${candidates.joinToString(", ") { it.name }}")
+            sendMessage(title, "$content: ${candidates.joinToString(", ") { it.name }}")
             val input = readLine() ?: ""
             val player = candidates.firstOrNull { it.name == input }
             if (player != null) return player
@@ -18,14 +17,14 @@ class ConsolePlayerIO : PlayerIO {
         }
     }
 
-    override fun promptFreeText(playerName: String, title: String, content: String): String {
-        sendMessage(playerName, title, content)
+    override fun promptFreeText(title: String, content: String): String {
+        sendMessage(title, content)
         return readLine() ?: ""
     }
 
-    override fun promptChoice(playerName: String, title: String, content: String, options: List<String>): Int {
+    override fun promptChoice(title: String, content: String, options: List<String>): Int {
         while (true) {
-            sendMessage(playerName, title, content)
+            sendMessage(title, content)
             options.forEachIndexed { i, option -> println("${i + 1}: $option") }
             val input = readLine()?.toIntOrNull()
             if (input != null && input in 1..options.size) return input - 1

--- a/src/main/kotlin/werewolf/human/HumanPlayer.kt
+++ b/src/main/kotlin/werewolf/human/HumanPlayer.kt
@@ -15,10 +15,10 @@ import werewolf.game.StatementType
 
 class HumanPlayer(role: Role, override val name: String, private val io: PlayerIO) : Player(role) {
     override fun choose(context: SelectionContext): Choice =
-        Choice(this, context, io.promptPlayer(name, context.title, context.description, context.candidates()), "プレイヤーが選択")
+        Choice(this, context, io.promptPlayer(context.title, context.description, context.candidates()), "プレイヤーが選択")
 
     override fun onReceive(event: GameEvent) {
-        io.sendMessage(name, event.title, event.body())
+        io.sendMessage(event.title, event.body())
     }
 
     override fun speak(context: DiscussionContext): Claim {
@@ -34,29 +34,29 @@ class HumanPlayer(role: Role, override val name: String, private val io: PlayerI
     private fun selectType(context: DiscussionContext): StatementType {
         val types = StatementType.entries.filter { it in context.availableTypes }
         if (types.size == 1) return types.first()
-        val idx = io.promptChoice(name, context.title, context.description, types.map { it.displayName })
+        val idx = io.promptChoice(context.title, context.description, types.map { it.displayName })
         return types[idx]
     }
 
     private fun buildPlain(context: DiscussionContext): Statement =
-        Statement.Plain(io.promptFreeText(name, context.title, "発言してください"))
+        Statement.Plain(io.promptFreeText(context.title, "発言してください"))
 
     private fun buildDivinationReport(context: DiscussionContext): Statement {
-        val target = io.promptPlayer(name, "占い報告 - 対象", "誰の占い結果を報告しますか？", context.allPlayers.filter { it !== this })
+        val target = io.promptPlayer("占い報告 - 対象", "誰の占い結果を報告しますか？", context.allPlayers.filter { it !== this })
         val results = DivineResult.entries
-        val resultIdx = io.promptChoice(name, "占い報告 - 結果", "占い結果を選んでください", results.map { it.displayName })
+        val resultIdx = io.promptChoice("占い報告 - 結果", "占い結果を選んでください", results.map { it.displayName })
         return Statement.DivinationReport(this, target, results[resultIdx])
     }
 
     private fun buildMediumReport(context: DiscussionContext): Statement {
-        val target = io.promptPlayer(name, "霊媒報告 - 対象", "誰の霊媒結果を報告しますか？", context.allPlayers.filter { it !== this })
+        val target = io.promptPlayer("霊媒報告 - 対象", "誰の霊媒結果を報告しますか？", context.allPlayers.filter { it !== this })
         val results = MediumResult.entries
-        val resultIdx = io.promptChoice(name, "霊媒報告 - 結果", "霊媒結果を選んでください", results.map { it.displayName })
+        val resultIdx = io.promptChoice("霊媒報告 - 結果", "霊媒結果を選んでください", results.map { it.displayName })
         return Statement.MediumReport(this, target, results[resultIdx])
     }
 
     override fun watchEpilogue(chronicles: List<Recallable>) {
         val content = chronicles.joinToString("\n") { "  ${it.chronicle()}" }
-        io.sendMessage(name, "ゲーム振り返り", content)
+        io.sendMessage("ゲーム振り返り", content)
     }
 }

--- a/src/main/kotlin/werewolf/human/PlayerIO.kt
+++ b/src/main/kotlin/werewolf/human/PlayerIO.kt
@@ -3,8 +3,8 @@ package werewolf.human
 import werewolf.game.Player
 
 interface PlayerIO {
-    fun sendMessage(playerName: String, title: String, content: String)
-    fun promptPlayer(playerName: String, title: String, content: String, candidates: List<Player>): Player
-    fun promptFreeText(playerName: String, title: String, content: String): String
-    fun promptChoice(playerName: String, title: String, content: String, options: List<String>): Int
+    fun sendMessage(title: String, content: String)
+    fun promptPlayer(title: String, content: String, candidates: List<Player>): Player
+    fun promptFreeText(title: String, content: String): String
+    fun promptChoice(title: String, content: String, options: List<String>): Int
 }


### PR DESCRIPTION
## Summary
- `PlayerIO` インターフェースから `playerName` 引数を削除
- `ConsolePlayerIO` の表示を `=== Name：title ===` + 本文（2行）から `[title] 内容`（1行）に変更
- `HumanPlayer` の各 IO 呼び出しを更新

Closes #194

## Test plan
- [x] `./gradlew build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)