### PR TITLE
Record FallbackChoice/FallbackClaim in _myMemories with intent text

### DIFF
--- a/src/main/kotlin/werewolf/ai/AiPlayer.kt
+++ b/src/main/kotlin/werewolf/ai/AiPlayer.kt
@@ -56,7 +56,7 @@ class AiPlayer(
                 memorize(InvalidAiInput(completion.text, completion.metadata))
             }
         }
-        return FallbackClaim(this, context)
+        return FallbackClaim(this, context).also { _myMemories.add(it) }
     }
 
     private fun parseSpeakResponse(input: String): Pair<String, String> {
@@ -93,7 +93,7 @@ class AiPlayer(
                 memorize(InvalidAiInput(completion.text, completion.metadata))
             }
         }
-        return FallbackChoice(this, context)
+        return FallbackChoice(this, context).also { _myMemories.add(it) }
     }
 
     private fun parseChoiceResponse(input: String, candidates: List<Player>): Pair<Player, String> {

--- a/src/main/kotlin/werewolf/game/Choice.kt
+++ b/src/main/kotlin/werewolf/game/Choice.kt
@@ -42,6 +42,6 @@ private class NormalChoice(
 
 class FallbackChoice(chooser: Player, context: SelectionContext) : Choice(
     chooser, context, context.candidates().random(),
-    intentForRecall = "",
+    intentForRecall = "回答取得に失敗したためランダム選択",
     intentForChronicle = "回答取得に失敗したためランダム選択",
 )

--- a/src/main/kotlin/werewolf/game/Claim.kt
+++ b/src/main/kotlin/werewolf/game/Claim.kt
@@ -42,6 +42,6 @@ private class NormalClaim(
 
 class FallbackClaim(speaker: Player, context: DiscussionContext) : Claim(
     speaker, context, Statement.Plain(""),
-    intentForRecall = "",
+    intentForRecall = "回答取得に失敗したため空文字を返却",
     intentForChronicle = "回答取得に失敗したため空文字を返却",
 )

--- a/src/test/kotlin/werewolf/AiPlayerChooseTest.kt
+++ b/src/test/kotlin/werewolf/AiPlayerChooseTest.kt
@@ -89,6 +89,17 @@ class AiPlayerChooseTest {
     }
 
     @Test
+    fun `selectTarget records FallbackChoice in recall memory for subsequent prompts`() {
+        val lm = FakeLanguageModel("理由：Unknown", "理由：AlsoUnknown", "怪しいから：Wolf")
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm, testInstruction())
+        val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
+        val context = SelectionContext.Vote(villager, listOf(villager, wolf))
+        villager.selectTarget(context)
+        villager.selectTarget(context)
+        assertTrue(lm.histories[2].any { it.contains("回答取得に失敗したためランダム選択") })
+    }
+
+    @Test
     fun `choose records InvalidAiInput with raw response when format is invalid`() {
         val lm = FakeLanguageModel("bad response", "怪しいから：Wolf", metadata = ModelMetadata { "model=test" })
         val villager = AiPlayer(Role.VILLAGER, "Villager", lm, testInstruction())

--- a/src/test/kotlin/werewolf/AiPlayerSpeakTest.kt
+++ b/src/test/kotlin/werewolf/AiPlayerSpeakTest.kt
@@ -63,6 +63,15 @@ class AiPlayerSpeakTest {
     }
 
     @Test
+    fun `discuss records FallbackClaim in recall memory for subsequent prompts`() {
+        val lm = FakeLanguageModel("no bracket", "no bracket", "hello[真意]")
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm, testInstruction())
+        villager.discuss(openContext())
+        villager.discuss(openContext())
+        assertTrue(lm.histories[2].any { it.contains("回答取得に失敗したため空文字を返却") })
+    }
+
+    @Test
     fun `speak records InvalidAiInput with raw response when format is invalid`() {
         val lm = FakeLanguageModel("bad response", "[valid]", metadata = ModelMetadata { "model=test" })
         val villager = AiPlayer(Role.VILLAGER, "Villager", lm, testInstruction())


### PR DESCRIPTION
fixes #239

## Summary

- `FallbackChoice` / `FallbackClaim` を `_myMemories` に追加し、フォールバック行動が次回プロンプトのhistoryに反映されるようにした
- `FallbackChoice` / `FallbackClaim` の `intentForRecall` に意図テキストを設定した（従来は空文字）
- 上記の動作を検証するテストを `AiPlayerChooseTest` / `AiPlayerSpeakTest` に追加した

## Test plan

- [x] `selectTarget records FallbackChoice in recall memory for subsequent prompts`: フォールバック後の次回プロンプトhistoryに「回答取得に失敗したためランダム選択」が含まれること
- [x] `discuss records FallbackClaim in recall memory for subsequent prompts`: フォールバック後の次回プロンプトhistoryに「回答取得に失敗したため空文字を返却」が含まれること
- [x] `./gradlew check` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)