### PR TITLE
Enable browser gameplay via WebSocket input (Step 2)

### DIFF
--- a/src/main/kotlin/werewolf/lodge/WebHumanConnection.kt
+++ b/src/main/kotlin/werewolf/lodge/WebHumanConnection.kt
@@ -57,8 +57,14 @@ class WebHumanConnection : HumanConnection {
     private fun DefaultWebSocketSession.relayToPlayer(webPlayer: WebPlayer) {
         launch {
             for (frame in incoming) {
-                if (frame is Frame.Text && frame.readText() == "abort") {
-                    webPlayer.requestAbort()
+                if (frame is Frame.Text) {
+                    val text = frame.readText()
+                    if (text == "abort") {
+                        webPlayer.requestAbort()
+                        webPlayer.incoming.trySend("")
+                    } else {
+                        webPlayer.incoming.trySend(text)
+                    }
                 }
             }
         }

--- a/src/main/kotlin/werewolf/web/WebPlayer.kt
+++ b/src/main/kotlin/werewolf/web/WebPlayer.kt
@@ -5,13 +5,16 @@ import kotlinx.coroutines.runBlocking
 import werewolf.game.Choice
 import werewolf.game.Claim
 import werewolf.game.DiscussionContext
+import werewolf.game.DivineResult
 import werewolf.game.GameEvent
 import werewolf.game.GameOverSignal
+import werewolf.game.MediumResult
 import werewolf.game.Player
 import werewolf.game.Recallable
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
+import werewolf.game.StatementType
 
 class WebPlayer(role: Role, override val name: String) : Player(role) {
     val outgoing = Channel<String>(Channel.UNLIMITED)
@@ -37,24 +40,64 @@ class WebPlayer(role: Role, override val name: String) : Player(role) {
 
     override fun choose(context: SelectionContext): Choice {
         checkAbort()
-        val candidatesJson = context.candidates().joinToString(",") { it.name.jsonEncode() }
-        val prompt = """{"type":"choose","title":${context.title.jsonEncode()},"description":${context.description.jsonEncode()},"candidates":[$candidatesJson]}"""
-        enqueue(prompt)
-        while (true) {
-            val selected = runBlocking { incoming.receive() }
-            checkAbort()
-            val player = context.candidates().find { it.name == selected }
-            if (player != null) return Choice(this, context, player, "ブラウザ選択")
-            enqueue(prompt)
-        }
+        val candidates = context.candidates()
+        val selected = promptChoice(context.title, context.description, candidates.map { it.name })
+        return Choice(this, context, candidates.first { it.name == selected }, "ブラウザ選択")
     }
 
     override fun speak(context: DiscussionContext): Claim {
         checkAbort()
-        enqueue("""{"type":"speak","title":${context.title.jsonEncode()},"description":${context.description.jsonEncode()}}""")
+        val type = selectStatementType(context)
+        val statement = when (type) {
+            StatementType.PLAIN -> buildPlain(context)
+            StatementType.DIVINATION_REPORT -> buildDivinationReport(context)
+            StatementType.MEDIUM_REPORT -> buildMediumReport(context)
+        }
+        return Claim(this, context, statement, "ブラウザ発言")
+    }
+
+    private fun selectStatementType(context: DiscussionContext): StatementType {
+        val types = StatementType.entries.filter { it in context.availableTypes }
+        if (types.size == 1) return types.first()
+        val selected = promptChoice(context.title, context.description, types.map { it.displayName })
+        return types.first { it.displayName == selected }
+    }
+
+    private fun buildPlain(context: DiscussionContext): Statement {
+        enqueue("""{"type":"speak","title":${context.title.jsonEncode()},"description":"発言してください"}""")
         val text = runBlocking { incoming.receive() }
         checkAbort()
-        return Claim(this, context, Statement.Plain(text), "ブラウザ発言")
+        return Statement.Plain(text)
+    }
+
+    private fun buildDivinationReport(context: DiscussionContext): Statement {
+        val candidates = context.allPlayers.filter { it !== this }
+        val targetName = promptChoice("占い報告 - 対象", "誰の占い結果を報告しますか？", candidates.map { it.name })
+        val target = candidates.first { it.name == targetName }
+        val results = DivineResult.entries
+        val resultName = promptChoice("占い報告 - 結果", "占い結果を選んでください", results.map { it.displayName })
+        return Statement.DivinationReport(this, target, results.first { it.displayName == resultName })
+    }
+
+    private fun buildMediumReport(context: DiscussionContext): Statement {
+        val candidates = context.allPlayers.filter { it !== this }
+        val targetName = promptChoice("霊媒報告 - 対象", "誰の霊媒結果を報告しますか？", candidates.map { it.name })
+        val target = candidates.first { it.name == targetName }
+        val results = MediumResult.entries
+        val resultName = promptChoice("霊媒報告 - 結果", "霊媒結果を選んでください", results.map { it.displayName })
+        return Statement.MediumReport(this, target, results.first { it.displayName == resultName })
+    }
+
+    private fun promptChoice(title: String, description: String, options: List<String>): String {
+        val optionsJson = options.joinToString(",") { it.jsonEncode() }
+        val prompt = """{"type":"choose","title":${title.jsonEncode()},"description":${description.jsonEncode()},"candidates":[$optionsJson]}"""
+        enqueue(prompt)
+        while (true) {
+            val selected = runBlocking { incoming.receive() }
+            checkAbort()
+            if (selected in options) return selected
+            enqueue(prompt)
+        }
     }
 
     override fun watchEpilogue(chronicles: List<Recallable>) {

--- a/src/main/kotlin/werewolf/web/WebPlayer.kt
+++ b/src/main/kotlin/werewolf/web/WebPlayer.kt
@@ -1,6 +1,7 @@
 package werewolf.web
 
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.runBlocking
 import werewolf.game.Choice
 import werewolf.game.Claim
 import werewolf.game.DiscussionContext
@@ -14,6 +15,7 @@ import werewolf.game.Statement
 
 class WebPlayer(role: Role, override val name: String) : Player(role) {
     val outgoing = Channel<String>(Channel.UNLIMITED)
+    val incoming = Channel<String>(Channel.UNLIMITED)
     @Volatile private var abortRequested = false
 
     fun requestAbort() {
@@ -35,12 +37,24 @@ class WebPlayer(role: Role, override val name: String) : Player(role) {
 
     override fun choose(context: SelectionContext): Choice {
         checkAbort()
-        return Choice(this, context, context.candidates().first(), "自動選択")
+        val candidatesJson = context.candidates().joinToString(",") { it.name.jsonEncode() }
+        val prompt = """{"type":"choose","title":${context.title.jsonEncode()},"description":${context.description.jsonEncode()},"candidates":[$candidatesJson]}"""
+        enqueue(prompt)
+        while (true) {
+            val selected = runBlocking { incoming.receive() }
+            checkAbort()
+            val player = context.candidates().find { it.name == selected }
+            if (player != null) return Choice(this, context, player, "ブラウザ選択")
+            enqueue(prompt)
+        }
     }
 
     override fun speak(context: DiscussionContext): Claim {
         checkAbort()
-        return Claim(this, context, Statement.Plain("..."), "自動発言")
+        enqueue("""{"type":"speak","title":${context.title.jsonEncode()},"description":${context.description.jsonEncode()}}""")
+        val text = runBlocking { incoming.receive() }
+        checkAbort()
+        return Claim(this, context, Statement.Plain(text), "ブラウザ発言")
     }
 
     override fun watchEpilogue(chronicles: List<Recallable>) {

--- a/src/main/kotlin/werewolf/web/WebPlayer.kt
+++ b/src/main/kotlin/werewolf/web/WebPlayer.kt
@@ -32,7 +32,7 @@ class WebPlayer(role: Role, override val name: String) : Player(role) {
 
     override fun onReceive(event: GameEvent) {
         checkAbort()
-        enqueue("""{"type":"message","title":${event.title.jsonEncode()},"body":${event.body().jsonEncode()}}""")
+        enqueue("""{"type":"event","title":${event.title.jsonEncode()},"body":${event.body().jsonEncode()}}""")
     }
 
     override fun choose(context: SelectionContext): Choice {

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -6,11 +6,18 @@
     <style>
         body { font-family: sans-serif; max-width: 800px; margin: 0 auto; padding: 16px; }
         #status { color: #666; margin-bottom: 8px; }
-        #log { border: 1px solid #ccc; height: 600px; overflow-y: auto; padding: 8px; background: #fafafa; }
+        #log { border: 1px solid #ccc; height: 500px; overflow-y: auto; padding: 8px; background: #fafafa; }
         .message { margin: 4px 0; line-height: 1.4; }
         .title { font-weight: bold; color: #444; }
         .epilogue { margin-top: 16px; padding: 12px; background: #eef; white-space: pre-wrap; border-left: 4px solid #88a; }
-        #controls { margin-top: 8px; }
+        #controls { margin-top: 8px; margin-bottom: 8px; }
+        #input-area { margin-bottom: 8px; padding: 12px; border: 2px solid #88a; background: #f0f0fa; display: none; }
+        #input-title { font-weight: bold; margin-bottom: 4px; }
+        #input-description { color: #666; font-size: 0.9em; margin-bottom: 10px; }
+        #choose-buttons button { margin: 4px; padding: 6px 14px; cursor: pointer; }
+        #speak-input { display: none; }
+        #speak-text { width: 70%; padding: 6px; font-size: 1em; }
+        #speak-send { padding: 6px 14px; cursor: pointer; margin-left: 6px; }
     </style>
 </head>
 <body>
@@ -19,29 +26,93 @@
     <div id="controls">
         <button onclick="sendAbort()">ゲームを中断</button>
     </div>
+    <div id="input-area">
+        <div id="input-title"></div>
+        <div id="input-description"></div>
+        <div id="choose-buttons"></div>
+        <div id="speak-input">
+            <input type="text" id="speak-text" placeholder="発言を入力...">
+            <button id="speak-send" onclick="submitSpeak()">送信</button>
+        </div>
+    </div>
     <div id="log"></div>
     <script>
         const log = document.getElementById('log');
         const status = document.getElementById('status');
+        const inputArea = document.getElementById('input-area');
         const ws = new WebSocket(`ws://${location.host}/game`);
 
         ws.onopen = () => { status.textContent = '接続済み'; };
-        ws.onclose = () => { status.textContent = '切断'; };
+        ws.onclose = () => { status.textContent = '切断'; hideInput(); };
         ws.onerror = () => { status.textContent = 'エラー'; };
 
         ws.onmessage = (event) => {
             const msg = JSON.parse(event.data);
-            const div = document.createElement('div');
             if (msg.type === 'message') {
-                div.className = 'message';
-                div.innerHTML = `<span class="title">[${esc(msg.title)}]</span> ${esc(msg.body)}`;
+                appendLog('message', `<span class="title">[${esc(msg.title)}]</span> ${esc(msg.body)}`);
             } else if (msg.type === 'epilogue') {
+                hideInput();
+                const div = document.createElement('div');
                 div.className = 'epilogue';
                 div.textContent = msg.content;
+                log.appendChild(div);
+                log.scrollTop = log.scrollHeight;
+            } else if (msg.type === 'choose') {
+                showChoose(msg.title, msg.description, msg.candidates);
+            } else if (msg.type === 'speak') {
+                showSpeak(msg.title, msg.description);
             }
+        };
+
+        function appendLog(className, html) {
+            const div = document.createElement('div');
+            div.className = className;
+            div.innerHTML = html;
             log.appendChild(div);
             log.scrollTop = log.scrollHeight;
-        };
+        }
+
+        function showChoose(title, description, candidates) {
+            document.getElementById('input-title').textContent = title;
+            document.getElementById('input-description').textContent = description;
+            const buttons = document.getElementById('choose-buttons');
+            buttons.innerHTML = '';
+            candidates.forEach(name => {
+                const btn = document.createElement('button');
+                btn.textContent = name;
+                btn.onclick = () => { ws.send(name); hideInput(); };
+                buttons.appendChild(btn);
+            });
+            document.getElementById('choose-buttons').style.display = 'block';
+            document.getElementById('speak-input').style.display = 'none';
+            inputArea.style.display = 'block';
+        }
+
+        function showSpeak(title, description) {
+            document.getElementById('input-title').textContent = title;
+            document.getElementById('input-description').textContent = description;
+            document.getElementById('choose-buttons').style.display = 'none';
+            document.getElementById('speak-input').style.display = 'block';
+            document.getElementById('speak-text').value = '';
+            inputArea.style.display = 'block';
+            document.getElementById('speak-text').focus();
+        }
+
+        function submitSpeak() {
+            const text = document.getElementById('speak-text').value.trim();
+            if (text && ws.readyState === WebSocket.OPEN) {
+                ws.send(text);
+                hideInput();
+            }
+        }
+
+        function hideInput() {
+            inputArea.style.display = 'none';
+        }
+
+        document.getElementById('speak-text').addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') submitSpeak();
+        });
 
         function sendAbort() {
             if (ws.readyState === WebSocket.OPEN) ws.send('abort');

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -47,7 +47,7 @@
         ws.onerror = () => { status.textContent = 'エラー'; };
 
         const handlers = {
-            message:  (msg) => appendLog('message', `<span class="title">[${esc(msg.title)}]</span> ${esc(msg.body)}`),
+            message:  (msg) => showMessage(msg.title, msg.body),
             epilogue: (msg) => showEpilogue(msg.content),
             choose:   (msg) => showChoose(msg.title, msg.description, msg.candidates),
             speak:    (msg) => showSpeak(msg.title, msg.description),
@@ -64,6 +64,10 @@
             div.innerHTML = html;
             log.appendChild(div);
             log.scrollTop = log.scrollHeight;
+        }
+
+        function showMessage(title, body) {
+            appendLog('message', `<span class="title">[${esc(title)}]</span> ${esc(body)}`);
         }
 
         function showEpilogue(content) {

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -51,7 +51,6 @@
             if (msg.type === 'message') {
                 appendLog('message', `<span class="title">[${esc(msg.title)}]</span> ${esc(msg.body)}`);
             } else if (msg.type === 'epilogue') {
-                hideInput();
                 const div = document.createElement('div');
                 div.className = 'epilogue';
                 div.textContent = msg.content;
@@ -115,7 +114,7 @@
         });
 
         function sendAbort() {
-            if (ws.readyState === WebSocket.OPEN) ws.send('abort');
+            if (ws.readyState === WebSocket.OPEN) { ws.send('abort'); hideInput(); }
         }
 
         function esc(text) {

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -7,7 +7,7 @@
         body { font-family: sans-serif; max-width: 800px; margin: 0 auto; padding: 16px; }
         #status { color: #666; margin-bottom: 8px; }
         #log { border: 1px solid #ccc; height: 500px; overflow-y: auto; padding: 8px; background: #fafafa; }
-        .message { margin: 4px 0; line-height: 1.4; }
+        .event { margin: 4px 0; line-height: 1.4; }
         .title { font-weight: bold; color: #444; }
         .epilogue { margin-top: 16px; padding: 12px; background: #eef; white-space: pre-wrap; border-left: 4px solid #88a; }
         #controls { margin-top: 8px; margin-bottom: 8px; }
@@ -47,7 +47,7 @@
         ws.onerror = () => { status.textContent = 'エラー'; };
 
         const handlers = {
-            message:  (msg) => showMessage(msg.title, msg.body),
+            event:    (msg) => showEvent(msg.title, msg.body),
             epilogue: (msg) => showEpilogue(msg.content),
             choose:   (msg) => showChoose(msg.title, msg.description, msg.candidates),
             speak:    (msg) => showSpeak(msg.title, msg.description),
@@ -66,8 +66,8 @@
             log.scrollTop = log.scrollHeight;
         }
 
-        function showMessage(title, body) {
-            appendLog('message', `<span class="title">[${esc(title)}]</span> ${esc(body)}`);
+        function showEvent(title, body) {
+            appendLog('event', `<span class="title">[${esc(title)}]</span> ${esc(body)}`);
         }
 
         function showEpilogue(content) {

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -46,27 +46,30 @@
         ws.onclose = () => { status.textContent = '切断'; hideInput(); };
         ws.onerror = () => { status.textContent = 'エラー'; };
 
+        const handlers = {
+            message:  (msg) => appendLog('message', `<span class="title">[${esc(msg.title)}]</span> ${esc(msg.body)}`),
+            epilogue: (msg) => showEpilogue(msg.content),
+            choose:   (msg) => showChoose(msg.title, msg.description, msg.candidates),
+            speak:    (msg) => showSpeak(msg.title, msg.description),
+        };
+
         ws.onmessage = (event) => {
             const msg = JSON.parse(event.data);
-            if (msg.type === 'message') {
-                appendLog('message', `<span class="title">[${esc(msg.title)}]</span> ${esc(msg.body)}`);
-            } else if (msg.type === 'epilogue') {
-                const div = document.createElement('div');
-                div.className = 'epilogue';
-                div.textContent = msg.content;
-                log.appendChild(div);
-                log.scrollTop = log.scrollHeight;
-            } else if (msg.type === 'choose') {
-                showChoose(msg.title, msg.description, msg.candidates);
-            } else if (msg.type === 'speak') {
-                showSpeak(msg.title, msg.description);
-            }
+            handlers[msg.type]?.(msg);
         };
 
         function appendLog(className, html) {
             const div = document.createElement('div');
             div.className = className;
             div.innerHTML = html;
+            log.appendChild(div);
+            log.scrollTop = log.scrollHeight;
+        }
+
+        function showEpilogue(content) {
+            const div = document.createElement('div');
+            div.className = 'epilogue';
+            div.textContent = content;
             log.appendChild(div);
             log.scrollTop = log.scrollHeight;
         }


### PR DESCRIPTION
## Summary

- `WebPlayer.choose()` / `speak()` を Channel 待ちで本実装（スタブから置き換え）
- `speak()` に発言型選択（PLAIN / DIVINATION_REPORT / MEDIUM_REPORT）を追加
- `WebHumanConnection.relayToPlayer()` でブラウザからの入力を Channel へ転送
- `index.html` に選択肢ボタン・テキスト入力 UI を追加、dispatch table 形式でイベント処理

中断（abort）・Epilogue 送信も本実装済み。

## Test plan

- [x] ブラウザから選択肢ボタンを押して投票・役職行動ができる
- [x] ブラウザからテキスト入力で発言ができる
- [x] 占い師・霊媒師で発言型を選択できる
- [x] Epilogue がブラウザに表示される
- [x] 中断ボタンでゲームを終了できる
- [x] `./gradlew check` が通る

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)