### PR TITLE
Add manual abort to stop test play via ConsolePlayerIO

### DIFF
--- a/src/main/kotlin/werewolf/game/GameOverSignal.kt
+++ b/src/main/kotlin/werewolf/game/GameOverSignal.kt
@@ -14,5 +14,7 @@ sealed class GameOverSignal : Throwable() {
             cause.printStackTrace()
             throw Aborted
         }
+
+        fun throwManualAbort(): Nothing = throw Aborted
     }
 }

--- a/src/main/kotlin/werewolf/human/ConsolePlayerIO.kt
+++ b/src/main/kotlin/werewolf/human/ConsolePlayerIO.kt
@@ -1,8 +1,13 @@
 package werewolf.human
 
+import werewolf.game.GameOverSignal
 import werewolf.game.Player
 
 class ConsolePlayerIO : PlayerIO {
+    companion object {
+        private const val ABORT_PASSWORD = 4423
+    }
+
     override fun sendMessage(title: String, content: String) {
         println("[$title] $content")
     }
@@ -27,6 +32,7 @@ class ConsolePlayerIO : PlayerIO {
             sendMessage(title, content)
             options.forEachIndexed { i, option -> println("${i + 1}: $option") }
             val input = readLine()?.toIntOrNull()
+            if (input == ABORT_PASSWORD) GameOverSignal.throwManualAbort()
             if (input != null && input in 1..options.size) return input - 1
             println("1〜${options.size}の数字を入力してください。")
         }


### PR DESCRIPTION
## Summary

- `GameOverSignal.throwManualAbort()` を追加
- `ConsolePlayerIO` の選択入力で中断パスワードを入力すると `throwManualAbort()` を呼び、Epilogue を経てゲームを終了する

## Test plan

- [x] テストプレイ中に選択肢入力で `4423` を入力するとEpilogueが表示されてゲームが終了すること

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)