### PR TITLE
Add survival panel to web UI

### DIFF
--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -15,12 +15,16 @@
     | { type: 'choose'; title: string; description: string; candidates: string[] }
     | { type: 'speak'; title: string; description: string }
 
+  type PlayerStatus = 'alive' | 'executed' | 'attacked'
+  type SurvivalEntry = { name: string; status: PlayerStatus }
+
   let status = '接続中...'
   let entries: LogEntry[] = []
   let input: InputState = { type: 'idle' }
   let speakText = ''
   let logEl: HTMLElement
   let ws: WebSocket
+  let survivalPlayers: SurvivalEntry[] = []
 
   onMount(() => {
     ws = new WebSocket(`ws://${location.host}/game`)
@@ -48,6 +52,9 @@
       case 'speak':
         input = { type: 'speak', title: msg.title as string, description: msg.description as string }
         speakText = ''
+        break
+      case 'survival':
+        survivalPlayers = msg.players as SurvivalEntry[]
         break
     }
   }
@@ -80,60 +87,88 @@
     const line = `[${c.actor}] [${c.category}] ${c.content}`
     return c.intent ? `${line}\n  [${c.intent}]` : line
   }
+
+  function statusLabel(s: PlayerStatus): string {
+    if (s === 'alive') return '生存'
+    if (s === 'executed') return '処刑'
+    return '襲撃'
+  }
 </script>
 
-<main>
-  <h1>人狼ゲーム</h1>
-  <p class="status">{status}</p>
+<div class="layout">
+  <div class="main">
+    <h1>人狼ゲーム</h1>
+    <p class="status">{status}</p>
 
