### PR TITLE
Transition to epilogue on AI API error and make LanguageModel a fun interface

### DIFF
--- a/src/main/kotlin/werewolf/ai/AiPlayer.kt
+++ b/src/main/kotlin/werewolf/ai/AiPlayer.kt
@@ -6,6 +6,7 @@ import werewolf.game.DiscussionContext
 import werewolf.game.FallbackChoice
 import werewolf.game.FallbackClaim
 import werewolf.game.GameEvent
+import werewolf.game.GameOverSignal
 import werewolf.game.Player
 import werewolf.game.Recallable
 import werewolf.game.Role
@@ -103,14 +104,7 @@ class AiPlayer(
 
     private class InvalidAiInputException(message: String) : Exception(message)
 
-    override fun watchEpilogue(chronicles: List<Recallable>) {
-        val instruction = buildString {
-            appendLine("=== エピローグ（プレイヤー $name） ===")
-            chronicles.forEach { appendLine(it.chronicle()) }
-            append("プレイヤーとして200文字以内でゲームの振り返りをしてください。")
-        }
-        prompt(instruction)
-    }
+    override fun watchEpilogue(chronicles: List<Recallable>) = Unit
 
     private fun prompt(instruction: String): Completion {
         val user = buildString {
@@ -121,7 +115,12 @@ class AiPlayer(
             if (_myMemories.isEmpty()) appendLine("（なし）")
             else _myMemories.forEach { appendLine(it.recall()) }
         }
-        return languageModel.ask(gameDescription, user)
+        @Suppress("TooGenericExceptionCaught")
+        return try {
+            languageModel.ask(gameDescription, user)
+        } catch (e: Exception) {
+            GameOverSignal.throwAborted(e)
+        }
     }
 
     private fun withMetadata(intent: String, metadata: ModelMetadata) =

--- a/src/main/kotlin/werewolf/ai/LanguageModel.kt
+++ b/src/main/kotlin/werewolf/ai/LanguageModel.kt
@@ -1,6 +1,6 @@
 package werewolf.ai
 
 
-interface LanguageModel {
+fun interface LanguageModel {
     fun ask(system: String, user: String): Completion
 }

--- a/src/main/kotlin/werewolf/game/GameOverSignal.kt
+++ b/src/main/kotlin/werewolf/game/GameOverSignal.kt
@@ -1,10 +1,18 @@
 package werewolf.game
 
-class GameOverSignal private constructor(val winningSide: Side) : Throwable() {
+sealed class GameOverSignal : Throwable() {
+    class Completed(val winningSide: Side) : GameOverSignal()
+    object Aborted : GameOverSignal()
+
     companion object {
         fun throwIfGameOver(aliveCounts: AliveCounts) {
             WinConditionChecker.winningSide(aliveCounts)
-                ?.let { throw GameOverSignal(it) }
+                ?.let { throw Completed(it) }
+        }
+
+        fun throwAborted(cause: Exception): Nothing {
+            cause.printStackTrace()
+            throw Aborted
         }
     }
 }

--- a/src/main/kotlin/werewolf/phase/Epilogue.kt
+++ b/src/main/kotlin/werewolf/phase/Epilogue.kt
@@ -13,8 +13,13 @@ class Epilogue(
     private val signal: GameOverSignal
 ) {
     fun perform() {
-        GameEvent.GameOver.send(signal.winningSide, AllPlayers(playerManager))
-        playerManager.allPlayers.forEach { GameEvent.GameResult.send(oracle.isWinner(it, signal.winningSide), it) }
+        when (signal) {
+            is GameOverSignal.Completed -> {
+                GameEvent.GameOver.send(signal.winningSide, AllPlayers(playerManager))
+                playerManager.allPlayers.forEach { GameEvent.GameResult.send(oracle.isWinner(it, signal.winningSide), it) }
+            }
+            is GameOverSignal.Aborted -> Unit
+        }
         showRecap()
     }
 

--- a/src/test/kotlin/werewolf/AiPlayerTest.kt
+++ b/src/test/kotlin/werewolf/AiPlayerTest.kt
@@ -8,6 +8,7 @@ import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class AiPlayerTest {
@@ -191,14 +192,18 @@ class AiPlayerTest {
     }
 
     @Test
-    fun `watchEpilogue prompt includes chronicle of events and reflection instruction`() {
-        val lm = FakeLanguageModel("")
+    fun `watchEpilogue does not call languageModel`() {
+        val lm = FakeLanguageModel()
         val villager = AiPlayer(Role.VILLAGER, "Villager", lm)
-        GameEvent.RoleAssigned.send(Role.VILLAGER, villager)
-        val memories = villager.reveal(fakeCitizenWinSignal())
-        villager.watchEpilogue(memories)
-        assertContains(lm.prompts.first(), "Villager")
-        assertContains(lm.prompts.first(), "役職通知")
-        assertContains(lm.prompts.first(), "振り返り")
+        villager.watchEpilogue(emptyList())
+        assertTrue(lm.prompts.isEmpty())
+    }
+
+    @Test
+    @Suppress("TooGenericExceptionThrown")
+    fun `discuss throws GameOverSignal when languageModel throws`() {
+        val lm = LanguageModel { _, _ -> throw Exception("API error") }
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm)
+        assertFailsWith<GameOverSignal> { villager.discuss(openContext()) }
     }
 }

--- a/src/test/kotlin/werewolf/EpilogueTest.kt
+++ b/src/test/kotlin/werewolf/EpilogueTest.kt
@@ -5,6 +5,7 @@ import werewolf.phase.*
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class EpilogueTest {
@@ -63,6 +64,17 @@ class EpilogueTest {
 
         assertTrue(wolf.watchedEvents.isNotEmpty())
         assertTrue(villager.watchedEvents.isNotEmpty())
+    }
+
+    @Test
+    fun `GameOver and GameResult are not sent when game is aborted`() {
+        val villager = WatchingPlayer(Role.VILLAGER, "Villager")
+        val setup = TestLodge(villager to Role.VILLAGER).create()
+
+        Epilogue(setup.playerManager, setup.oracle, fakeAbortedSignal()).perform()
+
+        assertNull(villager.gameOver)
+        assertNull(villager.gameResult)
     }
 
     @Test

--- a/src/test/kotlin/werewolf/TestFactories.kt
+++ b/src/test/kotlin/werewolf/TestFactories.kt
@@ -7,6 +7,10 @@ fun fakeCitizenWinSignal(): GameOverSignal = try {
     error("unreachable")
 } catch (s: GameOverSignal) { s }
 
+fun fakeAbortedSignal(): GameOverSignal = try {
+    GameOverSignal.throwAborted(Exception("test"))
+} catch (s: GameOverSignal) { s }
+
 fun openContext(
     players: List<Player> = emptyList(),
     round: Int = 1,


### PR DESCRIPTION
Closes #198

## Summary
- `GameOverSignal` を sealed class に変更し `Completed(winningSide: Side)` と `Aborted` に型で分離
- `AiPlayer.prompt()` で API 例外をキャッチして `GameOverSignal.throwAborted()` を呼び出しエピローグへ移行
- `AiPlayer.watchEpilogue()` を空実装に変更（エピローグ移行後の再度 API 呼び出しを防ぐ）
- `LanguageModel` を `fun interface` に変更

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)