### PR TITLE
Fix abort keyword collision by JSON-structuring client→server messages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("jvm") version "2.1.20"
+    kotlin("plugin.serialization") version "2.1.20"
     id("io.gitlab.arturbosch.detekt") version "1.23.8"
     id("org.sonarqube") version "5.1.0.4882"
     jacoco
@@ -20,6 +21,7 @@ dependencies {
     implementation("io.ktor:ktor-server-core-jvm:$ktorVersion")
     implementation("io.ktor:ktor-server-netty:$ktorVersion")
     implementation("io.ktor:ktor-server-websockets-jvm:$ktorVersion")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
     testImplementation(kotlin("test"))
     testImplementation("com.tngtech.archunit:archunit-junit5:1.3.0")
 }

--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -84,20 +84,20 @@
   }
 
   function choose(name: string) {
-    ws.send(name)
+    ws.send(JSON.stringify({ type: 'choose', value: name }))
     input = { type: 'idle' }
   }
 
   function speak() {
     const text = speakText.trim()
     if (!text || ws.readyState !== WebSocket.OPEN) return
-    ws.send(text)
+    ws.send(JSON.stringify({ type: 'speak', text }))
     input = { type: 'idle' }
     speakText = ''
   }
 
   function abort() {
-    if (ws.readyState === WebSocket.OPEN) ws.send('abort')
+    if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type: 'abort' }))
     input = { type: 'idle' }
   }
 

--- a/src/main/kotlin/werewolf/lodge/WebHumanConnection.kt
+++ b/src/main/kotlin/werewolf/lodge/WebHumanConnection.kt
@@ -62,10 +62,11 @@ class WebHumanConnection : HumanConnection {
             for (frame in incoming) {
                 if (frame is Frame.Text) {
                     val msg = Json.parseToJsonElement(frame.readText()).jsonObject
-                    when (getStringField(msg, "type", "client message")) {
+                    when (val type = getStringField(msg, "type", "client message")) {
                         "abort" -> { webHumanIO.requestAbort(); webHumanIO.incoming.trySend("") }
                         "choose" -> webHumanIO.incoming.trySend(getStringField(msg, "value", "choose message"))
                         "speak" -> webHumanIO.incoming.trySend(getStringField(msg, "text", "speak message"))
+                        else -> error("Unknown message type '$type' in client message: $msg")
                     }
                 }
             }

--- a/src/main/kotlin/werewolf/lodge/WebHumanConnection.kt
+++ b/src/main/kotlin/werewolf/lodge/WebHumanConnection.kt
@@ -14,6 +14,10 @@ import io.ktor.websocket.readText
 import io.ktor.websocket.send
 import java.util.concurrent.CountDownLatch
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
 import werewolf.human.HumanIO
 import werewolf.human.web.WebHumanIO
 
@@ -57,12 +61,11 @@ class WebHumanConnection : HumanConnection {
         launch {
             for (frame in incoming) {
                 if (frame is Frame.Text) {
-                    val text = frame.readText()
-                    if (text == "abort") {
-                        webHumanIO.requestAbort()
-                        webHumanIO.incoming.trySend("")
-                    } else {
-                        webHumanIO.incoming.trySend(text)
+                    val msg = Json.parseToJsonElement(frame.readText()).jsonObject
+                    when (getStringField(msg, "type", "client message")) {
+                        "abort" -> { webHumanIO.requestAbort(); webHumanIO.incoming.trySend("") }
+                        "choose" -> webHumanIO.incoming.trySend(getStringField(msg, "value", "choose message"))
+                        "speak" -> webHumanIO.incoming.trySend(getStringField(msg, "text", "speak message"))
                     }
                 }
             }
@@ -79,6 +82,12 @@ class WebHumanConnection : HumanConnection {
         private const val SERVER_STOP_GRACE_MS = 100L
         private const val SERVER_STOP_TIMEOUT_MS = 1000L
     }
+}
+
+private fun getStringField(json: JsonObject, key: String, context: String): String {
+    val element = json[key] ?: error("Missing '$key' field in $context: $json")
+    return (element as? JsonPrimitive)?.content
+        ?: error("Field '$key' is not a string primitive in $context: $json")
 }
 
 private class ConnectionObserver {


### PR DESCRIPTION
## Summary

- クライアント→サーバーのWebSocketメッセージをJSON化し、`abort` という文字列を発言しても誤ってゲームが終了しなくなった
- サーバー側のJSONパースに `kotlinx-serialization-json` を導入し、各フィールドの欠落を個別のエラーとして検出できるようにした

## Test plan

- [ ] 発言入力欄に `abort` と入力して送信してもゲームが継続することを確認
- [ ] 通常の選択・発言・中断が引き続き動作することを確認

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)