### PR TITLE
Remove duplicate statement display in watchEpilogue

### DIFF
--- a/src/main/kotlin/werewolf/game/GameEvent.kt
+++ b/src/main/kotlin/werewolf/game/GameEvent.kt
@@ -67,6 +67,7 @@ sealed class GameEvent : Recallable() {
         override val title = "発言（${round}ラウンド目）"
         override fun body() = "$speakerName: ${statement.text()}"
         override val recipients: Notifiable = allPlayers
+        override val isRedundantInChronicle = true
         companion object {
             fun send(round: Int, speakerName: String, statement: Statement, allPlayers: AllPlayers) =
                 StatementMade(round, speakerName, statement, allPlayers).dispatch()
@@ -129,6 +130,7 @@ sealed class GameEvent : Recallable() {
         override val title = "密談（${round}ラウンド目）"
         override fun body() = "$speakerName: $statement"
         override val recipients: Notifiable = wolves
+        override val isRedundantInChronicle = true
         companion object {
             fun send(round: Int, speakerName: String, statement: String, wolves: Wolves) =
                 WerewolfStatementMade(round, speakerName, statement, wolves).dispatch()

--- a/src/main/kotlin/werewolf/game/Recallable.kt
+++ b/src/main/kotlin/werewolf/game/Recallable.kt
@@ -5,4 +5,5 @@ abstract class Recallable {
     abstract fun recall(): String
     abstract fun chronicle(): String
     open val intentForChronicle: String? get() = null
+    open val isRedundantInChronicle: Boolean get() = false
 }

--- a/src/main/kotlin/werewolf/human/HumanPlayer.kt
+++ b/src/main/kotlin/werewolf/human/HumanPlayer.kt
@@ -56,10 +56,12 @@ class HumanPlayer(role: Role, override val name: String, private val io: PlayerI
     }
 
     override fun watchEpilogue(chronicles: List<Recallable>) {
-        val content = chronicles.joinToString("\n") {
-            val intent = it.intentForChronicle
-            if (intent != null) "${it.chronicle()}\n  [$intent]" else it.chronicle()
-        }
+        val content = chronicles
+            .filter { !it.isRedundantInChronicle }
+            .joinToString("\n") {
+                val intent = it.intentForChronicle
+                if (intent != null) "${it.chronicle()}\n  [$intent]" else it.chronicle()
+            }
         io.sendMessage("ゲーム振り返り", content)
     }
 }

--- a/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
@@ -1,0 +1,60 @@
+package werewolf
+
+import werewolf.game.*
+import werewolf.human.HumanPlayer
+import werewolf.human.PlayerIO
+import werewolf.phase.Conclave
+import werewolf.phase.Epilogue
+import werewolf.phase.OpenDiscussion
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class HumanPlayerEpilogueTest {
+
+    private class SpeakingIO : PlayerIO {
+        val messages = mutableListOf<Pair<String, String>>()
+        override fun sendMessage(title: String, content: String) { messages += title to content }
+        override fun promptPlayer(title: String, content: String, candidates: List<Player>): Player = error("not used")
+        override fun promptFreeText(title: String, content: String): String = "human speaks"
+        override fun promptChoice(title: String, content: String, options: List<String>): Int = 0
+    }
+
+    private class SpeakingPlayer(role: Role, name: String) : NothingPlayer(role, name) {
+        override fun onReceive(event: GameEvent) {}
+        override fun watchEpilogue(chronicles: List<Recallable>) {}
+        override fun speak(context: DiscussionContext): Claim =
+            Claim(this, context, Statement.Plain("$name speaks"), "intent")
+    }
+
+    @Test
+    fun `claims from discussion appear in epilogue but StatementMade does not`() {
+        val io = SpeakingIO()
+        val human = HumanPlayer(Role.VILLAGER, "Human", io)
+        val speaker = SpeakingPlayer(Role.VILLAGER, "Speaker")
+        val setup = TestLodge(human to Role.VILLAGER, speaker to Role.VILLAGER).create()
+
+        OpenDiscussion(setup.playerManager, day = 1).conduct()
+        Epilogue(setup.playerManager, setup.oracle, fakeCitizenWinSignal()).perform()
+
+        val content = io.messages.last().second
+        assertTrue(content.contains("[Speaker] [議論]"))
+        assertFalse(content.contains("発言（"))  // StatementMade のタイトルパターン
+    }
+
+    @Test
+    fun `claims from conclave appear in epilogue but WerewolfStatementMade does not`() {
+        val io = SpeakingIO()
+        val human = HumanPlayer(Role.WEREWOLF, "Human", io)
+        val wolf = SpeakingPlayer(Role.WEREWOLF, "Wolf")
+        val setup = TestLodge(human to Role.WEREWOLF, wolf to Role.WEREWOLF).create()
+
+        Conclave(setup.oracle, setup.playerManager, day = 1).conduct()
+        Epilogue(setup.playerManager, setup.oracle, fakeCitizenWinSignal()).perform()
+
+        val content = io.messages.last().second
+        assertTrue(content.contains("[Wolf] [密談]"))
+        assertFalse(content.contains("密談（"))  // WerewolfStatementMade のタイトルパターン
+    }
+}

--- a/src/test/kotlin/werewolf/HumanPlayerTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerTest.kt
@@ -19,10 +19,11 @@ class HumanPlayerTest {
         override fun promptChoice(title: String, content: String, options: List<String>): Int = error("not used")
     }
 
-    private fun recallable(chronicleText: String, intent: String? = null) = object : Recallable() {
+    private fun recallable(chronicleText: String, intent: String? = null, redundant: Boolean = false) = object : Recallable() {
         override fun recall() = chronicleText
         override fun chronicle() = chronicleText
         override val intentForChronicle get() = intent
+        override val isRedundantInChronicle get() = redundant
     }
 
     @Test
@@ -39,5 +40,13 @@ class HumanPlayerTest {
         val player = HumanPlayer(Role.VILLAGER, "Player", io)
         player.watchEpilogue(listOf(recallable("some chronicle", "some intent")))
         assertEquals("some chronicle\n  [some intent]", io.messages.last().second)
+    }
+
+    @Test
+    fun `watchEpilogue excludes redundant records`() {
+        val io = CapturingIO()
+        val player = HumanPlayer(Role.VILLAGER, "Player", io)
+        player.watchEpilogue(listOf(recallable("kept"), recallable("excluded", redundant = true)))
+        assertEquals("kept", io.messages.last().second)
     }
 }


### PR DESCRIPTION
## Summary

- `Recallable` に `isRedundantInChronicle` プロパティを追加（デフォルト `false`）
- `GameEvent.StatementMade` と `GameEvent.WerewolfStatementMade` で `true` にオーバーライド
- `HumanPlayer.watchEpilogue` でフィルタリングし、Claim と StatementMade の二重表示を解消

Closes #208

## Test plan

- [ ] `HumanPlayerTest`: `isRedundantInChronicle == true` のレコードが除外されることを確認
- [ ] `HumanPlayerEpilogueTest`: 議論後のエピローグに Claim は表示され `発言（` は含まれないことを確認
- [ ] `HumanPlayerEpilogueTest`: 密談後のエピローグに Claim は表示され `密談（` は含まれないことを確認
- [ ] `./gradlew test` がすべてパスすること

🤖 Claude: Generated with [Claude Code](https://claude.com/claude-code)