### PR TITLE
Move input validation from ConsolePlayerIO to PlayerIO

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ tasks.jacocoTestReport {
                     "werewolf/ai/anthropic/**",
                     "werewolf/ai/gemini/**",
                     "werewolf/ai/poc/**",
+                    "werewolf/human/console/**",
                     // プレイヤーと役職の組み合わせを定義する配線コードのため、カバレッジ計測対象外とする
                     "werewolf/lodge/**",
                 )
@@ -77,6 +78,6 @@ sonar {
         property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml")
         // JaCoCo除外と合わせて、SonarCloud側でもソースファイルとして計測対象外にする
         property("sonar.coverage.exclusions",
-            "**/ai/anthropic/**,**/ai/gemini/**,**/ai/poc/**,**/lodge/**")
+            "**/ai/anthropic/**,**/ai/gemini/**,**/ai/poc/**,**/human/console/**,**/lodge/**")
     }
 }

--- a/src/main/kotlin/werewolf/human/ConsolePlayerIO.kt
+++ b/src/main/kotlin/werewolf/human/ConsolePlayerIO.kt
@@ -1,40 +1,11 @@
 package werewolf.human
 
-import werewolf.game.GameOverSignal
-import werewolf.game.Player
-
-class ConsolePlayerIO : PlayerIO {
-    companion object {
-        private const val ABORT_PASSWORD = 4423
-    }
-
+class ConsolePlayerIO : PlayerIO() {
     override fun sendMessage(title: String, content: String) {
         println("[$title] $content")
     }
 
-    override fun promptPlayer(title: String, content: String, candidates: List<Player>): Player {
-        while (true) {
-            sendMessage(title, "$content: ${candidates.joinToString(", ") { it.name }}")
-            val input = readLine() ?: ""
-            val player = candidates.firstOrNull { it.name == input }
-            if (player != null) return player
-            println("「$input」は候補にいません。もう一度入力してください。")
-        }
-    }
-
-    override fun promptFreeText(title: String, content: String): String {
-        sendMessage(title, content)
-        return readLine() ?: ""
-    }
-
-    override fun promptChoice(title: String, content: String, options: List<String>): Int {
-        while (true) {
-            sendMessage(title, content)
-            options.forEachIndexed { i, option -> println("${i + 1}: $option") }
-            val input = readLine()?.toIntOrNull()
-            if (input == ABORT_PASSWORD) GameOverSignal.throwManualAbort()
-            if (input != null && input in 1..options.size) return input - 1
-            println("1〜${options.size}の数字を入力してください。")
-        }
-    }
+    override fun readFreeText(): String = readLine() ?: ""
+    override fun readChoice(): String = readLine() ?: ""
+    override fun readPlayer(): String = readLine() ?: ""
 }

--- a/src/main/kotlin/werewolf/human/PlayerIO.kt
+++ b/src/main/kotlin/werewolf/human/PlayerIO.kt
@@ -1,10 +1,41 @@
 package werewolf.human
 
+import werewolf.game.GameOverSignal
 import werewolf.game.Player
 
-interface PlayerIO {
-    fun sendMessage(title: String, content: String)
-    fun promptPlayer(title: String, content: String, candidates: List<Player>): Player
-    fun promptFreeText(title: String, content: String): String
-    fun promptChoice(title: String, content: String, options: List<String>): Int
+abstract class PlayerIO {
+    companion object {
+        private const val ABORT_PASSWORD = 4423
+    }
+
+    abstract fun sendMessage(title: String, content: String)
+    protected abstract fun readFreeText(): String
+    protected abstract fun readChoice(): String
+    protected abstract fun readPlayer(): String
+
+    fun promptFreeText(title: String, content: String): String {
+        sendMessage(title, content)
+        return readFreeText()
+    }
+
+    fun promptPlayer(title: String, content: String, candidates: List<Player>): Player {
+        while (true) {
+            sendMessage(title, "$content: ${candidates.joinToString(", ") { it.name }}")
+            val input = readPlayer()
+            val player = candidates.firstOrNull { it.name == input }
+            if (player != null) return player
+            sendMessage(title, "「$input」は候補にいません。もう一度入力してください。")
+        }
+    }
+
+    fun promptChoice(title: String, content: String, options: List<String>): Int {
+        val optionsText = options.mapIndexed { i, option -> "${i + 1}: $option" }.joinToString("\n")
+        while (true) {
+            sendMessage(title, "$content\n$optionsText")
+            val input = readChoice().toIntOrNull()
+            if (input == ABORT_PASSWORD) GameOverSignal.throwManualAbort()
+            if (input != null && input in 1..options.size) return input - 1
+            sendMessage(title, "1〜${options.size}の数字を入力してください。")
+        }
+    }
 }

--- a/src/main/kotlin/werewolf/human/console/ConsolePlayerIO.kt
+++ b/src/main/kotlin/werewolf/human/console/ConsolePlayerIO.kt
@@ -1,4 +1,6 @@
-package werewolf.human
+package werewolf.human.console
+
+import werewolf.human.PlayerIO
 
 class ConsolePlayerIO : PlayerIO() {
     override fun sendMessage(title: String, content: String) {

--- a/src/main/kotlin/werewolf/lodge/AnthropicLodge.kt
+++ b/src/main/kotlin/werewolf/lodge/AnthropicLodge.kt
@@ -6,7 +6,7 @@ import werewolf.ai.Instruction
 import werewolf.ai.anthropic.AnthropicLanguageModel
 import werewolf.game.Player
 import werewolf.game.Role
-import werewolf.human.ConsolePlayerIO
+import werewolf.human.console.ConsolePlayerIO
 import werewolf.human.HumanPlayer
 
 object AnthropicLodge : Lodge() {

--- a/src/main/kotlin/werewolf/lodge/CpuLodge.kt
+++ b/src/main/kotlin/werewolf/lodge/CpuLodge.kt
@@ -2,7 +2,7 @@ package werewolf.lodge
 
 import werewolf.game.Player
 import werewolf.game.Role
-import werewolf.human.ConsolePlayerIO
+import werewolf.human.console.ConsolePlayerIO
 import werewolf.human.HumanPlayer
 
 abstract class CpuLodge : Lodge() {

--- a/src/main/kotlin/werewolf/lodge/GeminiLodge.kt
+++ b/src/main/kotlin/werewolf/lodge/GeminiLodge.kt
@@ -6,7 +6,7 @@ import werewolf.ai.Instruction
 import werewolf.ai.gemini.GeminiLanguageModel
 import werewolf.game.Player
 import werewolf.game.Role
-import werewolf.human.ConsolePlayerIO
+import werewolf.human.console.ConsolePlayerIO
 import werewolf.human.HumanPlayer
 
 object GeminiLodge : Lodge() {

--- a/src/main/kotlin/werewolf/lodge/SmallLodge.kt
+++ b/src/main/kotlin/werewolf/lodge/SmallLodge.kt
@@ -1,7 +1,7 @@
 package werewolf.lodge
 
 import werewolf.game.Role
-import werewolf.human.ConsolePlayerIO
+import werewolf.human.console.ConsolePlayerIO
 import werewolf.human.HumanPlayer
 
 object SmallLodge : Lodge() {

--- a/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
@@ -13,12 +13,12 @@ import kotlin.test.assertTrue
 
 class HumanPlayerEpilogueTest {
 
-    private class SpeakingIO : PlayerIO {
+    private class SpeakingIO : PlayerIO() {
         val messages = mutableListOf<Pair<String, String>>()
         override fun sendMessage(title: String, content: String) { messages += title to content }
-        override fun promptPlayer(title: String, content: String, candidates: List<Player>): Player = error("not used")
-        override fun promptFreeText(title: String, content: String): String = "human speaks"
-        override fun promptChoice(title: String, content: String, options: List<String>): Int = 0
+        override fun readFreeText(): String = "human speaks"
+        override fun readChoice(): String = "1"
+        override fun readPlayer(): String = error("not used")
     }
 
     private class SpeakingPlayer(role: Role, name: String) : NothingPlayer(role, name) {

--- a/src/test/kotlin/werewolf/HumanPlayerTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerTest.kt
@@ -1,6 +1,5 @@
 package werewolf
 
-import werewolf.game.Player
 import werewolf.game.Recallable
 import werewolf.game.Role
 import werewolf.human.HumanPlayer
@@ -11,12 +10,12 @@ import kotlin.test.assertEquals
 
 class HumanPlayerTest {
 
-    private class CapturingIO : PlayerIO {
+    private class CapturingIO : PlayerIO() {
         val messages = mutableListOf<Pair<String, String>>()
         override fun sendMessage(title: String, content: String) { messages += title to content }
-        override fun promptPlayer(title: String, content: String, candidates: List<Player>): Player = error("not used")
-        override fun promptFreeText(title: String, content: String): String = error("not used")
-        override fun promptChoice(title: String, content: String, options: List<String>): Int = error("not used")
+        override fun readFreeText(): String = error("not used")
+        override fun readChoice(): String = error("not used")
+        override fun readPlayer(): String = error("not used")
     }
 
     private fun recallable(chronicleText: String, intent: String? = null, redundant: Boolean = false) = object : Recallable() {

--- a/src/test/kotlin/werewolf/PlayerIOTest.kt
+++ b/src/test/kotlin/werewolf/PlayerIOTest.kt
@@ -1,0 +1,78 @@
+package werewolf
+
+import werewolf.game.GameOverSignal
+import werewolf.game.Role
+import werewolf.human.PlayerIO
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class PlayerIOTest {
+
+    private class TestPlayerIO(
+        private val choiceInputs: ArrayDeque<String> = ArrayDeque(),
+        private val playerInputs: ArrayDeque<String> = ArrayDeque(),
+        private val freeTextInputs: ArrayDeque<String> = ArrayDeque(),
+    ) : PlayerIO() {
+        val messages = mutableListOf<Pair<String, String>>()
+        override fun sendMessage(title: String, content: String) { messages += title to content }
+        override fun readFreeText(): String = freeTextInputs.removeFirst()
+        override fun readChoice(): String = choiceInputs.removeFirst()
+        override fun readPlayer(): String = playerInputs.removeFirst()
+    }
+
+    private fun choiceIO(vararg inputs: String) =
+        TestPlayerIO(choiceInputs = ArrayDeque(inputs.toList()))
+
+    private fun playerIO(vararg inputs: String) =
+        TestPlayerIO(playerInputs = ArrayDeque(inputs.toList()))
+
+    @Test
+    fun `promptFreeText sends message and returns input`() {
+        val io = TestPlayerIO(freeTextInputs = ArrayDeque(listOf("hello")))
+        val result = io.promptFreeText("title", "content")
+        assertEquals("hello", result)
+        assertEquals("title" to "content", io.messages.single())
+    }
+
+    @Test
+    fun `promptChoice returns zero-based index for valid input`() {
+        val io = choiceIO("2")
+        assertEquals(1, io.promptChoice("title", "content", listOf("A", "B", "C")))
+    }
+
+    @Test
+    fun `promptChoice retries on out-of-range input then succeeds`() {
+        val io = choiceIO("0", "4", "2")
+        assertEquals(1, io.promptChoice("title", "content", listOf("A", "B", "C")))
+    }
+
+    @Test
+    fun `promptChoice retries on non-numeric input then succeeds`() {
+        val io = choiceIO("abc", "1")
+        assertEquals(0, io.promptChoice("title", "content", listOf("A")))
+    }
+
+    @Test
+    fun `promptChoice throws GameOverSignal on abort password`() {
+        val io = choiceIO("4423")
+        assertFailsWith<GameOverSignal> {
+            io.promptChoice("title", "content", listOf("A"))
+        }
+    }
+
+    @Test
+    fun `promptPlayer returns player matching name`() {
+        val alice = NothingPlayer(Role.VILLAGER, "Alice")
+        val bob = NothingPlayer(Role.VILLAGER, "Bob")
+        val io = playerIO("Alice")
+        assertEquals(alice, io.promptPlayer("title", "content", listOf(alice, bob)))
+    }
+
+    @Test
+    fun `promptPlayer retries on unknown name then succeeds`() {
+        val alice = NothingPlayer(Role.VILLAGER, "Alice")
+        val io = playerIO("Charlie", "Alice")
+        assertEquals(alice, io.promptPlayer("title", "content", listOf(alice)))
+    }
+}


### PR DESCRIPTION
## Summary

- `PlayerIO` を interface から abstract class に変更し、バリデーションループと中断パスワードチェックをここに移す
- `promptFreeText` / `promptPlayer` / `promptChoice` は具体メソッド（final）として `PlayerIO` に実装
- 入力読み取りは `readFreeText()` / `readChoice()` / `readPlayer()` の protected abstract メソッドに分離
- `ConsolePlayerIO` は `sendMessage` と上記3メソッドのみを実装するシンプルな形に
- `PlayerIOTest` を新規追加してバリデーションロジックをテスト

## Closes

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)