### PR TITLE
Separate chronicle content from intent in Recallable

### DIFF
--- a/src/main/kotlin/werewolf/game/Choice.kt
+++ b/src/main/kotlin/werewolf/game/Choice.kt
@@ -5,14 +5,14 @@ sealed class Choice(
     val context: SelectionContext,
     val selected: Player,
     private val intentForRecall: String,
-    val intentForChronicle: String,
+    override val intentForChronicle: String,
 ) : Recallable() {
     init {
         require(selected in context.candidates()) { "${selected.name} is not in candidates" }
     }
 
     override fun recall() = "[${context.title}] ${selected.name} [$intentForRecall]"
-    override fun chronicle() = "[${chooser.name}] [${context.title}] ${selected.name} [$intentForChronicle]"
+    override fun chronicle() = "[${chooser.name}] [${context.title}] ${selected.name}"
 
     companion object {
         operator fun invoke(

--- a/src/main/kotlin/werewolf/game/Claim.kt
+++ b/src/main/kotlin/werewolf/game/Claim.kt
@@ -5,14 +5,14 @@ sealed class Claim(
     val context: DiscussionContext,
     val statement: Statement,
     private val intentForRecall: String,
-    val intentForChronicle: String,
+    override val intentForChronicle: String,
 ) : Recallable() {
     init {
         require(statement.type in context.availableTypes) { "${statement.type} is not available in ${context.title}" }
     }
 
     override fun recall() = "[${context.title}] ${statement.text()} [$intentForRecall]"
-    override fun chronicle() = "[${speaker.name}] [${context.title}] ${statement.text()} [$intentForChronicle]"
+    override fun chronicle() = "[${speaker.name}] [${context.title}] ${statement.text()}"
 
     companion object {
         operator fun invoke(

--- a/src/main/kotlin/werewolf/game/Recallable.kt
+++ b/src/main/kotlin/werewolf/game/Recallable.kt
@@ -4,4 +4,5 @@ abstract class Recallable {
     val sequenceId: Long = System.nanoTime()
     abstract fun recall(): String
     abstract fun chronicle(): String
+    open val intentForChronicle: String? get() = null
 }

--- a/src/main/kotlin/werewolf/human/HumanPlayer.kt
+++ b/src/main/kotlin/werewolf/human/HumanPlayer.kt
@@ -56,7 +56,10 @@ class HumanPlayer(role: Role, override val name: String, private val io: PlayerI
     }
 
     override fun watchEpilogue(chronicles: List<Recallable>) {
-        val content = chronicles.joinToString("\n") { "  ${it.chronicle()}" }
+        val content = chronicles.joinToString("\n") {
+            val intent = it.intentForChronicle
+            if (intent != null) "${it.chronicle()}\n  [$intent]" else it.chronicle()
+        }
         io.sendMessage("ゲーム振り返り", content)
     }
 }

--- a/src/test/kotlin/werewolf/AiPlayerTest.kt
+++ b/src/test/kotlin/werewolf/AiPlayerTest.kt
@@ -168,18 +168,18 @@ class AiPlayerTest {
     }
 
     @Test
-    fun `speak metadata is included in claim chronicle but not in recall`() {
+    fun `speak metadata is included in intentForChronicle but not in recall`() {
         val lm = FakeLanguageModel("hello[真意内容]", "[dummy]", metadata = ModelMetadata { "model=test" })
         val villager = AiPlayer(Role.VILLAGER, "Villager", lm)
         villager.discuss(openContext())
         villager.discuss(openContext())
         val memories = villager.reveal(fakeCitizenWinSignal())
-        assertTrue(memories.filterIsInstance<Claim>().any { it.chronicle().contains("model=test") })
+        assertTrue(memories.filterIsInstance<Claim>().any { it.intentForChronicle?.contains("model=test") == true })
         assertFalse(lm.prompts[1].contains("model=test"))
     }
 
     @Test
-    fun `choose metadata is included in choice chronicle but not in recall`() {
+    fun `choose metadata is included in intentForChronicle but not in recall`() {
         val lm = FakeLanguageModel("Wolf：怪しいから", "[dummy]", metadata = ModelMetadata { "model=test" })
         val villager = AiPlayer(Role.VILLAGER, "Villager", lm)
         val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
@@ -187,7 +187,7 @@ class AiPlayerTest {
         villager.selectTarget(context)
         villager.discuss(openContext())
         val memories = villager.reveal(fakeCitizenWinSignal())
-        assertTrue(memories.filterIsInstance<Choice>().any { it.chronicle().contains("model=test") })
+        assertTrue(memories.filterIsInstance<Choice>().any { it.intentForChronicle?.contains("model=test") == true })
         assertFalse(lm.prompts[1].contains("model=test"))
     }
 

--- a/src/test/kotlin/werewolf/ClaimTest.kt
+++ b/src/test/kotlin/werewolf/ClaimTest.kt
@@ -36,11 +36,19 @@ class ClaimTest {
     }
 
     @Test
-    fun `chronicle returns speaker name, context title, statement text, and intent`() {
+    fun `chronicle returns speaker name, context title, and statement text`() {
         val speaker = NothingPlayer(Role.VILLAGER, "Speaker")
         val context = openContext(listOf(speaker))
         val claim = Claim(speaker, context, Statement.Plain("発言内容"), "真意内容")
-        assertEquals("[Speaker] [議論] 発言内容 [真意内容]", claim.chronicle())
+        assertEquals("[Speaker] [議論] 発言内容", claim.chronicle())
+    }
+
+    @Test
+    fun `intentForChronicle returns the chronicle intent`() {
+        val speaker = NothingPlayer(Role.VILLAGER, "Speaker")
+        val context = openContext(listOf(speaker))
+        val claim = Claim(speaker, context, Statement.Plain("発言内容"), "真意内容")
+        assertEquals("真意内容", claim.intentForChronicle)
     }
 
     @Test

--- a/src/test/kotlin/werewolf/HumanPlayerTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerTest.kt
@@ -1,0 +1,43 @@
+package werewolf
+
+import werewolf.game.Player
+import werewolf.game.Recallable
+import werewolf.game.Role
+import werewolf.human.HumanPlayer
+import werewolf.human.PlayerIO
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HumanPlayerTest {
+
+    private class CapturingIO : PlayerIO {
+        val messages = mutableListOf<Pair<String, String>>()
+        override fun sendMessage(title: String, content: String) { messages += title to content }
+        override fun promptPlayer(title: String, content: String, candidates: List<Player>): Player = error("not used")
+        override fun promptFreeText(title: String, content: String): String = error("not used")
+        override fun promptChoice(title: String, content: String, options: List<String>): Int = error("not used")
+    }
+
+    private fun recallable(chronicleText: String, intent: String? = null) = object : Recallable() {
+        override fun recall() = chronicleText
+        override fun chronicle() = chronicleText
+        override val intentForChronicle get() = intent
+    }
+
+    @Test
+    fun `watchEpilogue shows chronicle when intentForChronicle is null`() {
+        val io = CapturingIO()
+        val player = HumanPlayer(Role.VILLAGER, "Player", io)
+        player.watchEpilogue(listOf(recallable("some chronicle")))
+        assertEquals("some chronicle", io.messages.last().second)
+    }
+
+    @Test
+    fun `watchEpilogue appends intent on next line when intentForChronicle is present`() {
+        val io = CapturingIO()
+        val player = HumanPlayer(Role.VILLAGER, "Player", io)
+        player.watchEpilogue(listOf(recallable("some chronicle", "some intent")))
+        assertEquals("some chronicle\n  [some intent]", io.messages.last().second)
+    }
+}


### PR DESCRIPTION
## Summary

- `Recallable` に `open val intentForChronicle: String? get() = null` を追加し、chronicle 本文とインテントをデータレベルで分離
- `Choice` / `Claim` の `intentForChronicle` に `override` を付け、`chronicle()` からインテント部分を削除
- `HumanPlayer.watchEpilogue` でインテントが存在する場合のみ次の行（`  [...]` 形式）に出力するよう変更

Closes #199

## Test plan

- [ ] `ClaimTest`: chronicle に intent が含まれないこと、`intentForChronicle` が正しい値を返すことを確認
- [ ] `AiPlayerTest`: メタデータが `intentForChronicle` に含まれ、recall には含まれないことを確認
- [ ] `./gradlew test` がすべてパスすること

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)