### PR TITLE
Show player's own choice in game log after selection

### DIFF
--- a/src/main/kotlin/werewolf/human/HumanPlayer.kt
+++ b/src/main/kotlin/werewolf/human/HumanPlayer.kt
@@ -18,7 +18,9 @@ class HumanPlayer(role: Role, override val name: String, private val io: HumanIO
     override fun choose(context: SelectionContext): Choice {
         val candidates = context.candidates()
         val selected = io.promptChoice(ChoiceView(context.title, context.description, candidates.map { it.name }))
-        return Choice(this, context, candidates.single { it.name == selected }, "プレイヤーが選択")
+        val choice = Choice(this, context, candidates.single { it.name == selected }, "プレイヤーが選択")
+        io.display(choice.toRecallView())
+        return choice
     }
 
     override fun onReceive(event: GameEvent) {

--- a/src/main/kotlin/werewolf/human/web/WebHumanIO.kt
+++ b/src/main/kotlin/werewolf/human/web/WebHumanIO.kt
@@ -57,9 +57,9 @@ class WebHumanIO : HumanIO {
 
 private fun RecallView.toJson(): String = when (this) {
     is RecallView.Observation ->
-        """{"type":"event","title":${category.jsonEncode()},"body":${content.jsonEncode()}}"""
+        """{"type":"observation","title":${category.jsonEncode()},"body":${content.jsonEncode()}}"""
     is RecallView.Action ->
-        """{"type":"event","title":${category.jsonEncode()},"body":${content.jsonEncode()},"intent":${intent.jsonEncode()}}"""
+        """{"type":"action","title":${category.jsonEncode()},"body":${content.jsonEncode()},"intent":${intent.jsonEncode()}}"""
 }
 
 private fun ChronicleView.toJson(): String = when (this) {

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -9,6 +9,7 @@
         #log { border: 1px solid #ccc; height: 500px; overflow-y: auto; padding: 8px; background: #fafafa; }
         .event { margin: 4px 0; line-height: 1.4; }
         .title { font-weight: bold; color: #444; }
+        .intent { color: #888; font-size: 0.9em; }
         .epilogue { margin-top: 16px; padding: 12px; background: #eef; white-space: pre-wrap; border-left: 4px solid #88a; }
         #controls { margin-top: 8px; margin-bottom: 8px; }
         #input-area { margin-bottom: 8px; padding: 12px; border: 2px solid #88a; background: #f0f0fa; display: none; }
@@ -47,10 +48,11 @@
         ws.onerror = () => { status.textContent = 'エラー'; };
 
         const handlers = {
-            event:    (msg) => showEvent(msg.title, msg.body),
-            epilogue: (msg) => showEpilogue(msg.chronicles),
-            choose:   (msg) => showChoose(msg.title, msg.description, msg.candidates),
-            speak:    (msg) => showSpeak(msg.title, msg.description),
+            observation: (msg) => showEvent(msg.title, msg.body),
+            action:      (msg) => showAction(msg.title, msg.body, msg.intent),
+            epilogue:    (msg) => showEpilogue(msg.chronicles),
+            choose:      (msg) => showChoose(msg.title, msg.description, msg.candidates),
+            speak:       (msg) => showSpeak(msg.title, msg.description),
         };
 
         ws.onmessage = (event) => {
@@ -68,6 +70,11 @@
 
         function showEvent(title, body) {
             appendLog('event', `<span class="title">[${esc(title)}]</span> ${esc(body)}`);
+        }
+
+        function showAction(title, body, intent) {
+            const intentHtml = intent ? `<br><span class="intent">  [${esc(intent)}]</span>` : '';
+            appendLog('event', `<span class="title">[${esc(title)}]</span> ${esc(body)}${intentHtml}`);
         }
 
         function showEpilogue(chronicles) {

--- a/src/test/kotlin/werewolf/HumanPlayerTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerTest.kt
@@ -24,9 +24,10 @@ class HumanPlayerTest {
     ) : HumanIO {
         private val queue = ArrayDeque(choiceAnswers.toList())
         val promptedChoices = mutableListOf<ChoiceView>()
+        val displayedViews = mutableListOf<RecallView>()
         var capturedChronicles: List<ChronicleView> = emptyList()
 
-        override fun display(view: RecallView) {}
+        override fun display(view: RecallView) { displayedViews += view }
         override fun promptChoice(view: ChoiceView): String {
             promptedChoices += view
             return queue.removeFirst()
@@ -46,6 +47,21 @@ class HumanPlayerTest {
 
         assertEquals(alice, selected)
         assertEquals(listOf("Alice"), io.promptedChoices.single().options)
+    }
+
+    @Test
+    fun `choose displays the selected player via io`() {
+        val alice = NothingPlayer(Role.VILLAGER, "Alice")
+        val io = CapturingIO("Alice")
+        val human = HumanPlayer(Role.VILLAGER, "Human", io)
+        val context = SelectionContext.Vote(human, listOf(human, alice))
+
+        human.selectTarget(context)
+
+        assertEquals(
+            listOf<RecallView>(RecallView.Action("投票", "Alice", "プレイヤーが選択")),
+            io.displayedViews,
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `HumanPlayer.choose()` で選択後に `io.display(choice.toRecallView())` を呼ぶよう変更し、選択内容をゲームログに表示
- `WebHumanIO` の `RecallView.toJson()` で型名を整理: `"event"` → `"observation"` / `"action"`
- Web UI に `showAction()` ハンドラを追加し、title・body に加えて intent も表示

## Test plan

- [ ] `HumanPlayerTest` に `choose displays the selected player via io` を追加済み
- [ ] Web UI で投票・夜の行動後にログ欄に選択内容と intent が表示されることを確認

Closes #233

🤖 Generated with [Claude Code](https://claude.ai/claude-code)