-  <div class="controls">
-    <button on:click={abort}>ゲームを中断</button>
-  </div>
-
-  {#if input.type === 'choose'}
-    <div class="input-area">
-      <p class="input-title">{input.title}</p>
-      <p class="input-description">{input.description}</p>
-      <div>
-        {#each input.candidates as name}
-          <button on:click={() => choose(name)}>{name}</button>
-        {/each}
-      </div>
+    <div class="controls">
+      <button on:click={abort}>ゲームを中断</button>
     </div>
-  {:else if input.type === 'speak'}
-    <div class="input-area">
-      <p class="input-title">{input.title}</p>
-      <p class="input-description">{input.description}</p>
-      <div>
-        <input
-          type="text"
-          bind:value={speakText}
-          placeholder="発言を入力..."
-          on:keydown={(e) => e.key === 'Enter' && speak()}
-        />
-        <button on:click={speak}>送信</button>
-      </div>
-    </div>
-  {/if}
 
-  <div class="log" bind:this={logEl}>
-    {#each entries as entry}
-      {#if entry.type === 'observation'}
-        <div class="event"><span class="title">[{entry.title}]</span> {entry.body}</div>
-      {:else if entry.type === 'action'}
-        <div class="event">
-          <span class="title">[{entry.title}]</span> {entry.body}
-          {#if entry.intent}<br /><span class="intent">  [{entry.intent}]</span>{/if}
+    {#if input.type === 'choose'}
+      <div class="input-area">
+        <p class="input-title">{input.title}</p>
+        <p class="input-description">{input.description}</p>
+        <div>
+          {#each input.candidates as name}
+            <button on:click={() => choose(name)}>{name}</button>
+          {/each}
         </div>
-      {:else if entry.type === 'epilogue'}
-        <pre class="epilogue">{entry.chronicles.map(formatChronicle).join('\n')}</pre>
-      {/if}
-    {/each}
+      </div>
+    {:else if input.type === 'speak'}
+      <div class="input-area">
+        <p class="input-title">{input.title}</p>
+        <p class="input-description">{input.description}</p>
+        <div>
+          <input
+            type="text"
+            bind:value={speakText}
+            placeholder="発言を入力..."
+            on:keydown={(e) => e.key === 'Enter' && speak()}
+          />
+          <button on:click={speak}>送信</button>
+        </div>
+      </div>
+    {/if}
+
+    <div class="log" bind:this={logEl}>
+      {#each entries as entry}
+        {#if entry.type === 'observation'}
+          <div class="event"><span class="title">[{entry.title}]</span> {entry.body}</div>
+        {:else if entry.type === 'action'}
+          <div class="event">
+            <span class="title">[{entry.title}]</span> {entry.body}
+            {#if entry.intent}<br /><span class="intent">  [{entry.intent}]</span>{/if}
+          </div>
+        {:else if entry.type === 'epilogue'}
+          <pre class="epilogue">{entry.chronicles.map(formatChronicle).join('\n')}</pre>
+        {/if}
+      {/each}
+    </div>
   </div>
-</main>
+
+  <aside class="panel">
+    <h2>生存状況</h2>
+    {#if survivalPlayers.length === 0}
+      <p class="panel-empty">ゲーム開始前</p>
+    {:else}
+      <ul class="survival-list">
+        {#each survivalPlayers as p}
+          <li class="survival-entry {p.status}">
+            <span class="player-name">{p.name}</span>
+            <span class="player-status">{statusLabel(p.status)}</span>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </aside>
+</div>
 
 <style>
-  main { font-family: sans-serif; max-width: 800px; margin: 0 auto; padding: 16px; }
+  .layout { display: flex; gap: 16px; max-width: 1100px; margin: 0 auto; padding: 16px; font-family: sans-serif; }
+  .main { flex: 1; min-width: 0; }
+  .panel { width: 200px; flex-shrink: 0; border: 1px solid #ccc; border-radius: 4px; padding: 12px; background: #fafafa; align-self: flex-start; }
+  h1 { margin: 0 0 4px; }
+  h2 { margin: 0 0 10px; font-size: 1em; color: #444; }
   .status { color: #666; margin-bottom: 8px; }
   .controls { margin: 8px 0; }
   .log { border: 1px solid #ccc; height: 500px; overflow-y: auto; padding: 8px; background: #fafafa; }
@@ -146,4 +181,14 @@
   .input-description { color: #666; font-size: 0.9em; margin: 0 0 10px; }
   button { margin: 4px; padding: 6px 14px; cursor: pointer; }
   input[type='text'] { width: 70%; padding: 6px; font-size: 1em; }
+
+  .panel-empty { color: #999; font-size: 0.9em; }
+  .survival-list { list-style: none; margin: 0; padding: 0; }
+  .survival-entry { display: flex; justify-content: space-between; align-items: center; padding: 4px 0; border-bottom: 1px solid #eee; font-size: 0.9em; }
+  .survival-entry:last-child { border-bottom: none; }
+  .player-name { flex: 1; }
+  .player-status { font-size: 0.8em; padding: 1px 6px; border-radius: 3px; }
+  .alive .player-status { background: #d4f7d4; color: #2a6e2a; }
+  .executed .player-status { background: #f7d4d4; color: #6e2a2a; }
+  .attacked .player-status { background: #f7ead4; color: #6e4a2a; }
 </style>

--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -91,7 +91,8 @@
   function statusLabel(s: PlayerStatus): string {
     if (s === 'alive') return '生存'
     if (s === 'executed') return '処刑'
-    return '襲撃'
+    if (s === 'attacked') return '襲撃'
+    throw new Error(`Unknown player status: ${s}`)
   }
 </script>
 

--- a/src/main/kotlin/werewolf/game/GameEvent.kt
+++ b/src/main/kotlin/werewolf/game/GameEvent.kt
@@ -13,6 +13,16 @@ sealed class GameEvent : Recallable() {
     fun isPublicKnowledge(): Boolean = recipients is AllPlayers
 
     @ConsistentCopyVisibility
+    data class PlayersAnnounced private constructor(val players: List<Player>, private val allPlayers: AllPlayers) : GameEvent() {
+        override val title = "参加者一覧"
+        override fun body() = players.joinToString("、") { it.name }
+        override val recipients: Notifiable = allPlayers
+        companion object {
+            fun send(players: List<Player>, allPlayers: AllPlayers) = PlayersAnnounced(players, allPlayers).dispatch()
+        }
+    }
+
+    @ConsistentCopyVisibility
     data class RoleAssigned private constructor(val role: Role, private val recipient: Player) : GameEvent() {
         override val title = "役職通知"
         override fun body() = "あなたの役職は「${role.displayName}」です。"

--- a/src/main/kotlin/werewolf/human/GameNote.kt
+++ b/src/main/kotlin/werewolf/human/GameNote.kt
@@ -1,0 +1,20 @@
+package werewolf.human
+
+import werewolf.game.GameEvent
+import werewolf.view.PlayerStatus
+import werewolf.view.SurvivalView
+
+class GameNote {
+    private val playerStatuses = mutableMapOf<String, PlayerStatus>()
+
+    fun post(event: GameEvent) {
+        when (event) {
+            is GameEvent.PlayersAnnounced -> event.players.forEach { playerStatuses[it.name] = PlayerStatus.ALIVE }
+            is GameEvent.PlayerExecuted -> playerStatuses[event.executed.name] = PlayerStatus.EXECUTED
+            is GameEvent.PlayerAttacked -> playerStatuses[event.attacked.name] = PlayerStatus.ATTACKED
+            else -> Unit
+        }
+    }
+
+    fun summary(): SurvivalView = SurvivalView(playerStatuses.toMap())
+}

--- a/src/main/kotlin/werewolf/human/HumanIO.kt
+++ b/src/main/kotlin/werewolf/human/HumanIO.kt
@@ -3,9 +3,11 @@ package werewolf.human
 import werewolf.game.ChronicleView
 import werewolf.game.RecallView
 import werewolf.view.ChoiceView
+import werewolf.view.SurvivalView
 
 interface HumanIO {
     fun display(view: RecallView)
+    fun updatePanel(view: SurvivalView)
     fun promptChoice(view: ChoiceView): String
     fun promptFreeText(title: String, description: String): String
     fun watchEpilogue(chronicles: List<ChronicleView>)

--- a/src/main/kotlin/werewolf/human/HumanPlayer.kt
+++ b/src/main/kotlin/werewolf/human/HumanPlayer.kt
@@ -13,11 +13,11 @@ import werewolf.game.SelectionContext
 import werewolf.game.Statement
 import werewolf.game.StatementType
 import werewolf.view.ChoiceView
-import werewolf.view.PlayerStatus
 import werewolf.view.SurvivalView
 
 class HumanPlayer(role: Role, override val name: String, private val io: HumanIO) : Player(role) {
-    private val playerStatuses = mutableMapOf<String, PlayerStatus>()
+    private val gameNote = GameNote()
+    private var lastSummary: SurvivalView? = null
 
     override fun choose(context: SelectionContext): Choice {
         val candidates = context.candidates()
@@ -29,20 +29,11 @@ class HumanPlayer(role: Role, override val name: String, private val io: HumanIO
 
     override fun onReceive(event: GameEvent) {
         io.display(event.toRecallView())
-        when (event) {
-            is GameEvent.PlayersAnnounced -> {
-                event.players.forEach { playerStatuses[it.name] = PlayerStatus.ALIVE }
-                io.updatePanel(SurvivalView(playerStatuses.toMap()))
-            }
-            is GameEvent.PlayerExecuted -> {
-                playerStatuses[event.executed.name] = PlayerStatus.EXECUTED
-                io.updatePanel(SurvivalView(playerStatuses.toMap()))
-            }
-            is GameEvent.PlayerAttacked -> {
-                playerStatuses[event.attacked.name] = PlayerStatus.ATTACKED
-                io.updatePanel(SurvivalView(playerStatuses.toMap()))
-            }
-            else -> Unit
+        gameNote.post(event)
+        val current = gameNote.summary()
+        if (current != lastSummary) {
+            lastSummary = current
+            io.updatePanel(current)
         }
     }
 

--- a/src/main/kotlin/werewolf/human/HumanPlayer.kt
+++ b/src/main/kotlin/werewolf/human/HumanPlayer.kt
@@ -13,8 +13,12 @@ import werewolf.game.SelectionContext
 import werewolf.game.Statement
 import werewolf.game.StatementType
 import werewolf.view.ChoiceView
+import werewolf.view.PlayerStatus
+import werewolf.view.SurvivalView
 
 class HumanPlayer(role: Role, override val name: String, private val io: HumanIO) : Player(role) {
+    private val playerStatuses = mutableMapOf<String, PlayerStatus>()
+
     override fun choose(context: SelectionContext): Choice {
         val candidates = context.candidates()
         val selected = io.promptChoice(ChoiceView(context.title, context.description, candidates.map { it.name }))
@@ -25,6 +29,21 @@ class HumanPlayer(role: Role, override val name: String, private val io: HumanIO
 
     override fun onReceive(event: GameEvent) {
         io.display(event.toRecallView())
+        when (event) {
+            is GameEvent.PlayersAnnounced -> {
+                event.players.forEach { playerStatuses[it.name] = PlayerStatus.ALIVE }
+                io.updatePanel(SurvivalView(playerStatuses.toMap()))
+            }
+            is GameEvent.PlayerExecuted -> {
+                playerStatuses[event.executed.name] = PlayerStatus.EXECUTED
+                io.updatePanel(SurvivalView(playerStatuses.toMap()))
+            }
+            is GameEvent.PlayerAttacked -> {
+                playerStatuses[event.attacked.name] = PlayerStatus.ATTACKED
+                io.updatePanel(SurvivalView(playerStatuses.toMap()))
+            }
+            else -> Unit
+        }
     }
 
     override fun speak(context: DiscussionContext): Claim {

--- a/src/main/kotlin/werewolf/human/console/ConsoleHumanIO.kt
+++ b/src/main/kotlin/werewolf/human/console/ConsoleHumanIO.kt
@@ -5,11 +5,16 @@ import werewolf.game.GameOverSignal
 import werewolf.game.RecallView
 import werewolf.human.HumanIO
 import werewolf.view.ChoiceView
+import werewolf.view.SurvivalView
 
 class ConsoleHumanIO : HumanIO {
 
     companion object {
         private const val ABORT_PASSWORD = 4423
+    }
+
+    override fun updatePanel(view: SurvivalView) {
+        // Console has no persistent panel; survival info is visible in the event log
     }
 
     override fun display(view: RecallView) = when (view) {

--- a/src/main/kotlin/werewolf/human/web/WebHumanIO.kt
+++ b/src/main/kotlin/werewolf/human/web/WebHumanIO.kt
@@ -7,6 +7,8 @@ import werewolf.game.GameOverSignal
 import werewolf.game.RecallView
 import werewolf.human.HumanIO
 import werewolf.view.ChoiceView
+import werewolf.view.PlayerStatus
+import werewolf.view.SurvivalView
 
 class WebHumanIO : HumanIO {
     val outgoing = Channel<String>(Channel.UNLIMITED)
@@ -19,6 +21,13 @@ class WebHumanIO : HumanIO {
 
     fun checkAbort() {
         if (abortRequested) GameOverSignal.throwManualAbort()
+    }
+
+    override fun updatePanel(view: SurvivalView) {
+        val playersJson = view.players.entries.joinToString(",") {
+            """{"name":${it.key.jsonEncode()},"status":${it.value.toJson()}}"""
+        }
+        enqueue("""{"type":"survival","players":[$playersJson]}""")
     }
 
     override fun display(view: RecallView) {
@@ -53,6 +62,12 @@ class WebHumanIO : HumanIO {
     private fun enqueue(message: String) {
         check(outgoing.trySend(message).isSuccess) { "Failed to queue message" }
     }
+}
+
+private fun PlayerStatus.toJson(): String = when (this) {
+    PlayerStatus.ALIVE -> "\"alive\""
+    PlayerStatus.EXECUTED -> "\"executed\""
+    PlayerStatus.ATTACKED -> "\"attacked\""
 }
 
 private fun RecallView.toJson(): String = when (this) {

--- a/src/main/kotlin/werewolf/phase/InitialPhase.kt
+++ b/src/main/kotlin/werewolf/phase/InitialPhase.kt
@@ -1,11 +1,13 @@
 package werewolf.phase
 
+import werewolf.game.AllPlayers
 import werewolf.game.GameEvent
 import werewolf.game.Oracle
 import werewolf.game.PlayerManager
 
 class InitialPhase(private val playerManager: PlayerManager, private val oracle: Oracle) : Phase {
     override fun proceed(): Phase {
+        GameEvent.PlayersAnnounced.send(playerManager.allPlayers, AllPlayers(playerManager))
         playerManager.allPlayers.forEach { oracle.revealRole(it) }
         val wolves = oracle.werewolves(playerManager.players)
         wolves.forEach { self ->

--- a/src/main/kotlin/werewolf/view/SurvivalView.kt
+++ b/src/main/kotlin/werewolf/view/SurvivalView.kt
@@ -1,0 +1,5 @@
+package werewolf.view
+
+enum class PlayerStatus { ALIVE, EXECUTED, ATTACKED }
+
+data class SurvivalView(val players: Map<String, PlayerStatus>)

--- a/src/test/kotlin/werewolf/GameNoteTest.kt
+++ b/src/test/kotlin/werewolf/GameNoteTest.kt
@@ -11,6 +11,7 @@ import werewolf.game.RecallView
 import werewolf.game.Role
 import werewolf.human.HumanIO
 import werewolf.human.HumanPlayer
+import werewolf.phase.InitialPhase
 import werewolf.view.ChoiceView
 import werewolf.view.PlayerStatus
 import werewolf.view.SurvivalView
@@ -30,19 +31,18 @@ class GameNoteTest {
         override fun onReceive(event: GameEvent) {}
     }
 
-    private fun setup(io: CapturingIO, vararg others: Pair<String, Role>): GameSetup {
-        val human = HumanPlayer(Role.VILLAGER, "Human", io)
+    private fun createGameWithHuman(io: CapturingIO, vararg others: Pair<String, Role>): GameSetup {
+        val human = HumanPlayer(Role.VILLAGER, "V1", io)
         val otherPlayers = others.map { (name, role) -> SilentPlayer(role, name) to role }
         return TestLodge(*otherPlayers.toTypedArray(), human to Role.VILLAGER).create()
     }
 
     @Test
-    fun `PlayersAnnounced triggers panel with all players as alive`() {
+    fun `all players appear as alive at game start`() {
         val io = CapturingIO()
-        val gameSetup = setup(io, "Alice" to Role.VILLAGER, "Wolf" to Role.WEREWOLF)
-        val allPlayers = AllPlayers(gameSetup.playerManager)
+        val gameSetup = createGameWithHuman(io, "V2" to Role.VILLAGER, "Wolf" to Role.WEREWOLF)
 
-        GameEvent.PlayersAnnounced.send(gameSetup.playerManager.allPlayers, allPlayers)
+        InitialPhase(gameSetup.playerManager, gameSetup.oracle).proceed()
 
         val summary = io.panels.last()
         assertTrue(summary.players.values.all { it == PlayerStatus.ALIVE })
@@ -50,43 +50,41 @@ class GameNoteTest {
     }
 
     @Test
-    fun `PlayerExecuted marks player as executed`() {
+    fun `player is marked as executed after execution`() {
         val io = CapturingIO()
-        val gameSetup = setup(io, "Alice" to Role.VILLAGER)
-        val allPlayers = AllPlayers(gameSetup.playerManager)
-        val alice = gameSetup.playerManager.allPlayers.single { it.name == "Alice" }
+        // V2 + V3 to avoid game-over when V2 is executed (wolf would equal citizens)
+        val gameSetup = createGameWithHuman(io, "V2" to Role.VILLAGER, "V3" to Role.VILLAGER, "Wolf" to Role.WEREWOLF)
+        InitialPhase(gameSetup.playerManager, gameSetup.oracle).proceed()
+        val v2 = gameSetup.playerManager.allPlayers.single { it.name == "V2" }
 
-        GameEvent.PlayersAnnounced.send(gameSetup.playerManager.allPlayers, allPlayers)
-        GameEvent.PlayerExecuted.send(alice, allPlayers)
+        gameSetup.playerManager.execute(v2)
 
-        assertEquals(PlayerStatus.EXECUTED, io.panels.last().players["Alice"])
-        assertEquals(PlayerStatus.ALIVE, io.panels.last().players["Human"])
+        assertEquals(PlayerStatus.EXECUTED, io.panels.last().players["V2"])
+        assertEquals(PlayerStatus.ALIVE, io.panels.last().players["V1"])
     }
 
     @Test
-    fun `PlayerAttacked marks player as attacked`() {
+    fun `player is marked as attacked after night kill`() {
         val io = CapturingIO()
-        val gameSetup = setup(io, "Alice" to Role.VILLAGER)
-        val allPlayers = AllPlayers(gameSetup.playerManager)
-        val alice = gameSetup.playerManager.allPlayers.single { it.name == "Alice" }
+        // V2 + V3 to avoid game-over when V2 is attacked (wolf would equal citizens)
+        val gameSetup = createGameWithHuman(io, "V2" to Role.VILLAGER, "V3" to Role.VILLAGER, "Wolf" to Role.WEREWOLF)
+        InitialPhase(gameSetup.playerManager, gameSetup.oracle).proceed()
+        val v2 = gameSetup.playerManager.allPlayers.single { it.name == "V2" }
 
-        GameEvent.PlayersAnnounced.send(gameSetup.playerManager.allPlayers, allPlayers)
-        GameEvent.PlayerAttacked.send(alice, allPlayers)
+        gameSetup.playerManager.kill(v2)
 
-        assertEquals(PlayerStatus.ATTACKED, io.panels.last().players["Alice"])
+        assertEquals(PlayerStatus.ATTACKED, io.panels.last().players["V2"])
     }
 
     @Test
-    fun `irrelevant events do not trigger panel update`() {
+    fun `panel is not updated for unrelated events`() {
         val io = CapturingIO()
-        val gameSetup = setup(io, "Alice" to Role.VILLAGER)
-        val allPlayers = AllPlayers(gameSetup.playerManager)
+        val gameSetup = createGameWithHuman(io, "V2" to Role.VILLAGER, "Wolf" to Role.WEREWOLF)
+        InitialPhase(gameSetup.playerManager, gameSetup.oracle).proceed()
+        val countAfterStart = io.panels.size
 
-        GameEvent.PlayersAnnounced.send(gameSetup.playerManager.allPlayers, allPlayers)
-        val countAfterAnnounce = io.panels.size
+        GameEvent.DiscussionStarted.send(1, AllPlayers(gameSetup.playerManager))
 
-        GameEvent.DiscussionStarted.send(1, allPlayers)
-
-        assertEquals(countAfterAnnounce, io.panels.size)
+        assertEquals(countAfterStart, io.panels.size)
     }
 }

--- a/src/test/kotlin/werewolf/GameNoteTest.kt
+++ b/src/test/kotlin/werewolf/GameNoteTest.kt
@@ -1,0 +1,92 @@
+package werewolf
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import werewolf.game.AllPlayers
+import werewolf.game.ChronicleView
+import werewolf.game.GameEvent
+import werewolf.game.GameSetup
+import werewolf.game.RecallView
+import werewolf.game.Role
+import werewolf.human.HumanIO
+import werewolf.human.HumanPlayer
+import werewolf.view.ChoiceView
+import werewolf.view.PlayerStatus
+import werewolf.view.SurvivalView
+
+class GameNoteTest {
+
+    private class CapturingIO : HumanIO {
+        val panels = mutableListOf<SurvivalView>()
+        override fun display(view: RecallView) {}
+        override fun updatePanel(view: SurvivalView) { panels += view }
+        override fun promptChoice(view: ChoiceView): String = error("not expected")
+        override fun promptFreeText(title: String, description: String): String = error("not expected")
+        override fun watchEpilogue(chronicles: List<ChronicleView>) {}
+    }
+
+    private class SilentPlayer(role: Role, name: String) : NothingPlayer(role, name) {
+        override fun onReceive(event: GameEvent) {}
+    }
+
+    private fun setup(io: CapturingIO, vararg others: Pair<String, Role>): GameSetup {
+        val human = HumanPlayer(Role.VILLAGER, "Human", io)
+        val otherPlayers = others.map { (name, role) -> SilentPlayer(role, name) to role }
+        return TestLodge(*otherPlayers.toTypedArray(), human to Role.VILLAGER).create()
+    }
+
+    @Test
+    fun `PlayersAnnounced triggers panel with all players as alive`() {
+        val io = CapturingIO()
+        val gameSetup = setup(io, "Alice" to Role.VILLAGER, "Wolf" to Role.WEREWOLF)
+        val allPlayers = AllPlayers(gameSetup.playerManager)
+
+        GameEvent.PlayersAnnounced.send(gameSetup.playerManager.allPlayers, allPlayers)
+
+        val summary = io.panels.last()
+        assertTrue(summary.players.values.all { it == PlayerStatus.ALIVE })
+        assertEquals(3, summary.players.size)
+    }
+
+    @Test
+    fun `PlayerExecuted marks player as executed`() {
+        val io = CapturingIO()
+        val gameSetup = setup(io, "Alice" to Role.VILLAGER)
+        val allPlayers = AllPlayers(gameSetup.playerManager)
+        val alice = gameSetup.playerManager.allPlayers.single { it.name == "Alice" }
+
+        GameEvent.PlayersAnnounced.send(gameSetup.playerManager.allPlayers, allPlayers)
+        GameEvent.PlayerExecuted.send(alice, allPlayers)
+
+        assertEquals(PlayerStatus.EXECUTED, io.panels.last().players["Alice"])
+        assertEquals(PlayerStatus.ALIVE, io.panels.last().players["Human"])
+    }
+
+    @Test
+    fun `PlayerAttacked marks player as attacked`() {
+        val io = CapturingIO()
+        val gameSetup = setup(io, "Alice" to Role.VILLAGER)
+        val allPlayers = AllPlayers(gameSetup.playerManager)
+        val alice = gameSetup.playerManager.allPlayers.single { it.name == "Alice" }
+
+        GameEvent.PlayersAnnounced.send(gameSetup.playerManager.allPlayers, allPlayers)
+        GameEvent.PlayerAttacked.send(alice, allPlayers)
+
+        assertEquals(PlayerStatus.ATTACKED, io.panels.last().players["Alice"])
+    }
+
+    @Test
+    fun `irrelevant events do not trigger panel update`() {
+        val io = CapturingIO()
+        val gameSetup = setup(io, "Alice" to Role.VILLAGER)
+        val allPlayers = AllPlayers(gameSetup.playerManager)
+
+        GameEvent.PlayersAnnounced.send(gameSetup.playerManager.allPlayers, allPlayers)
+        val countAfterAnnounce = io.panels.size
+
+        GameEvent.DiscussionStarted.send(1, allPlayers)
+
+        assertEquals(countAfterAnnounce, io.panels.size)
+    }
+}

--- a/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
@@ -4,6 +4,7 @@ import werewolf.game.*
 import werewolf.human.HumanPlayer
 import werewolf.human.HumanIO
 import werewolf.view.ChoiceView
+import werewolf.view.SurvivalView
 import werewolf.phase.Conclave
 import werewolf.phase.Epilogue
 import werewolf.phase.OpenDiscussion
@@ -17,6 +18,7 @@ class HumanPlayerEpilogueTest {
     private class SpeakingIO : HumanIO {
         var capturedChronicles: List<ChronicleView> = emptyList()
         override fun display(view: RecallView) {}
+        override fun updatePanel(view: SurvivalView) {}
         override fun promptFreeText(title: String, description: String): String = "human speaks"
         override fun promptChoice(view: ChoiceView): String = view.options.first()
         override fun watchEpilogue(chronicles: List<ChronicleView>) { capturedChronicles = chronicles }

--- a/src/test/kotlin/werewolf/HumanPlayerTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerTest.kt
@@ -15,6 +15,7 @@ import werewolf.game.StatementType
 import werewolf.human.HumanIO
 import werewolf.human.HumanPlayer
 import werewolf.view.ChoiceView
+import werewolf.view.SurvivalView
 
 class HumanPlayerTest {
 
@@ -28,6 +29,7 @@ class HumanPlayerTest {
         var capturedChronicles: List<ChronicleView> = emptyList()
 
         override fun display(view: RecallView) { displayedViews += view }
+        override fun updatePanel(view: SurvivalView) {}
         override fun promptChoice(view: ChoiceView): String {
             promptedChoices += view
             return queue.removeFirst()

--- a/src/test/kotlin/werewolf/InitialPhaseTest.kt
+++ b/src/test/kotlin/werewolf/InitialPhaseTest.kt
@@ -63,6 +63,23 @@ class InitialPhaseTest {
     }
 
     @Test
+    fun `all players receive PlayersAnnounced with full player list`() {
+        val villager = RecordingPlayer(Role.VILLAGER, "Villager")
+        val wolf = RecordingPlayer(Role.WEREWOLF, "Wolf")
+        val setup = TestLodge(villager to Role.VILLAGER, wolf to Role.WEREWOLF).create()
+
+        InitialPhase(setup.playerManager, setup.oracle).proceed()
+
+        val announcedNames = villager.received
+            .filterIsInstance<GameEvent.PlayersAnnounced>()
+            .single()
+            .players
+            .map { it.name }
+        assertTrue(announcedNames.containsAll(listOf("Villager", "Wolf")))
+        assertEquals(announcedNames, wolf.received.filterIsInstance<GameEvent.PlayersAnnounced>().single().players.map { it.name })
+    }
+
+    @Test
     fun `returns NightPhase`() {
         val setup = TestLodge(
             RecordingPlayer(Role.WEREWOLF, "Wolf") to Role.WEREWOLF,


### PR DESCRIPTION
## Summary

- `GameEvent.PlayersAnnounced` を追加し、`InitialPhase` でゲーム開始時に全プレイヤーへ送信
- `SurvivalView`（`Map<name, PlayerStatus>`）と `HumanIO.updatePanel()` を新設
- `HumanPlayer` がイベント受信のたびに生死状態を蓄積し `updatePanel()` を呼ぶ
- `WebHumanIO` が `{"type":"survival","players":[...]}` として送信、`ConsoleHumanIO` は no-op
- `App.svelte` を2カラムレイアウトに変更し、生存状況パネルを追加

Related to #238

## Test plan

- [ ] `./gradlew check` が通ること（CI確認）
- [ ] Web UIでゲームを開始すると右パネルに参加者が「生存」で表示される
- [ ] 処刑が発生すると該当プレイヤーが「処刑」表示に変わる
- [ ] 夜の襲撃後に該当プレイヤーが「襲撃」表示に変わる

🤖 Generated with [Claude Code](https://claude.com/claude-code)