### PR TITLE
Replace recall()/chronicle() strings with structured RecallView/ChronicleView

### DIFF
--- a/src/main/kotlin/werewolf/ai/AiPlayer.kt
+++ b/src/main/kotlin/werewolf/ai/AiPlayer.kt
@@ -114,7 +114,7 @@ class AiPlayer(
     override fun watchEpilogue(chronicles: List<ChronicleView>) = Unit
 
     private fun prompt(instruction: String): Completion {
-        val history = _myMemories.map { it.toRecallView().formatForRecall() }
+        val history = _myMemories.map { it.toRecallView().toHistoryEntry() }
         val instructionText = buildString {
             appendLine("【指示】")
             append(instruction)
@@ -158,7 +158,8 @@ class AiPlayer(
     """.trimIndent()
 }
 
-private fun RecallView.formatForRecall(): String = when (this) {
+// Uses <> to avoid collision with AI response delimiters (: and [])
+private fun RecallView.toHistoryEntry(): String = when (this) {
     is RecallView.Observation -> "<$category> $content"
     is RecallView.Action -> "<$category> $content <$intent>"
 }

--- a/src/main/kotlin/werewolf/ai/AiPlayer.kt
+++ b/src/main/kotlin/werewolf/ai/AiPlayer.kt
@@ -1,6 +1,7 @@
 package werewolf.ai
 
 import werewolf.game.Choice
+import werewolf.game.ChronicleView
 import werewolf.game.Claim
 import werewolf.game.DiscussionContext
 import werewolf.game.FallbackChoice
@@ -9,6 +10,7 @@ import werewolf.game.GameEvent
 import werewolf.game.GameOverSignal
 import werewolf.game.Player
 import werewolf.game.Recallable
+import werewolf.game.RecallView
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
@@ -53,7 +55,7 @@ class AiPlayer(
                 return claim
             } catch (_: InvalidAiInputException) {
                 // AI応答が不正な形式のため、記録して次のイテレーションでリトライする
-                memorize(InvalidAiInput(completion.text, completion.metadata))
+                memorize(InvalidAiInput(this, completion.text, completion.metadata))
             }
         }
         return FallbackClaim(this, context).also { _myMemories.add(it) }
@@ -90,7 +92,7 @@ class AiPlayer(
                 return choice
             } catch (_: InvalidAiInputException) {
                 // AI応答が不正な形式のため、記録して次のイテレーションでリトライする
-                memorize(InvalidAiInput(completion.text, completion.metadata))
+                memorize(InvalidAiInput(this, completion.text, completion.metadata))
             }
         }
         return FallbackChoice(this, context).also { _myMemories.add(it) }
@@ -109,10 +111,10 @@ class AiPlayer(
 
     private class InvalidAiInputException(message: String) : Exception(message)
 
-    override fun watchEpilogue(chronicles: List<Recallable>) = Unit
+    override fun watchEpilogue(chronicles: List<ChronicleView>) = Unit
 
     private fun prompt(instruction: String): Completion {
-        val history = _myMemories.map { it.recall() }
+        val history = _myMemories.map { it.toRecallView().formatForRecall() }
         val instructionText = buildString {
             appendLine("【指示】")
             append(instruction)
@@ -155,3 +157,9 @@ class AiPlayer(
 ・投票：投票先は他のプレイヤーに開示されません。最多票のプレイヤーが処刑されます
     """.trimIndent()
 }
+
+private fun RecallView.formatForRecall(): String = when (this) {
+    is RecallView.Observation -> "<$category> $content"
+    is RecallView.Action -> "<$category> $content <$intent>"
+}
+

--- a/src/main/kotlin/werewolf/ai/Instruction.kt
+++ b/src/main/kotlin/werewolf/ai/Instruction.kt
@@ -1,8 +1,10 @@
 package werewolf.ai
 
+import werewolf.game.ChronicleView
 import werewolf.game.Recallable
+import werewolf.game.RecallView
 
 class Instruction(private val recipientName: String, private val text: String) : Recallable() {
-    override fun recall() = text
-    override fun chronicle() = "[$recipientName] [指示] $text"
+    override fun toRecallView() = RecallView.Observation("指示", text)
+    override fun toChronicleView() = ChronicleView.Observation(recipientName, "指示", text)
 }

--- a/src/main/kotlin/werewolf/ai/InvalidAiInput.kt
+++ b/src/main/kotlin/werewolf/ai/InvalidAiInput.kt
@@ -1,12 +1,15 @@
 package werewolf.ai
 
+import werewolf.game.ChronicleView
+import werewolf.game.Player
 import werewolf.game.Recallable
+import werewolf.game.RecallView
 
 class InvalidAiInput(
+    private val actor: Player,
     private val rawResponse: String,
     private val metadata: ModelMetadata,
 ) : Recallable() {
-    override fun recall() = error("InvalidAiInput is not stored in AI memory and should not appear in prompts")
-    override fun chronicle() = "[無効な応答] $rawResponse"
-    override val intentForChronicle: String = metadata.toDisplayString()
+    override fun toRecallView() = error("InvalidAiInput is not stored in AI memory and should not appear in prompts")
+    override fun toChronicleView() = ChronicleView.Action(actor.name, "無効な応答", rawResponse, metadata.toDisplayString())
 }

--- a/src/main/kotlin/werewolf/ai/RoleAdvice.kt
+++ b/src/main/kotlin/werewolf/ai/RoleAdvice.kt
@@ -1,11 +1,13 @@
 package werewolf.ai
 
+import werewolf.game.ChronicleView
 import werewolf.game.Recallable
+import werewolf.game.RecallView
 import werewolf.game.Role
 
 class RoleAdvice(private val recipientName: String, private val role: Role, private val text: String) : Recallable() {
-    override fun recall() = "<戦略アドバイス> $text"
-    override fun chronicle() = "[$recipientName] [${role.displayName}の戦略アドバイス] $text"
+    override fun toRecallView() = RecallView.Observation("戦略アドバイス", text)
+    override fun toChronicleView() = ChronicleView.Observation(recipientName, "${role.displayName}の戦略アドバイス", text)
 
     companion object {
         fun random(role: Role, name: String) = RoleAdvice(name, role, pool.getValue(role).random())

--- a/src/main/kotlin/werewolf/cpu/CpuPlayer.kt
+++ b/src/main/kotlin/werewolf/cpu/CpuPlayer.kt
@@ -1,9 +1,9 @@
 package werewolf.cpu
 
+import werewolf.game.ChronicleView
 import werewolf.game.Player
-import werewolf.game.Recallable
 import werewolf.game.Role
 
 abstract class CpuPlayer(role: Role) : Player(role) {
-    override fun watchEpilogue(chronicles: List<Recallable>) = Unit
+    override fun watchEpilogue(chronicles: List<ChronicleView>) = Unit
 }

--- a/src/main/kotlin/werewolf/game/Choice.kt
+++ b/src/main/kotlin/werewolf/game/Choice.kt
@@ -5,14 +5,14 @@ sealed class Choice(
     val context: SelectionContext,
     val selected: Player,
     private val intentForRecall: String,
-    override val intentForChronicle: String,
+    private val intentForChronicle: String,
 ) : Recallable() {
     init {
         require(selected in context.candidates()) { "${selected.name} is not in candidates" }
     }
 
-    override fun recall() = "<${context.title}> ${selected.name} <$intentForRecall>"
-    override fun chronicle() = "[${chooser.name}] [${context.title}] ${selected.name}"
+    override fun toRecallView() = RecallView.Action(context.title, selected.name, intentForRecall)
+    override fun toChronicleView() = ChronicleView.Action(chooser.name, context.title, selected.name, intentForChronicle)
 
     companion object {
         operator fun invoke(

--- a/src/main/kotlin/werewolf/game/ChronicleView.kt
+++ b/src/main/kotlin/werewolf/game/ChronicleView.kt
@@ -1,0 +1,6 @@
+package werewolf.game
+
+sealed class ChronicleView {
+    data class Observation(val recipient: String, val category: String, val content: String) : ChronicleView()
+    data class Action(val actor: String, val category: String, val content: String, val intent: String) : ChronicleView()
+}

--- a/src/main/kotlin/werewolf/game/Claim.kt
+++ b/src/main/kotlin/werewolf/game/Claim.kt
@@ -5,14 +5,14 @@ sealed class Claim(
     val context: DiscussionContext,
     val statement: Statement,
     private val intentForRecall: String,
-    override val intentForChronicle: String,
+    private val intentForChronicle: String,
 ) : Recallable() {
     init {
         require(statement.type in context.availableTypes) { "${statement.type} is not available in ${context.title}" }
     }
 
-    override fun recall() = "<${context.title}> ${statement.text()} <$intentForRecall>"
-    override fun chronicle() = "[${speaker.name}] [${context.title}] ${statement.text()}"
+    override fun toRecallView() = RecallView.Action(context.title, statement.text(), intentForRecall)
+    override fun toChronicleView() = ChronicleView.Action(speaker.name, context.title, statement.text(), intentForChronicle)
 
     companion object {
         operator fun invoke(

--- a/src/main/kotlin/werewolf/game/GameEvent.kt
+++ b/src/main/kotlin/werewolf/game/GameEvent.kt
@@ -7,8 +7,8 @@ sealed class GameEvent : Recallable() {
     abstract val title: String
     abstract fun body(): String
     protected abstract val recipients: Notifiable
-    override fun recall() = "<${title}> ${body()}"
-    override fun chronicle() = "[${recipients.recipientName}] [${title}] ${body()}"
+    final override fun toRecallView() = RecallView.Observation(title, body())
+    final override fun toChronicleView() = ChronicleView.Observation(recipients.recipientName, title, body())
     protected fun dispatch() = recipients.receive(this)
     fun isPublicKnowledge(): Boolean = recipients is AllPlayers
 
@@ -67,7 +67,6 @@ sealed class GameEvent : Recallable() {
         override val title = "発言"
         override fun body() = "$speakerName: ${statement.text()}"
         override val recipients: Notifiable = allPlayers
-        override val isRedundantInChronicle = true
         companion object {
             fun send(round: Int, speakerName: String, statement: Statement, allPlayers: AllPlayers) =
                 StatementMade(round, speakerName, statement, allPlayers).dispatch()
@@ -150,7 +149,6 @@ sealed class GameEvent : Recallable() {
         override val title = "密談"
         override fun body() = "$speakerName: $statement"
         override val recipients: Notifiable = wolves
-        override val isRedundantInChronicle = true
         companion object {
             fun send(round: Int, speakerName: String, statement: String, wolves: Wolves) =
                 WerewolfStatementMade(round, speakerName, statement, wolves).dispatch()

--- a/src/main/kotlin/werewolf/game/GameRecap.kt
+++ b/src/main/kotlin/werewolf/game/GameRecap.kt
@@ -6,4 +6,12 @@ class GameRecap(private val playerManager: PlayerManager, private val signal: Ga
             .flatMap { it.reveal(signal) }
             .distinct()
             .sortedBy { it.sequenceId }
+
+    fun chronicles(): List<ChronicleView> =
+        events()
+            .filterNot { isRedundantWithClaim(it) }
+            .map { it.toChronicleView() }
+
+    private fun isRedundantWithClaim(recallable: Recallable): Boolean =
+        recallable is GameEvent.StatementMade || recallable is GameEvent.WerewolfStatementMade
 }

--- a/src/main/kotlin/werewolf/game/Player.kt
+++ b/src/main/kotlin/werewolf/game/Player.kt
@@ -28,7 +28,7 @@ abstract class Player(private val role: Role) : Notifiable {
         return claim.statement
     }
     protected abstract fun speak(context: DiscussionContext): Claim
-    abstract fun watchEpilogue(chronicles: List<Recallable>)
+    abstract fun watchEpilogue(chronicles: List<ChronicleView>)
 
     protected fun memorize(recallable: Recallable) {
         _memories.add(recallable)

--- a/src/main/kotlin/werewolf/game/RecallView.kt
+++ b/src/main/kotlin/werewolf/game/RecallView.kt
@@ -1,0 +1,6 @@
+package werewolf.game
+
+sealed class RecallView {
+    data class Observation(val category: String, val content: String) : RecallView()
+    data class Action(val category: String, val content: String, val intent: String) : RecallView()
+}

--- a/src/main/kotlin/werewolf/game/Recallable.kt
+++ b/src/main/kotlin/werewolf/game/Recallable.kt
@@ -2,8 +2,6 @@ package werewolf.game
 
 abstract class Recallable {
     val sequenceId: Long = System.nanoTime()
-    abstract fun recall(): String
-    abstract fun chronicle(): String
-    open val intentForChronicle: String? get() = null
-    open val isRedundantInChronicle: Boolean get() = false
+    abstract fun toRecallView(): RecallView
+    abstract fun toChronicleView(): ChronicleView
 }

--- a/src/main/kotlin/werewolf/human/HumanPlayer.kt
+++ b/src/main/kotlin/werewolf/human/HumanPlayer.kt
@@ -56,11 +56,11 @@ class HumanPlayer(role: Role, override val name: String, private val io: PlayerI
     }
 
     override fun watchEpilogue(chronicles: List<ChronicleView>) {
-        io.sendMessage("ゲーム振り返り", chronicles.joinToString("\n") { it.format() })
+        io.sendMessage("ゲーム振り返り", chronicles.joinToString("\n") { it.formatForConsole() })
     }
 }
 
-private fun ChronicleView.format(): String = when (this) {
+private fun ChronicleView.formatForConsole(): String = when (this) {
     is ChronicleView.Observation -> "[$recipient] [$category] $content"
     is ChronicleView.Action -> {
         val line = "[$actor] [$category] $content"

--- a/src/main/kotlin/werewolf/human/HumanPlayer.kt
+++ b/src/main/kotlin/werewolf/human/HumanPlayer.kt
@@ -2,12 +2,12 @@ package werewolf.human
 
 import werewolf.game.Choice
 import werewolf.game.Claim
+import werewolf.game.ChronicleView
 import werewolf.game.DiscussionContext
 import werewolf.game.DivineResult
 import werewolf.game.GameEvent
 import werewolf.game.MediumResult
 import werewolf.game.Player
-import werewolf.game.Recallable
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
@@ -55,13 +55,15 @@ class HumanPlayer(role: Role, override val name: String, private val io: PlayerI
         return Statement.MediumReport(this, target, results[resultIdx])
     }
 
-    override fun watchEpilogue(chronicles: List<Recallable>) {
-        val content = chronicles
-            .filter { !it.isRedundantInChronicle }
-            .joinToString("\n") {
-                val intent = it.intentForChronicle
-                if (intent != null) "${it.chronicle()}\n  [$intent]" else it.chronicle()
-            }
-        io.sendMessage("ゲーム振り返り", content)
+    override fun watchEpilogue(chronicles: List<ChronicleView>) {
+        io.sendMessage("ゲーム振り返り", chronicles.joinToString("\n") { it.format() })
+    }
+}
+
+private fun ChronicleView.format(): String = when (this) {
+    is ChronicleView.Observation -> "[$recipient] [$category] $content"
+    is ChronicleView.Action -> {
+        val line = "[$actor] [$category] $content"
+        if (intent.isNotEmpty()) "$line\n  [$intent]" else line
     }
 }

--- a/src/main/kotlin/werewolf/phase/Epilogue.kt
+++ b/src/main/kotlin/werewolf/phase/Epilogue.kt
@@ -24,7 +24,7 @@ class Epilogue(
     }
 
     private fun showRecap() {
-        val events = GameRecap(playerManager, signal).events()
-        playerManager.allPlayers.forEach { it.watchEpilogue(events) }
+        val chronicles = GameRecap(playerManager, signal).chronicles()
+        playerManager.allPlayers.forEach { it.watchEpilogue(chronicles) }
     }
 }

--- a/src/main/kotlin/werewolf/web/WebPlayer.kt
+++ b/src/main/kotlin/werewolf/web/WebPlayer.kt
@@ -4,13 +4,13 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runBlocking
 import werewolf.game.Choice
 import werewolf.game.Claim
+import werewolf.game.ChronicleView
 import werewolf.game.DiscussionContext
 import werewolf.game.DivineResult
 import werewolf.game.GameEvent
 import werewolf.game.GameOverSignal
 import werewolf.game.MediumResult
 import werewolf.game.Player
-import werewolf.game.Recallable
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
@@ -100,17 +100,22 @@ class WebPlayer(role: Role, override val name: String) : Player(role) {
         }
     }
 
-    override fun watchEpilogue(chronicles: List<Recallable>) {
-        val content = chronicles
-            .filter { !it.isRedundantInChronicle }
-            .joinToString("\n") {
-                val intent = it.intentForChronicle
-                if (intent != null) "${it.chronicle()}\n  [$intent]" else it.chronicle()
-            }
-        enqueue("""{"type":"epilogue","content":${content.jsonEncode()}}""")
+    override fun watchEpilogue(chronicles: List<ChronicleView>) {
+        val json = chronicles.joinToString(",", "[", "]") { it.toJson() }
+        enqueue("""{"type":"epilogue","chronicles":$json}""")
         outgoing.close()
     }
-
-    private fun String.jsonEncode(): String =
-        "\"${replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "").replace("\t", " ")}\""
 }
+
+private fun ChronicleView.toJson(): String = when (this) {
+    is ChronicleView.Observation ->
+        """{"type":"observation","recipient":${recipient.jsonEncode()}""" +
+        ""","category":${category.jsonEncode()},"content":${content.jsonEncode()}}"""
+    is ChronicleView.Action ->
+        """{"type":"action","actor":${actor.jsonEncode()}""" +
+        ""","category":${category.jsonEncode()},"content":${content.jsonEncode()}""" +
+        ""","intent":${intent.jsonEncode()}}"""
+}
+
+private fun String.jsonEncode(): String =
+    "\"${replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "").replace("\t", " ")}\""

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -48,7 +48,7 @@
 
         const handlers = {
             event:    (msg) => showEvent(msg.title, msg.body),
-            epilogue: (msg) => showEpilogue(msg.content),
+            epilogue: (msg) => showEpilogue(msg.chronicles),
             choose:   (msg) => showChoose(msg.title, msg.description, msg.candidates),
             speak:    (msg) => showSpeak(msg.title, msg.description),
         };
@@ -70,10 +70,18 @@
             appendLog('event', `<span class="title">[${esc(title)}]</span> ${esc(body)}`);
         }
 
-        function showEpilogue(content) {
+        function showEpilogue(chronicles) {
+            const text = chronicles.map(view => {
+                if (view.type === 'observation') {
+                    return `[${view.recipient}] [${view.category}] ${view.content}`;
+                } else {
+                    const line = `[${view.actor}] [${view.category}] ${view.content}`;
+                    return view.intent ? `${line}\n  [${view.intent}]` : line;
+                }
+            }).join('\n');
             const div = document.createElement('div');
             div.className = 'epilogue';
-            div.textContent = content;
+            div.textContent = text;
             log.appendChild(div);
             log.scrollTop = log.scrollHeight;
         }

--- a/src/test/kotlin/werewolf/AiPlayerChooseTest.kt
+++ b/src/test/kotlin/werewolf/AiPlayerChooseTest.kt
@@ -3,6 +3,7 @@ package werewolf
 import werewolf.ai.AiPlayer
 import werewolf.ai.InvalidAiInput
 import werewolf.ai.ModelMetadata
+import werewolf.game.ChronicleView
 import werewolf.game.Choice
 import werewolf.game.Role
 import werewolf.game.SelectionContext
@@ -11,6 +12,7 @@ import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class AiPlayerChooseTest {
@@ -84,7 +86,9 @@ class AiPlayerChooseTest {
         villager.selectTarget(context)
         villager.discuss(openContext())
         val memories = villager.reveal(fakeCitizenWinSignal())
-        assertTrue(memories.filterIsInstance<Choice>().any { it.intentForChronicle?.contains("model=test") == true })
+        val choiceChronicle = memories.filterIsInstance<Choice>().first().toChronicleView()
+        assertIs<ChronicleView.Action>(choiceChronicle)
+        assertTrue(choiceChronicle.intent.contains("model=test"))
         assertFalse(lm.prompts[1].contains("model=test"))
     }
 
@@ -107,8 +111,9 @@ class AiPlayerChooseTest {
         val context = SelectionContext.Vote(villager, listOf(villager, wolf))
         villager.selectTarget(context)
         val memories = villager.reveal(fakeCitizenWinSignal())
-        val record = memories.filterIsInstance<InvalidAiInput>().first()
-        assertTrue(record.chronicle().contains("bad response"))
-        assertEquals("model=test", record.intentForChronicle)
+        val invalidInputChronicle = memories.filterIsInstance<InvalidAiInput>().first().toChronicleView()
+        assertIs<ChronicleView.Action>(invalidInputChronicle)
+        assertTrue(invalidInputChronicle.content.contains("bad response"))
+        assertEquals("model=test", invalidInputChronicle.intent)
     }
 }

--- a/src/test/kotlin/werewolf/AiPlayerSpeakTest.kt
+++ b/src/test/kotlin/werewolf/AiPlayerSpeakTest.kt
@@ -3,6 +3,7 @@ package werewolf
 import werewolf.ai.AiPlayer
 import werewolf.ai.InvalidAiInput
 import werewolf.ai.ModelMetadata
+import werewolf.game.ChronicleView
 import werewolf.game.Claim
 import werewolf.game.Role
 import werewolf.game.Statement
@@ -58,7 +59,9 @@ class AiPlayerSpeakTest {
         villager.discuss(openContext())
         villager.discuss(openContext())
         val memories = villager.reveal(fakeCitizenWinSignal())
-        assertTrue(memories.filterIsInstance<Claim>().any { it.intentForChronicle?.contains("model=test") == true })
+        val claimChronicle = memories.filterIsInstance<Claim>().first().toChronicleView()
+        assertIs<ChronicleView.Action>(claimChronicle)
+        assertTrue(claimChronicle.intent.contains("model=test"))
         assertFalse(lm.prompts[1].contains("model=test"))
     }
 
@@ -77,8 +80,9 @@ class AiPlayerSpeakTest {
         val villager = AiPlayer(Role.VILLAGER, "Villager", lm, testInstruction())
         villager.discuss(openContext())
         val memories = villager.reveal(fakeCitizenWinSignal())
-        val record = memories.filterIsInstance<InvalidAiInput>().first()
-        assertTrue(record.chronicle().contains("bad response"))
-        assertEquals("model=test", record.intentForChronicle)
+        val invalidInputChronicle = memories.filterIsInstance<InvalidAiInput>().first().toChronicleView()
+        assertIs<ChronicleView.Action>(invalidInputChronicle)
+        assertTrue(invalidInputChronicle.content.contains("bad response"))
+        assertEquals("model=test", invalidInputChronicle.intent)
     }
 }

--- a/src/test/kotlin/werewolf/AiPlayerTest.kt
+++ b/src/test/kotlin/werewolf/AiPlayerTest.kt
@@ -3,6 +3,7 @@ package werewolf
 import werewolf.ai.AiPlayer
 import werewolf.ai.Instruction
 import werewolf.ai.LanguageModel
+import werewolf.game.ChronicleView
 import werewolf.game.GameEvent
 import werewolf.game.GameOverSignal
 import werewolf.game.Role
@@ -11,6 +12,7 @@ import werewolf.game.SelectionContext
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class AiPlayerTest {
@@ -60,7 +62,9 @@ class AiPlayerTest {
         val lm = FakeLanguageModel()
         val villager = AiPlayer(Role.VILLAGER, "Villager", lm, Instruction("Villager", "慎重に行動してください。"))
         val memories = villager.reveal(fakeCitizenWinSignal())
-        assertTrue(memories.any { it.chronicle().contains("慎重に行動してください。") })
+        assertTrue(memories.filterIsInstance<Instruction>().any {
+            (it.toChronicleView() as ChronicleView.Observation).content.contains("慎重に行動してください。")
+        })
     }
 
     @Test
@@ -68,7 +72,11 @@ class AiPlayerTest {
         val lm = FakeLanguageModel()
         val villager = AiPlayer(Role.VILLAGER, "Villager", lm, Instruction("Villager", "慎重に行動してください。"))
         val memories = villager.reveal(fakeCitizenWinSignal())
-        assertTrue(memories.any { it.chronicle().contains("Villager") && it.chronicle().contains("慎重に行動してください。") })
+        assertTrue(memories.filterIsInstance<Instruction>().any {
+            (it.toChronicleView() as ChronicleView.Observation).let { v ->
+                v.recipient == "Villager" && v.content.contains("慎重に行動してください。")
+            }
+        })
     }
 
     @Test

--- a/src/test/kotlin/werewolf/ClaimTest.kt
+++ b/src/test/kotlin/werewolf/ClaimTest.kt
@@ -4,9 +4,10 @@ import werewolf.game.*
 
 import kotlin.test.Test
 import kotlin.test.assertContains
-import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
+import kotlin.test.assertEquals
 
 class ClaimTest {
 
@@ -28,27 +29,19 @@ class ClaimTest {
     }
 
     @Test
-    fun `recall returns context title, statement text, and intent in brackets`() {
+    fun `toRecallView returns action with context title, content and intent`() {
         val speaker = NothingPlayer(Role.VILLAGER, "Speaker")
         val context = openContext(listOf(speaker))
         val claim = Claim(speaker, context, Statement.Plain("発言内容"), "真意内容")
-        assertEquals("<議論> 発言内容 <真意内容>", claim.recall())
+        assertEquals(RecallView.Action("議論", "発言内容", "真意内容"), claim.toRecallView())
     }
 
     @Test
-    fun `chronicle returns speaker name, context title, and statement text`() {
+    fun `toChronicleView returns action with speaker, context title, content and intent`() {
         val speaker = NothingPlayer(Role.VILLAGER, "Speaker")
         val context = openContext(listOf(speaker))
         val claim = Claim(speaker, context, Statement.Plain("発言内容"), "真意内容")
-        assertEquals("[Speaker] [議論] 発言内容", claim.chronicle())
-    }
-
-    @Test
-    fun `intentForChronicle returns the chronicle intent`() {
-        val speaker = NothingPlayer(Role.VILLAGER, "Speaker")
-        val context = openContext(listOf(speaker))
-        val claim = Claim(speaker, context, Statement.Plain("発言内容"), "真意内容")
-        assertEquals("真意内容", claim.intentForChronicle)
+        assertEquals(ChronicleView.Action("Speaker", "議論", "発言内容", "真意内容"), claim.toChronicleView())
     }
 
     @Test
@@ -57,6 +50,8 @@ class ClaimTest {
         val context = openContext(listOf(speaker))
         val claim = FallbackClaim(speaker, context)
         assertEquals("", claim.statement.text())
-        assertContains(claim.intentForChronicle, "失敗")
+        val fallbackClaimChronicle = claim.toChronicleView()
+        assertIs<ChronicleView.Action>(fallbackClaimChronicle)
+        assertContains(fallbackClaimChronicle.intent, "失敗")
     }
 }

--- a/src/test/kotlin/werewolf/EpilogueTest.kt
+++ b/src/test/kotlin/werewolf/EpilogueTest.kt
@@ -17,7 +17,7 @@ class EpilogueTest {
     private open class WatchingPlayer(role: Role, name: String) : ReceivingPlayer(role, name) {
         var gameOver: GameEvent.GameOver? = null
         var gameResult: GameEvent.GameResult? = null
-        val watchedEvents: MutableList<Recallable> = mutableListOf()
+        val watchedEvents: MutableList<ChronicleView> = mutableListOf()
 
         override fun onReceive(event: GameEvent) {
             when (event) {
@@ -27,7 +27,7 @@ class EpilogueTest {
             }
         }
 
-        override fun watchEpilogue(chronicles: List<Recallable>) {
+        override fun watchEpilogue(chronicles: List<ChronicleView>) {
             watchedEvents.addAll(chronicles)
         }
     }
@@ -88,6 +88,6 @@ class EpilogueTest {
 
         Epilogue(setup.playerManager, setup.oracle, signal).perform()
 
-        assertTrue(chooser.watchedEvents.any { it is Choice })
+        assertTrue(chooser.watchedEvents.any { it is ChronicleView.Action })
     }
 }

--- a/src/test/kotlin/werewolf/GameRecapTest.kt
+++ b/src/test/kotlin/werewolf/GameRecapTest.kt
@@ -3,7 +3,7 @@ package werewolf
 import werewolf.game.*
 
 import kotlin.test.Test
-import kotlin.test.assertContains
+import kotlin.test.assertIs
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -60,8 +60,12 @@ class GameRecapTest {
 
         val events = GameRecap(pm, anySignal()).events()
         assertEquals(3, events.size)
-        assertContains(events[0].chronicle(), "V1")
-        assertContains(events[1].chronicle(), "V2")
+        val v1Chronicle = events[0].toChronicleView()
+        assertIs<ChronicleView.Observation>(v1Chronicle)
+        assertEquals("V1", v1Chronicle.recipient)
+        val v2Chronicle = events[1].toChronicleView()
+        assertIs<ChronicleView.Observation>(v2Chronicle)
+        assertEquals("V2", v2Chronicle.recipient)
         assertTrue(events[2] is GameEvent.TimeChanged)
     }
 }

--- a/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
@@ -23,7 +23,7 @@ class HumanPlayerEpilogueTest {
 
     private class SpeakingPlayer(role: Role, name: String) : NothingPlayer(role, name) {
         override fun onReceive(event: GameEvent) {}
-        override fun watchEpilogue(chronicles: List<Recallable>) {}
+        override fun watchEpilogue(chronicles: List<ChronicleView>) {}
         override fun speak(context: DiscussionContext): Claim =
             Claim(this, context, Statement.Plain("$name speaks"), "intent")
     }

--- a/src/test/kotlin/werewolf/HumanPlayerTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerTest.kt
@@ -1,6 +1,6 @@
 package werewolf
 
-import werewolf.game.Recallable
+import werewolf.game.ChronicleView
 import werewolf.game.Role
 import werewolf.human.HumanPlayer
 import werewolf.human.PlayerIO
@@ -18,34 +18,32 @@ class HumanPlayerTest {
         override fun readPlayer(): String = error("not used")
     }
 
-    private fun recallable(chronicleText: String, intent: String? = null, redundant: Boolean = false) = object : Recallable() {
-        override fun recall() = chronicleText
-        override fun chronicle() = chronicleText
-        override val intentForChronicle get() = intent
-        override val isRedundantInChronicle get() = redundant
+    @Test
+    fun `watchEpilogue formats observation as bracket blocks`() {
+        val io = CapturingIO()
+        val player = HumanPlayer(Role.VILLAGER, "Player", io)
+        player.watchEpilogue(listOf(ChronicleView.Observation("Player", "カテゴリ", "内容")))
+        assertEquals("[Player] [カテゴリ] 内容", io.messages.last().second)
     }
 
     @Test
-    fun `watchEpilogue shows chronicle when intentForChronicle is null`() {
+    fun `watchEpilogue formats action with intent on next line`() {
         val io = CapturingIO()
         val player = HumanPlayer(Role.VILLAGER, "Player", io)
-        player.watchEpilogue(listOf(recallable("some chronicle")))
-        assertEquals("some chronicle", io.messages.last().second)
+        player.watchEpilogue(listOf(ChronicleView.Action("Player", "カテゴリ", "内容", "真意")))
+        assertEquals("[Player] [カテゴリ] 内容\n  [真意]", io.messages.last().second)
     }
 
     @Test
-    fun `watchEpilogue appends intent on next line when intentForChronicle is present`() {
+    fun `watchEpilogue joins multiple chronicles with newline`() {
         val io = CapturingIO()
         val player = HumanPlayer(Role.VILLAGER, "Player", io)
-        player.watchEpilogue(listOf(recallable("some chronicle", "some intent")))
-        assertEquals("some chronicle\n  [some intent]", io.messages.last().second)
-    }
-
-    @Test
-    fun `watchEpilogue excludes redundant records`() {
-        val io = CapturingIO()
-        val player = HumanPlayer(Role.VILLAGER, "Player", io)
-        player.watchEpilogue(listOf(recallable("kept"), recallable("excluded", redundant = true)))
-        assertEquals("kept", io.messages.last().second)
+        player.watchEpilogue(
+            listOf(
+                ChronicleView.Observation("Player", "カテゴリ", "1件目"),
+                ChronicleView.Observation("Player", "カテゴリ", "2件目"),
+            )
+        )
+        assertEquals("[Player] [カテゴリ] 1件目\n[Player] [カテゴリ] 2件目", io.messages.last().second)
     }
 }

--- a/src/test/kotlin/werewolf/NothingPlayer.kt
+++ b/src/test/kotlin/werewolf/NothingPlayer.kt
@@ -6,5 +6,5 @@ open class NothingPlayer(role: Role, override val name: String) : Player(role) {
     override fun speak(context: DiscussionContext): Claim = error("speak not expected")
     override fun onReceive(event: GameEvent) { error("onReceive not expected") }
     override fun choose(context: SelectionContext): Choice = error("choose not expected")
-    override fun watchEpilogue(chronicles: List<Recallable>) { error("watchEpilogue not expected") }
+    override fun watchEpilogue(chronicles: List<ChronicleView>) { error("watchEpilogue not expected") }
 }


### PR DESCRIPTION
## Summary
- `Recallable` に `toRecallView()` / `toChronicleView()` を追加し、文字列メソッド `recall()` / `chronicle()` を削除
- `RecallView` / `ChronicleView` を sealed class（Observation / Action）として新設。intent の有無を型で表現
- `watchEpilogue` の引数を `List<Recallable>` → `List<ChronicleView>` に変更し、`GameRecap.chronicles()` でフィルタ済みの構造化データを渡す
- `HumanPlayer` / `WebPlayer` / `AiPlayer` の整形ロジックを private 拡張関数として切り出し
- `WebPlayer` はエピローグを JSON 配列として送信し、ブラウザ側でフォーマット

Closes #234

## Test plan
- [ ] `./gradlew check` が通ること
- [ ] `HumanPlayerEpilogueTest`：Claim は表示され StatementMade は除外されること
- [ ] `EpilogueTest`：全プレイヤーに chronicles が渡ること、Choice の Action が含まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)