### PR TITLE
Add divination panel: show seer/medium results and player reports separately

### DIFF
--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -198,24 +198,24 @@
     {/if}
 
     {#if divination.divineResults.length > 0}
-      <h2 class="panel-section">占い結果（確定）</h2>
+      <h2 class="panel-section">占い結果</h2>
       <ul class="result-list">
         {#each divination.divineResults as r}
           <li class="result-entry">
             <span class="result-name">{r.targetName}</span>
-            <span class="badge {isWerewolf(r.result) ? 'black' : 'white'}">{isWerewolf(r.result) ? '黒' : '白'}</span>
+            <span class="badge {isWerewolf(r.result) ? 'black' : 'white'}">&nbsp;</span>
           </li>
         {/each}
       </ul>
     {/if}
 
     {#if divination.mediumResults.length > 0}
-      <h2 class="panel-section">霊媒結果（確定）</h2>
+      <h2 class="panel-section">霊媒結果</h2>
       <ul class="result-list">
         {#each divination.mediumResults as r}
           <li class="result-entry">
             <span class="result-name">{r.targetName}</span>
-            <span class="badge {isWerewolf(r.result) ? 'black' : 'white'}">{isWerewolf(r.result) ? '黒' : '白'}</span>
+            <span class="badge {isWerewolf(r.result) ? 'black' : 'white'}">&nbsp;</span>
           </li>
         {/each}
       </ul>
@@ -240,7 +240,7 @@
                   {@const entry = reportOf(divination.divineReports, player, src)}
                   <td>
                     {#if entry}
-                      <span class="badge {isWerewolf(entry.result) ? 'black' : 'white'}">{isWerewolf(entry.result) ? '黒' : '白'}</span>
+                      <span class="badge {isWerewolf(entry.result) ? 'black' : 'white'}">&nbsp;</span>
                     {/if}
                   </td>
                 {/each}
@@ -270,7 +270,7 @@
                   {@const entry = reportOf(divination.mediumReports, player, src)}
                   <td>
                     {#if entry}
-                      <span class="badge {isWerewolf(entry.result) ? 'black' : 'white'}">{isWerewolf(entry.result) ? '黒' : '白'}</span>
+                      <span class="badge {isWerewolf(entry.result) ? 'black' : 'white'}">&nbsp;</span>
                     {/if}
                   </td>
                 {/each}

--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -18,6 +18,9 @@
   type PlayerStatus = 'alive' | 'executed' | 'attacked'
   type SurvivalEntry = { name: string; status: PlayerStatus }
 
+  type ReportEntry = { source: string; targetName: string; result: string; trusted: boolean }
+  type DivinationData = { playerNames: string[]; divineReports: ReportEntry[]; mediumReports: ReportEntry[] }
+
   let status = '接続中...'
   let entries: LogEntry[] = []
   let input: InputState = { type: 'idle' }
@@ -25,6 +28,7 @@
   let logEl: HTMLElement
   let ws: WebSocket
   let survivalPlayers: SurvivalEntry[] = []
+  let divination: DivinationData = { playerNames: [], divineReports: [], mediumReports: [] }
 
   onMount(() => {
     ws = new WebSocket(`ws://${location.host}/game`)
@@ -55,6 +59,9 @@
         break
       case 'survival':
         survivalPlayers = msg.players as SurvivalEntry[]
+        break
+      case 'divination':
+        divination = msg as unknown as DivinationData
         break
     }
   }
@@ -93,6 +100,22 @@
     if (s === 'executed') return '処刑'
     if (s === 'attacked') return '襲撃'
     throw new Error(`Unknown player status: ${s}`)
+  }
+
+  function isWerewolf(result: string): boolean {
+    return result === '人狼' || result === '人狼である'
+  }
+
+  function uniqueSources(reports: ReportEntry[]): string[] {
+    const seen = new Set<string>()
+    return reports.reduce<string[]>((acc, r) => {
+      if (!seen.has(r.source)) { seen.add(r.source); acc.push(r.source) }
+      return acc
+    }, [])
+  }
+
+  function resultOf(reports: ReportEntry[], player: string, source: string): ReportEntry | undefined {
+    return reports.find(r => r.targetName === player && r.source === source)
   }
 </script>
 
@@ -161,15 +184,80 @@
         {/each}
       </ul>
     {/if}
+
+    {#if divination.divineReports.length > 0}
+      {@const sources = uniqueSources(divination.divineReports)}
+      <h2 class="panel-section">占い結果</h2>
+      <div class="report-scroll">
+        <table class="report-table">
+          <thead>
+            <tr>
+              <th></th>
+              {#each sources as src}<th>{src}</th>{/each}
+            </tr>
+          </thead>
+          <tbody>
+            {#each divination.playerNames as player}
+              <tr>
+                <td class="row-label">{player}</td>
+                {#each sources as src}
+                  {@const entry = resultOf(divination.divineReports, player, src)}
+                  <td>
+                    {#if entry}
+                      <span class="badge {isWerewolf(entry.result) ? 'black' : 'white'} {entry.trusted ? 'trusted' : ''}">
+                        {isWerewolf(entry.result) ? '黒' : '白'}
+                      </span>
+                    {/if}
+                  </td>
+                {/each}
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    {/if}
+
+    {#if divination.mediumReports.length > 0}
+      {@const sources = uniqueSources(divination.mediumReports)}
+      <h2 class="panel-section">霊媒結果</h2>
+      <div class="report-scroll">
+        <table class="report-table">
+          <thead>
+            <tr>
+              <th></th>
+              {#each sources as src}<th>{src}</th>{/each}
+            </tr>
+          </thead>
+          <tbody>
+            {#each divination.playerNames as player}
+              <tr>
+                <td class="row-label">{player}</td>
+                {#each sources as src}
+                  {@const entry = resultOf(divination.mediumReports, player, src)}
+                  <td>
+                    {#if entry}
+                      <span class="badge {isWerewolf(entry.result) ? 'black' : 'white'} {entry.trusted ? 'trusted' : ''}">
+                        {isWerewolf(entry.result) ? '黒' : '白'}
+                      </span>
+                    {/if}
+                  </td>
+                {/each}
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    {/if}
   </aside>
 </div>
 
 <style>
   .layout { display: flex; gap: 16px; max-width: 1100px; margin: 0 auto; padding: 16px; font-family: sans-serif; }
   .main { flex: 1; min-width: 0; }
-  .panel { width: 200px; flex-shrink: 0; border: 1px solid #ccc; border-radius: 4px; padding: 12px; background: #fafafa; align-self: flex-start; }
+  .panel { width: 240px; flex-shrink: 0; border: 1px solid #ccc; border-radius: 4px; padding: 12px; background: #fafafa; align-self: flex-start; }
   h1 { margin: 0 0 4px; }
   h2 { margin: 0 0 10px; font-size: 1em; color: #444; }
+  .panel-section { margin: 14px 0 6px; }
   .status { color: #666; margin-bottom: 8px; }
   .controls { margin: 8px 0; }
   .log { border: 1px solid #ccc; height: 500px; overflow-y: auto; padding: 8px; background: #fafafa; }
@@ -192,4 +280,14 @@
   .alive .player-status { background: #d4f7d4; color: #2a6e2a; }
   .executed .player-status { background: #f7d4d4; color: #6e2a2a; }
   .attacked .player-status { background: #f7ead4; color: #6e4a2a; }
+
+  .report-scroll { overflow-x: auto; }
+  .report-table { border-collapse: collapse; font-size: 0.8em; width: 100%; }
+  .report-table th { font-weight: normal; color: #666; padding: 2px 4px; text-align: center; white-space: nowrap; }
+  .report-table td { padding: 2px 4px; text-align: center; }
+  .row-label { text-align: left; white-space: nowrap; color: #444; }
+  .badge { display: inline-block; padding: 1px 5px; border-radius: 3px; font-size: 0.85em; }
+  .badge.black { background: #333; color: #fff; }
+  .badge.white { background: #eee; color: #333; border: 1px solid #ccc; }
+  .badge.trusted { font-weight: bold; box-shadow: 0 0 0 1px #666; }
 </style>

--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -18,8 +18,14 @@
   type PlayerStatus = 'alive' | 'executed' | 'attacked'
   type SurvivalEntry = { name: string; status: PlayerStatus }
 
-  type ReportEntry = { source: string; targetName: string; result: string; trusted: boolean }
-  type DivinationData = { playerNames: string[]; divineReports: ReportEntry[]; mediumReports: ReportEntry[] }
+  type ReportEntry = { source: string; targetName: string; result: string }
+  type DivinationData = {
+    playerNames: string[]
+    divineResults: { targetName: string; result: string }[]
+    mediumResults: { targetName: string; result: string }[]
+    divineReports: ReportEntry[]
+    mediumReports: ReportEntry[]
+  }
 
   let status = '接続中...'
   let entries: LogEntry[] = []
@@ -28,7 +34,13 @@
   let logEl: HTMLElement
   let ws: WebSocket
   let survivalPlayers: SurvivalEntry[] = []
-  let divination: DivinationData = { playerNames: [], divineReports: [], mediumReports: [] }
+  let divination: DivinationData = {
+    playerNames: [],
+    divineResults: [],
+    mediumResults: [],
+    divineReports: [],
+    mediumReports: [],
+  }
 
   onMount(() => {
     ws = new WebSocket(`ws://${location.host}/game`)
@@ -114,7 +126,7 @@
     }, [])
   }
 
-  function resultOf(reports: ReportEntry[], player: string, source: string): ReportEntry | undefined {
+  function reportOf(reports: ReportEntry[], player: string, source: string): ReportEntry | undefined {
     return reports.find(r => r.targetName === player && r.source === source)
   }
 </script>
@@ -185,9 +197,33 @@
       </ul>
     {/if}
 
+    {#if divination.divineResults.length > 0}
+      <h2 class="panel-section">占い結果（確定）</h2>
+      <ul class="result-list">
+        {#each divination.divineResults as r}
+          <li class="result-entry">
+            <span class="result-name">{r.targetName}</span>
+            <span class="badge {isWerewolf(r.result) ? 'black' : 'white'}">{isWerewolf(r.result) ? '黒' : '白'}</span>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+
+    {#if divination.mediumResults.length > 0}
+      <h2 class="panel-section">霊媒結果（確定）</h2>
+      <ul class="result-list">
+        {#each divination.mediumResults as r}
+          <li class="result-entry">
+            <span class="result-name">{r.targetName}</span>
+            <span class="badge {isWerewolf(r.result) ? 'black' : 'white'}">{isWerewolf(r.result) ? '黒' : '白'}</span>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+
     {#if divination.divineReports.length > 0}
       {@const sources = uniqueSources(divination.divineReports)}
-      <h2 class="panel-section">占い結果</h2>
+      <h2 class="panel-section">占い申告</h2>
       <div class="report-scroll">
         <table class="report-table">
           <thead>
@@ -201,12 +237,10 @@
               <tr>
                 <td class="row-label">{player}</td>
                 {#each sources as src}
-                  {@const entry = resultOf(divination.divineReports, player, src)}
+                  {@const entry = reportOf(divination.divineReports, player, src)}
                   <td>
                     {#if entry}
-                      <span class="badge {isWerewolf(entry.result) ? 'black' : 'white'} {entry.trusted ? 'trusted' : ''}">
-                        {isWerewolf(entry.result) ? '黒' : '白'}
-                      </span>
+                      <span class="badge {isWerewolf(entry.result) ? 'black' : 'white'}">{isWerewolf(entry.result) ? '黒' : '白'}</span>
                     {/if}
                   </td>
                 {/each}
@@ -219,7 +253,7 @@
 
     {#if divination.mediumReports.length > 0}
       {@const sources = uniqueSources(divination.mediumReports)}
-      <h2 class="panel-section">霊媒結果</h2>
+      <h2 class="panel-section">霊媒申告</h2>
       <div class="report-scroll">
         <table class="report-table">
           <thead>
@@ -233,12 +267,10 @@
               <tr>
                 <td class="row-label">{player}</td>
                 {#each sources as src}
-                  {@const entry = resultOf(divination.mediumReports, player, src)}
+                  {@const entry = reportOf(divination.mediumReports, player, src)}
                   <td>
                     {#if entry}
-                      <span class="badge {isWerewolf(entry.result) ? 'black' : 'white'} {entry.trusted ? 'trusted' : ''}">
-                        {isWerewolf(entry.result) ? '黒' : '白'}
-                      </span>
+                      <span class="badge {isWerewolf(entry.result) ? 'black' : 'white'}">{isWerewolf(entry.result) ? '黒' : '白'}</span>
                     {/if}
                   </td>
                 {/each}
@@ -281,6 +313,10 @@
   .executed .player-status { background: #f7d4d4; color: #6e2a2a; }
   .attacked .player-status { background: #f7ead4; color: #6e4a2a; }
 
+  .result-list { list-style: none; margin: 0; padding: 0; }
+  .result-entry { display: flex; justify-content: space-between; align-items: center; padding: 3px 0; font-size: 0.9em; }
+  .result-name { flex: 1; }
+
   .report-scroll { overflow-x: auto; }
   .report-table { border-collapse: collapse; font-size: 0.8em; width: 100%; }
   .report-table th { font-weight: normal; color: #666; padding: 2px 4px; text-align: center; white-space: nowrap; }
@@ -289,5 +325,4 @@
   .badge { display: inline-block; padding: 1px 5px; border-radius: 3px; font-size: 0.85em; }
   .badge.black { background: #333; color: #fff; }
   .badge.white { background: #eee; color: #333; border: 1px solid #ccc; }
-  .badge.trusted { font-weight: bold; box-shadow: 0 0 0 1px #666; }
 </style>

--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -18,11 +18,11 @@
   type PlayerStatus = 'alive' | 'executed' | 'attacked'
   type SurvivalEntry = { name: string; status: PlayerStatus }
 
-  type ReportEntry = { source: string; targetName: string; result: string }
+  type ReportEntry = { source: string; targetName: string; isWerewolf: boolean }
   type DivinationData = {
     playerNames: string[]
-    divineResults: { targetName: string; result: string }[]
-    mediumResults: { targetName: string; result: string }[]
+    divineResults: { targetName: string; isWerewolf: boolean }[]
+    mediumResults: { targetName: string; isWerewolf: boolean }[]
     divineReports: ReportEntry[]
     mediumReports: ReportEntry[]
   }
@@ -114,10 +114,6 @@
     throw new Error(`Unknown player status: ${s}`)
   }
 
-  function isWerewolf(result: string): boolean {
-    return result === '人狼' || result === '人狼である'
-  }
-
   function uniqueSources(reports: ReportEntry[]): string[] {
     const seen = new Set<string>()
     return reports.reduce<string[]>((acc, r) => {
@@ -203,7 +199,7 @@
         {#each divination.divineResults as r}
           <li class="result-entry">
             <span class="result-name">{r.targetName}</span>
-            <span class="badge {isWerewolf(r.result) ? 'black' : 'white'}">&nbsp;</span>
+            <span class="badge {r.isWerewolf ? 'black' : 'white'}">&nbsp;</span>
           </li>
         {/each}
       </ul>
@@ -215,7 +211,7 @@
         {#each divination.mediumResults as r}
           <li class="result-entry">
             <span class="result-name">{r.targetName}</span>
-            <span class="badge {isWerewolf(r.result) ? 'black' : 'white'}">&nbsp;</span>
+            <span class="badge {r.isWerewolf ? 'black' : 'white'}">&nbsp;</span>
           </li>
         {/each}
       </ul>
@@ -240,7 +236,7 @@
                   {@const entry = reportOf(divination.divineReports, player, src)}
                   <td>
                     {#if entry}
-                      <span class="badge {isWerewolf(entry.result) ? 'black' : 'white'}">&nbsp;</span>
+                      <span class="badge {entry.isWerewolf ? 'black' : 'white'}">&nbsp;</span>
                     {/if}
                   </td>
                 {/each}
@@ -270,7 +266,7 @@
                   {@const entry = reportOf(divination.mediumReports, player, src)}
                   <td>
                     {#if entry}
-                      <span class="badge {isWerewolf(entry.result) ? 'black' : 'white'}">&nbsp;</span>
+                      <span class="badge {entry.isWerewolf ? 'black' : 'white'}">&nbsp;</span>
                     {/if}
                   </td>
                 {/each}

--- a/src/main/kotlin/werewolf/human/GameNote.kt
+++ b/src/main/kotlin/werewolf/human/GameNote.kt
@@ -1,20 +1,48 @@
 package werewolf.human
 
 import werewolf.game.GameEvent
+import werewolf.game.Statement
+import werewolf.view.DivinationView
 import werewolf.view.PlayerStatus
+import werewolf.view.ReportEntry
 import werewolf.view.SurvivalView
 
-class GameNote {
+class GameNote(private val myName: String) {
     private val playerStatuses = mutableMapOf<String, PlayerStatus>()
+    private val playerNames = mutableListOf<String>()
+    private val myDivineResults = mutableMapOf<String, String>()
+    private val myMediumResults = mutableMapOf<String, String>()
+    private val claimedDivineResults = mutableMapOf<Pair<String, String>, String>()
+    private val claimedMediumResults = mutableMapOf<Pair<String, String>, String>()
 
     fun post(event: GameEvent) {
         when (event) {
-            is GameEvent.PlayersAnnounced -> event.players.forEach { playerStatuses[it.name] = PlayerStatus.ALIVE }
+            is GameEvent.PlayersAnnounced -> event.players.forEach {
+                playerStatuses[it.name] = PlayerStatus.ALIVE
+                playerNames += it.name
+            }
             is GameEvent.PlayerExecuted -> playerStatuses[event.executed.name] = PlayerStatus.EXECUTED
             is GameEvent.PlayerAttacked -> playerStatuses[event.attacked.name] = PlayerStatus.ATTACKED
+            is GameEvent.Divined -> myDivineResults[event.target.name] = event.result.displayName
+            is GameEvent.MediumRevealed -> myMediumResults[event.target.name] = event.result.displayName
+            is GameEvent.StatementMade -> when (val stmt = event.statement) {
+                is Statement.DivinationReport ->
+                    claimedDivineResults[event.speakerName to stmt.target.name] = stmt.result.displayName
+                is Statement.MediumReport ->
+                    claimedMediumResults[event.speakerName to stmt.target.name] = stmt.result.displayName
+                else -> Unit
+            }
             else -> Unit
         }
     }
 
     fun summary(): SurvivalView = SurvivalView(playerStatuses.toMap())
+
+    fun divinationSummary(): DivinationView {
+        val divine = myDivineResults.map { (target, result) -> ReportEntry(myName, target, result, trusted = true) } +
+            claimedDivineResults.map { (key, result) -> ReportEntry(key.first, key.second, result, trusted = false) }
+        val medium = myMediumResults.map { (target, result) -> ReportEntry(myName, target, result, trusted = true) } +
+            claimedMediumResults.map { (key, result) -> ReportEntry(key.first, key.second, result, trusted = false) }
+        return DivinationView(playerNames.toList(), divine, medium)
+    }
 }

--- a/src/main/kotlin/werewolf/human/GameNote.kt
+++ b/src/main/kotlin/werewolf/human/GameNote.kt
@@ -10,10 +10,10 @@ import werewolf.view.SurvivalView
 class GameNote(private val myName: String) {
     private val playerStatuses = mutableMapOf<String, PlayerStatus>()
     private val playerNames = mutableListOf<String>()
-    private val myDivineResults = mutableMapOf<String, String>()
-    private val myMediumResults = mutableMapOf<String, String>()
-    private val claimedDivineResults = mutableMapOf<Pair<String, String>, String>()
-    private val claimedMediumResults = mutableMapOf<Pair<String, String>, String>()
+    private val divineResults = mutableMapOf<String, String>()
+    private val mediumResults = mutableMapOf<String, String>()
+    private val divineReports = mutableSetOf<ReportEntry>()
+    private val mediumReports = mutableSetOf<ReportEntry>()
 
     fun post(event: GameEvent) {
         when (event) {
@@ -23,13 +23,13 @@ class GameNote(private val myName: String) {
             }
             is GameEvent.PlayerExecuted -> playerStatuses[event.executed.name] = PlayerStatus.EXECUTED
             is GameEvent.PlayerAttacked -> playerStatuses[event.attacked.name] = PlayerStatus.ATTACKED
-            is GameEvent.Divined -> myDivineResults[event.target.name] = event.result.displayName
-            is GameEvent.MediumRevealed -> myMediumResults[event.target.name] = event.result.displayName
+            is GameEvent.Divined -> divineResults[event.target.name] = event.result.displayName
+            is GameEvent.MediumRevealed -> mediumResults[event.target.name] = event.result.displayName
             is GameEvent.StatementMade -> when (val stmt = event.statement) {
                 is Statement.DivinationReport ->
-                    claimedDivineResults[event.speakerName to stmt.target.name] = stmt.result.displayName
+                    divineReports += ReportEntry(event.speakerName, stmt.target.name, stmt.result.displayName)
                 is Statement.MediumReport ->
-                    claimedMediumResults[event.speakerName to stmt.target.name] = stmt.result.displayName
+                    mediumReports += ReportEntry(event.speakerName, stmt.target.name, stmt.result.displayName)
                 else -> Unit
             }
             else -> Unit
@@ -38,11 +38,11 @@ class GameNote(private val myName: String) {
 
     fun summary(): SurvivalView = SurvivalView(playerStatuses.toMap())
 
-    fun divinationSummary(): DivinationView {
-        val divine = myDivineResults.map { (target, result) -> ReportEntry(myName, target, result, trusted = true) } +
-            claimedDivineResults.map { (key, result) -> ReportEntry(key.first, key.second, result, trusted = false) }
-        val medium = myMediumResults.map { (target, result) -> ReportEntry(myName, target, result, trusted = true) } +
-            claimedMediumResults.map { (key, result) -> ReportEntry(key.first, key.second, result, trusted = false) }
-        return DivinationView(playerNames.toList(), divine, medium)
-    }
+    fun divinationSummary(): DivinationView = DivinationView(
+        playerNames = playerNames.toList(),
+        divineResults = divineResults.toMap(),
+        mediumResults = mediumResults.toMap(),
+        divineReports = divineReports.toList(),
+        mediumReports = mediumReports.toList(),
+    )
 }

--- a/src/main/kotlin/werewolf/human/GameNote.kt
+++ b/src/main/kotlin/werewolf/human/GameNote.kt
@@ -7,7 +7,7 @@ import werewolf.view.PlayerStatus
 import werewolf.view.ReportEntry
 import werewolf.view.SurvivalView
 
-class GameNote(private val myName: String) {
+class GameNote {
     private val playerStatuses = mutableMapOf<String, PlayerStatus>()
     private val playerNames = mutableListOf<String>()
     private val divineResults = mutableMapOf<String, String>()

--- a/src/main/kotlin/werewolf/human/GameNote.kt
+++ b/src/main/kotlin/werewolf/human/GameNote.kt
@@ -1,6 +1,8 @@
 package werewolf.human
 
+import werewolf.game.DivineResult
 import werewolf.game.GameEvent
+import werewolf.game.MediumResult
 import werewolf.game.Statement
 import werewolf.view.DivinationView
 import werewolf.view.PlayerStatus
@@ -10,8 +12,8 @@ import werewolf.view.SurvivalView
 class GameNote {
     private val playerStatuses = mutableMapOf<String, PlayerStatus>()
     private val playerNames = mutableListOf<String>()
-    private val divineResults = mutableMapOf<String, String>()
-    private val mediumResults = mutableMapOf<String, String>()
+    private val divineResults = mutableMapOf<String, Boolean>()
+    private val mediumResults = mutableMapOf<String, Boolean>()
     private val divineReports = mutableSetOf<ReportEntry>()
     private val mediumReports = mutableSetOf<ReportEntry>()
 
@@ -23,13 +25,13 @@ class GameNote {
             }
             is GameEvent.PlayerExecuted -> playerStatuses[event.executed.name] = PlayerStatus.EXECUTED
             is GameEvent.PlayerAttacked -> playerStatuses[event.attacked.name] = PlayerStatus.ATTACKED
-            is GameEvent.Divined -> divineResults[event.target.name] = event.result.displayName
-            is GameEvent.MediumRevealed -> mediumResults[event.target.name] = event.result.displayName
+            is GameEvent.Divined -> divineResults[event.target.name] = event.result == DivineResult.WEREWOLF
+            is GameEvent.MediumRevealed -> mediumResults[event.target.name] = event.result == MediumResult.WEREWOLF
             is GameEvent.StatementMade -> when (val stmt = event.statement) {
                 is Statement.DivinationReport ->
-                    divineReports += ReportEntry(event.speakerName, stmt.target.name, stmt.result.displayName)
+                    divineReports += ReportEntry(event.speakerName, stmt.target.name, stmt.result == DivineResult.WEREWOLF)
                 is Statement.MediumReport ->
-                    mediumReports += ReportEntry(event.speakerName, stmt.target.name, stmt.result.displayName)
+                    mediumReports += ReportEntry(event.speakerName, stmt.target.name, stmt.result == MediumResult.WEREWOLF)
                 else -> Unit
             }
             else -> Unit

--- a/src/main/kotlin/werewolf/human/HumanIO.kt
+++ b/src/main/kotlin/werewolf/human/HumanIO.kt
@@ -3,11 +3,13 @@ package werewolf.human
 import werewolf.game.ChronicleView
 import werewolf.game.RecallView
 import werewolf.view.ChoiceView
+import werewolf.view.DivinationView
 import werewolf.view.SurvivalView
 
 interface HumanIO {
     fun display(view: RecallView)
     fun updatePanel(view: SurvivalView)
+    fun updateDivinationPanel(view: DivinationView)
     fun promptChoice(view: ChoiceView): String
     fun promptFreeText(title: String, description: String): String
     fun watchEpilogue(chronicles: List<ChronicleView>)

--- a/src/main/kotlin/werewolf/human/HumanPlayer.kt
+++ b/src/main/kotlin/werewolf/human/HumanPlayer.kt
@@ -17,7 +17,7 @@ import werewolf.view.DivinationView
 import werewolf.view.SurvivalView
 
 class HumanPlayer(role: Role, override val name: String, private val io: HumanIO) : Player(role) {
-    private val gameNote = GameNote(name)
+    private val gameNote = GameNote()
     private var lastSummary: SurvivalView? = null
     private var lastDivinationSummary: DivinationView? = null
 

--- a/src/main/kotlin/werewolf/human/HumanPlayer.kt
+++ b/src/main/kotlin/werewolf/human/HumanPlayer.kt
@@ -13,11 +13,13 @@ import werewolf.game.SelectionContext
 import werewolf.game.Statement
 import werewolf.game.StatementType
 import werewolf.view.ChoiceView
+import werewolf.view.DivinationView
 import werewolf.view.SurvivalView
 
 class HumanPlayer(role: Role, override val name: String, private val io: HumanIO) : Player(role) {
-    private val gameNote = GameNote()
+    private val gameNote = GameNote(name)
     private var lastSummary: SurvivalView? = null
+    private var lastDivinationSummary: DivinationView? = null
 
     override fun choose(context: SelectionContext): Choice {
         val candidates = context.candidates()
@@ -34,6 +36,11 @@ class HumanPlayer(role: Role, override val name: String, private val io: HumanIO
         if (current != lastSummary) {
             lastSummary = current
             io.updatePanel(current)
+        }
+        val currentDivination = gameNote.divinationSummary()
+        if (currentDivination != lastDivinationSummary) {
+            lastDivinationSummary = currentDivination
+            io.updateDivinationPanel(currentDivination)
         }
     }
 

--- a/src/main/kotlin/werewolf/human/console/ConsoleHumanIO.kt
+++ b/src/main/kotlin/werewolf/human/console/ConsoleHumanIO.kt
@@ -5,6 +5,7 @@ import werewolf.game.GameOverSignal
 import werewolf.game.RecallView
 import werewolf.human.HumanIO
 import werewolf.view.ChoiceView
+import werewolf.view.DivinationView
 import werewolf.view.SurvivalView
 
 class ConsoleHumanIO : HumanIO {
@@ -15,6 +16,10 @@ class ConsoleHumanIO : HumanIO {
 
     override fun updatePanel(view: SurvivalView) {
         // Console has no persistent panel; survival info is visible in the event log
+    }
+
+    override fun updateDivinationPanel(view: DivinationView) {
+        // Console has no persistent panel; divination info is visible in the event log
     }
 
     override fun display(view: RecallView) = when (view) {

--- a/src/main/kotlin/werewolf/human/web/WebHumanIO.kt
+++ b/src/main/kotlin/werewolf/human/web/WebHumanIO.kt
@@ -7,7 +7,9 @@ import werewolf.game.GameOverSignal
 import werewolf.game.RecallView
 import werewolf.human.HumanIO
 import werewolf.view.ChoiceView
+import werewolf.view.DivinationView
 import werewolf.view.PlayerStatus
+import werewolf.view.ReportEntry
 import werewolf.view.SurvivalView
 
 class WebHumanIO : HumanIO {
@@ -21,6 +23,13 @@ class WebHumanIO : HumanIO {
 
     fun checkAbort() {
         if (abortRequested) GameOverSignal.throwManualAbort()
+    }
+
+    override fun updateDivinationPanel(view: DivinationView) {
+        val playerNamesJson = view.playerNames.joinToString(",") { it.jsonEncode() }
+        val divineJson = view.divineReports.joinToString(",") { it.toJson() }
+        val mediumJson = view.mediumReports.joinToString(",") { it.toJson() }
+        enqueue("""{"type":"divination","playerNames":[$playerNamesJson],"divineReports":[$divineJson],"mediumReports":[$mediumJson]}""")
     }
 
     override fun updatePanel(view: SurvivalView) {
@@ -63,6 +72,9 @@ class WebHumanIO : HumanIO {
         check(outgoing.trySend(message).isSuccess) { "Failed to queue message" }
     }
 }
+
+private fun ReportEntry.toJson(): String =
+    """{"source":${source.jsonEncode()},"targetName":${targetName.jsonEncode()},"result":${result.jsonEncode()},"trusted":$trusted}"""
 
 private fun PlayerStatus.toJson(): String = when (this) {
     PlayerStatus.ALIVE -> "\"alive\""

--- a/src/main/kotlin/werewolf/human/web/WebHumanIO.kt
+++ b/src/main/kotlin/werewolf/human/web/WebHumanIO.kt
@@ -31,7 +31,11 @@ class WebHumanIO : HumanIO {
         val mediumResultsJson = view.mediumResults.entries.joinToString(",") { (k, v) -> """{"targetName":${k.jsonEncode()},"result":${v.jsonEncode()}}""" }
         val divineReportsJson = view.divineReports.joinToString(",") { it.toJson() }
         val mediumReportsJson = view.mediumReports.joinToString(",") { it.toJson() }
-        enqueue("""{"type":"divination","playerNames":[$playerNamesJson],"divineResults":[$divineResultsJson],"mediumResults":[$mediumResultsJson],"divineReports":[$divineReportsJson],"mediumReports":[$mediumReportsJson]}""")
+        enqueue(
+            """{"type":"divination","playerNames":[$playerNamesJson],""" +
+            """"divineResults":[$divineResultsJson],"mediumResults":[$mediumResultsJson],""" +
+            """"divineReports":[$divineReportsJson],"mediumReports":[$mediumReportsJson]}"""
+        )
     }
 
     override fun updatePanel(view: SurvivalView) {

--- a/src/main/kotlin/werewolf/human/web/WebHumanIO.kt
+++ b/src/main/kotlin/werewolf/human/web/WebHumanIO.kt
@@ -27,9 +27,11 @@ class WebHumanIO : HumanIO {
 
     override fun updateDivinationPanel(view: DivinationView) {
         val playerNamesJson = view.playerNames.joinToString(",") { it.jsonEncode() }
-        val divineJson = view.divineReports.joinToString(",") { it.toJson() }
-        val mediumJson = view.mediumReports.joinToString(",") { it.toJson() }
-        enqueue("""{"type":"divination","playerNames":[$playerNamesJson],"divineReports":[$divineJson],"mediumReports":[$mediumJson]}""")
+        val divineResultsJson = view.divineResults.entries.joinToString(",") { (k, v) -> """{"targetName":${k.jsonEncode()},"result":${v.jsonEncode()}}""" }
+        val mediumResultsJson = view.mediumResults.entries.joinToString(",") { (k, v) -> """{"targetName":${k.jsonEncode()},"result":${v.jsonEncode()}}""" }
+        val divineReportsJson = view.divineReports.joinToString(",") { it.toJson() }
+        val mediumReportsJson = view.mediumReports.joinToString(",") { it.toJson() }
+        enqueue("""{"type":"divination","playerNames":[$playerNamesJson],"divineResults":[$divineResultsJson],"mediumResults":[$mediumResultsJson],"divineReports":[$divineReportsJson],"mediumReports":[$mediumReportsJson]}""")
     }
 
     override fun updatePanel(view: SurvivalView) {
@@ -74,7 +76,7 @@ class WebHumanIO : HumanIO {
 }
 
 private fun ReportEntry.toJson(): String =
-    """{"source":${source.jsonEncode()},"targetName":${targetName.jsonEncode()},"result":${result.jsonEncode()},"trusted":$trusted}"""
+    """{"source":${source.jsonEncode()},"targetName":${targetName.jsonEncode()},"result":${result.jsonEncode()}}"""
 
 private fun PlayerStatus.toJson(): String = when (this) {
     PlayerStatus.ALIVE -> "\"alive\""

--- a/src/main/kotlin/werewolf/human/web/WebHumanIO.kt
+++ b/src/main/kotlin/werewolf/human/web/WebHumanIO.kt
@@ -27,8 +27,8 @@ class WebHumanIO : HumanIO {
 
     override fun updateDivinationPanel(view: DivinationView) {
         val playerNamesJson = view.playerNames.joinToString(",") { it.jsonEncode() }
-        val divineResultsJson = view.divineResults.entries.joinToString(",") { (k, v) -> """{"targetName":${k.jsonEncode()},"result":${v.jsonEncode()}}""" }
-        val mediumResultsJson = view.mediumResults.entries.joinToString(",") { (k, v) -> """{"targetName":${k.jsonEncode()},"result":${v.jsonEncode()}}""" }
+        val divineResultsJson = view.divineResults.entries.joinToString(",") { (k, v) -> """{"targetName":${k.jsonEncode()},"isWerewolf":$v}""" }
+        val mediumResultsJson = view.mediumResults.entries.joinToString(",") { (k, v) -> """{"targetName":${k.jsonEncode()},"isWerewolf":$v}""" }
         val divineReportsJson = view.divineReports.joinToString(",") { it.toJson() }
         val mediumReportsJson = view.mediumReports.joinToString(",") { it.toJson() }
         enqueue(
@@ -80,7 +80,7 @@ class WebHumanIO : HumanIO {
 }
 
 private fun ReportEntry.toJson(): String =
-    """{"source":${source.jsonEncode()},"targetName":${targetName.jsonEncode()},"result":${result.jsonEncode()}}"""
+    """{"source":${source.jsonEncode()},"targetName":${targetName.jsonEncode()},"isWerewolf":$isWerewolf}"""
 
 private fun PlayerStatus.toJson(): String = when (this) {
     PlayerStatus.ALIVE -> "\"alive\""

--- a/src/main/kotlin/werewolf/view/DivinationView.kt
+++ b/src/main/kotlin/werewolf/view/DivinationView.kt
@@ -1,14 +1,11 @@
 package werewolf.view
 
-data class ReportEntry(
-    val source: String,
-    val targetName: String,
-    val result: String,
-    val trusted: Boolean,
-)
+data class ReportEntry(val source: String, val targetName: String, val result: String)
 
 data class DivinationView(
     val playerNames: List<String>,
+    val divineResults: Map<String, String>,
+    val mediumResults: Map<String, String>,
     val divineReports: List<ReportEntry>,
     val mediumReports: List<ReportEntry>,
 )

--- a/src/main/kotlin/werewolf/view/DivinationView.kt
+++ b/src/main/kotlin/werewolf/view/DivinationView.kt
@@ -1,11 +1,11 @@
 package werewolf.view
 
-data class ReportEntry(val source: String, val targetName: String, val result: String)
+data class ReportEntry(val source: String, val targetName: String, val isWerewolf: Boolean)
 
 data class DivinationView(
     val playerNames: List<String>,
-    val divineResults: Map<String, String>,
-    val mediumResults: Map<String, String>,
+    val divineResults: Map<String, Boolean>,
+    val mediumResults: Map<String, Boolean>,
     val divineReports: List<ReportEntry>,
     val mediumReports: List<ReportEntry>,
 )

--- a/src/main/kotlin/werewolf/view/DivinationView.kt
+++ b/src/main/kotlin/werewolf/view/DivinationView.kt
@@ -1,0 +1,14 @@
+package werewolf.view
+
+data class ReportEntry(
+    val source: String,
+    val targetName: String,
+    val result: String,
+    val trusted: Boolean,
+)
+
+data class DivinationView(
+    val playerNames: List<String>,
+    val divineReports: List<ReportEntry>,
+    val mediumReports: List<ReportEntry>,
+)

--- a/src/test/kotlin/werewolf/GameNoteTest.kt
+++ b/src/test/kotlin/werewolf/GameNoteTest.kt
@@ -5,23 +5,30 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import werewolf.game.AllPlayers
 import werewolf.game.ChronicleView
+import werewolf.game.DivineResult
 import werewolf.game.GameEvent
 import werewolf.game.GameSetup
+import werewolf.game.MediumResult
 import werewolf.game.RecallView
 import werewolf.game.Role
+import werewolf.game.Statement
 import werewolf.human.HumanIO
 import werewolf.human.HumanPlayer
 import werewolf.phase.InitialPhase
 import werewolf.view.ChoiceView
+import werewolf.view.DivinationView
 import werewolf.view.PlayerStatus
+import werewolf.view.ReportEntry
 import werewolf.view.SurvivalView
 
 class GameNoteTest {
 
     private class CapturingIO : HumanIO {
         val panels = mutableListOf<SurvivalView>()
+        val divinationPanels = mutableListOf<DivinationView>()
         override fun display(view: RecallView) {}
         override fun updatePanel(view: SurvivalView) { panels += view }
+        override fun updateDivinationPanel(view: DivinationView) { divinationPanels += view }
         override fun promptChoice(view: ChoiceView): String = error("not expected")
         override fun promptFreeText(title: String, description: String): String = error("not expected")
         override fun watchEpilogue(chronicles: List<ChronicleView>) {}
@@ -86,5 +93,66 @@ class GameNoteTest {
         GameEvent.DiscussionStarted.send(1, AllPlayers(gameSetup.playerManager))
 
         assertEquals(countAfterStart, io.panels.size)
+    }
+
+    @Test
+    fun `divined result appears as trusted in divination panel`() {
+        val io = CapturingIO()
+        val gameSetup = createGameWithHuman(io, "Wolf" to Role.WEREWOLF)
+        InitialPhase(gameSetup.playerManager, gameSetup.oracle).proceed()
+        val human = gameSetup.playerManager.allPlayers.single { it.name == "V1" }
+        val wolf = gameSetup.playerManager.allPlayers.single { it.name == "Wolf" }
+
+        GameEvent.Divined.send(wolf, DivineResult.WEREWOLF, human)
+
+        assertEquals(
+            listOf(ReportEntry("V1", "Wolf", "人狼", trusted = true)),
+            io.divinationPanels.last().divineReports,
+        )
+    }
+
+    @Test
+    fun `medium result appears as trusted in divination panel`() {
+        val io = CapturingIO()
+        val gameSetup = createGameWithHuman(io, "Wolf" to Role.WEREWOLF)
+        InitialPhase(gameSetup.playerManager, gameSetup.oracle).proceed()
+        val human = gameSetup.playerManager.allPlayers.single { it.name == "V1" }
+        val wolf = gameSetup.playerManager.allPlayers.single { it.name == "Wolf" }
+
+        GameEvent.MediumRevealed.send(wolf, MediumResult.WEREWOLF, human)
+
+        assertEquals(
+            listOf(ReportEntry("V1", "Wolf", "人狼である", trusted = true)),
+            io.divinationPanels.last().mediumReports,
+        )
+    }
+
+    @Test
+    fun `claimed divine result appears as untrusted in divination panel`() {
+        val io = CapturingIO()
+        val gameSetup = createGameWithHuman(io, "V2" to Role.VILLAGER, "Wolf" to Role.WEREWOLF)
+        InitialPhase(gameSetup.playerManager, gameSetup.oracle).proceed()
+        val v2 = gameSetup.playerManager.allPlayers.single { it.name == "V2" }
+        val wolf = gameSetup.playerManager.allPlayers.single { it.name == "Wolf" }
+        val allPlayers = AllPlayers(gameSetup.playerManager)
+
+        GameEvent.StatementMade.send(1, "V2", Statement.DivinationReport(v2, wolf, DivineResult.WEREWOLF), allPlayers)
+
+        assertEquals(
+            listOf(ReportEntry("V2", "Wolf", "人狼", trusted = false)),
+            io.divinationPanels.last().divineReports,
+        )
+    }
+
+    @Test
+    fun `divination panel is not updated for unrelated events`() {
+        val io = CapturingIO()
+        val gameSetup = createGameWithHuman(io, "V2" to Role.VILLAGER, "Wolf" to Role.WEREWOLF)
+        InitialPhase(gameSetup.playerManager, gameSetup.oracle).proceed()
+        val countAfterStart = io.divinationPanels.size
+
+        GameEvent.DiscussionStarted.send(1, AllPlayers(gameSetup.playerManager))
+
+        assertEquals(countAfterStart, io.divinationPanels.size)
     }
 }

--- a/src/test/kotlin/werewolf/GameNoteTest.kt
+++ b/src/test/kotlin/werewolf/GameNoteTest.kt
@@ -105,7 +105,7 @@ class GameNoteTest {
 
         GameEvent.Divined.send(wolf, DivineResult.WEREWOLF, human)
 
-        assertEquals(mapOf("Wolf" to "人狼"), io.divinationPanels.last().divineResults)
+        assertEquals(mapOf("Wolf" to true), io.divinationPanels.last().divineResults)
     }
 
     @Test
@@ -118,7 +118,7 @@ class GameNoteTest {
 
         GameEvent.MediumRevealed.send(wolf, MediumResult.WEREWOLF, human)
 
-        assertEquals(mapOf("Wolf" to "人狼である"), io.divinationPanels.last().mediumResults)
+        assertEquals(mapOf("Wolf" to true), io.divinationPanels.last().mediumResults)
     }
 
     @Test
@@ -133,7 +133,7 @@ class GameNoteTest {
         GameEvent.StatementMade.send(1, "V2", Statement.DivinationReport(v2, wolf, DivineResult.WEREWOLF), allPlayers)
 
         assertEquals(
-            listOf(ReportEntry("V2", "Wolf", "人狼")),
+            listOf(ReportEntry("V2", "Wolf", isWerewolf = true)),
             io.divinationPanels.last().divineReports,
         )
     }

--- a/src/test/kotlin/werewolf/GameNoteTest.kt
+++ b/src/test/kotlin/werewolf/GameNoteTest.kt
@@ -96,7 +96,7 @@ class GameNoteTest {
     }
 
     @Test
-    fun `divined result appears as trusted in divination panel`() {
+    fun `divined result appears in divine results of divination panel`() {
         val io = CapturingIO()
         val gameSetup = createGameWithHuman(io, "Wolf" to Role.WEREWOLF)
         InitialPhase(gameSetup.playerManager, gameSetup.oracle).proceed()
@@ -105,14 +105,11 @@ class GameNoteTest {
 
         GameEvent.Divined.send(wolf, DivineResult.WEREWOLF, human)
 
-        assertEquals(
-            listOf(ReportEntry("V1", "Wolf", "人狼", trusted = true)),
-            io.divinationPanels.last().divineReports,
-        )
+        assertEquals(mapOf("Wolf" to "人狼"), io.divinationPanels.last().divineResults)
     }
 
     @Test
-    fun `medium result appears as trusted in divination panel`() {
+    fun `medium result appears in medium results of divination panel`() {
         val io = CapturingIO()
         val gameSetup = createGameWithHuman(io, "Wolf" to Role.WEREWOLF)
         InitialPhase(gameSetup.playerManager, gameSetup.oracle).proceed()
@@ -121,14 +118,11 @@ class GameNoteTest {
 
         GameEvent.MediumRevealed.send(wolf, MediumResult.WEREWOLF, human)
 
-        assertEquals(
-            listOf(ReportEntry("V1", "Wolf", "人狼である", trusted = true)),
-            io.divinationPanels.last().mediumReports,
-        )
+        assertEquals(mapOf("Wolf" to "人狼である"), io.divinationPanels.last().mediumResults)
     }
 
     @Test
-    fun `claimed divine result appears as untrusted in divination panel`() {
+    fun `claimed divine result appears in divine reports of divination panel`() {
         val io = CapturingIO()
         val gameSetup = createGameWithHuman(io, "V2" to Role.VILLAGER, "Wolf" to Role.WEREWOLF)
         InitialPhase(gameSetup.playerManager, gameSetup.oracle).proceed()
@@ -139,7 +133,7 @@ class GameNoteTest {
         GameEvent.StatementMade.send(1, "V2", Statement.DivinationReport(v2, wolf, DivineResult.WEREWOLF), allPlayers)
 
         assertEquals(
-            listOf(ReportEntry("V2", "Wolf", "人狼", trusted = false)),
+            listOf(ReportEntry("V2", "Wolf", "人狼")),
             io.divinationPanels.last().divineReports,
         )
     }

--- a/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
@@ -4,6 +4,7 @@ import werewolf.game.*
 import werewolf.human.HumanPlayer
 import werewolf.human.HumanIO
 import werewolf.view.ChoiceView
+import werewolf.view.DivinationView
 import werewolf.view.SurvivalView
 import werewolf.phase.Conclave
 import werewolf.phase.Epilogue
@@ -19,6 +20,7 @@ class HumanPlayerEpilogueTest {
         var capturedChronicles: List<ChronicleView> = emptyList()
         override fun display(view: RecallView) {}
         override fun updatePanel(view: SurvivalView) {}
+        override fun updateDivinationPanel(view: DivinationView) {}
         override fun promptFreeText(title: String, description: String): String = "human speaks"
         override fun promptChoice(view: ChoiceView): String = view.options.first()
         override fun watchEpilogue(chronicles: List<ChronicleView>) { capturedChronicles = chronicles }

--- a/src/test/kotlin/werewolf/HumanPlayerTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerTest.kt
@@ -15,6 +15,7 @@ import werewolf.game.StatementType
 import werewolf.human.HumanIO
 import werewolf.human.HumanPlayer
 import werewolf.view.ChoiceView
+import werewolf.view.DivinationView
 import werewolf.view.SurvivalView
 
 class HumanPlayerTest {
@@ -30,6 +31,7 @@ class HumanPlayerTest {
 
         override fun display(view: RecallView) { displayedViews += view }
         override fun updatePanel(view: SurvivalView) {}
+        override fun updateDivinationPanel(view: DivinationView) {}
         override fun promptChoice(view: ChoiceView): String {
             promptedChoices += view
             return queue.removeFirst()


### PR DESCRIPTION
## Summary

- `DivinationView` / `ReportEntry` を新設し、占い師・霊媒師がゲームから得た確定結果（`divineResults` / `mediumResults`）とプレイヤーの申告（`divineReports` / `mediumReports`）を構造で分離
- `GameNote` が `Divined`・`MediumRevealed`・`StatementMade` イベントを蓄積し、変化時のみ `updateDivinationPanel()` を送信
- `HumanIO` に `updateDivinationPanel(DivinationView)` を追加、全実装を更新
- Web UI のサイドパネルに「占い結果」「霊媒結果」（確定リスト）と「占い申告」「霊媒申告」（ソース別テーブル）を表示

Closes #238

## Test plan

- [ ] `GameNoteTest`: 占い結果・霊媒結果が `divineResults`/`mediumResults` に入ること、申告が `divineReports`/`mediumReports` に入ることを確認
- [ ] 占い師ロールでプレイし、夜の占い結果がパネルに表示されること
- [ ] 占い申告を行うと申告テーブルに自分の列が追加されること
- [ ] 他プレイヤーの申告が申告テーブルに反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)