### PR TITLE
Allow optional comment on typed statements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,6 +98,7 @@ val npmUpdateDeps by tasks.registering(Exec::class) {
 }
 
 tasks.processResources {
+    dependsOn(npmBuild)
     from("frontend/svelte/dist") {
         into("static/svelte")
     }

--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -89,9 +89,8 @@
   }
 
   function speak() {
-    const text = speakText.trim()
-    if (!text || ws.readyState !== WebSocket.OPEN) return
-    ws.send(JSON.stringify({ type: 'speak', text }))
+    if (ws.readyState !== WebSocket.OPEN) return
+    ws.send(JSON.stringify({ type: 'speak', text: speakText.trim() }))
     input = { type: 'idle' }
     speakText = ''
   }

--- a/src/main/kotlin/werewolf/game/Statement.kt
+++ b/src/main/kotlin/werewolf/game/Statement.kt
@@ -9,13 +9,25 @@ sealed class Statement {
         override fun text() = content
     }
 
-    data class DivinationReport(val claimant: Player, val target: Player, val result: DivineResult) : Statement() {
+    data class DivinationReport(
+        val claimant: Player,
+        val target: Player,
+        val result: DivineResult,
+        val comment: String = "",
+    ) : Statement() {
         override val type = StatementType.DIVINATION_REPORT
-        override fun text() = "${target.name} は「${result.displayName}」です。"
+        override fun text() = "${target.name} は「${result.displayName}」です。".withComment(comment)
     }
 
-    data class MediumReport(val claimant: Player, val target: Player, val result: MediumResult) : Statement() {
+    data class MediumReport(
+        val claimant: Player,
+        val target: Player,
+        val result: MediumResult,
+        val comment: String = "",
+    ) : Statement() {
         override val type = StatementType.MEDIUM_REPORT
-        override fun text() = "${target.name} は「${result.displayName}」です。"
+        override fun text() = "${target.name} は「${result.displayName}」です。".withComment(comment)
     }
 }
+
+private fun String.withComment(comment: String): String = if (comment.isBlank()) this else "$this $comment"

--- a/src/main/kotlin/werewolf/human/HumanPlayer.kt
+++ b/src/main/kotlin/werewolf/human/HumanPlayer.kt
@@ -70,7 +70,8 @@ class HumanPlayer(role: Role, override val name: String, private val io: HumanIO
         val target = candidates.single { it.name == targetName }
         val results = DivineResult.entries
         val resultName = io.promptChoice(ChoiceView("占い報告 - 結果", "占い結果を選んでください", results.map { it.displayName }))
-        return Statement.DivinationReport(this, target, results.single { it.displayName == resultName })
+        val comment = io.promptFreeText("占い報告 - 補足", "補足があれば入力してください")
+        return Statement.DivinationReport(this, target, results.single { it.displayName == resultName }, comment)
     }
 
     private fun buildMediumReport(context: DiscussionContext): Statement {
@@ -79,7 +80,8 @@ class HumanPlayer(role: Role, override val name: String, private val io: HumanIO
         val target = candidates.single { it.name == targetName }
         val results = MediumResult.entries
         val resultName = io.promptChoice(ChoiceView("霊媒報告 - 結果", "霊媒結果を選んでください", results.map { it.displayName }))
-        return Statement.MediumReport(this, target, results.single { it.displayName == resultName })
+        val comment = io.promptFreeText("霊媒報告 - 補足", "補足があれば入力してください")
+        return Statement.MediumReport(this, target, results.single { it.displayName == resultName }, comment)
     }
 
     override fun watchEpilogue(chronicles: List<ChronicleView>) {

--- a/src/test/kotlin/werewolf/ClaimTest.kt
+++ b/src/test/kotlin/werewolf/ClaimTest.kt
@@ -45,6 +45,26 @@ class ClaimTest {
     }
 
     @Test
+    fun `DivinationReport text appends comment when present and omits it when blank`() {
+        val speaker = NothingPlayer(Role.SEER, "Speaker")
+        val target = NothingPlayer(Role.VILLAGER, "Target")
+        val withComment = Statement.DivinationReport(speaker, target, DivineResult.WEREWOLF, "怪しいと思っていました")
+        val withoutComment = Statement.DivinationReport(speaker, target, DivineResult.WEREWOLF)
+        assertEquals("Target は「人狼」です。 怪しいと思っていました", withComment.text())
+        assertEquals("Target は「人狼」です。", withoutComment.text())
+    }
+
+    @Test
+    fun `MediumReport text appends comment when present and omits it when blank`() {
+        val speaker = NothingPlayer(Role.MEDIUM, "Speaker")
+        val target = NothingPlayer(Role.VILLAGER, "Target")
+        val withComment = Statement.MediumReport(speaker, target, MediumResult.NOT_WEREWOLF, "無実の方を処刑してしまい申し訳ない気持ちです")
+        val withoutComment = Statement.MediumReport(speaker, target, MediumResult.NOT_WEREWOLF)
+        assertEquals("Target は「人狼でない」です。 無実の方を処刑してしまい申し訳ない気持ちです", withComment.text())
+        assertEquals("Target は「人狼でない」です。", withoutComment.text())
+    }
+
+    @Test
     fun `FallbackClaim has empty statement and failure reason in chronicle`() {
         val speaker = NothingPlayer(Role.VILLAGER, "Speaker")
         val context = openContext(listOf(speaker))

--- a/src/test/kotlin/werewolf/HumanPlayerTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerTest.kt
@@ -127,6 +127,46 @@ class HumanPlayerTest {
     }
 
     @Test
+    fun `speak with DIVINATION_REPORT attaches the entered comment`() {
+        val alice = NothingPlayer(Role.VILLAGER, "Alice")
+        val io = CapturingIO(
+            StatementType.DIVINATION_REPORT.displayName,
+            "Alice",
+            DivineResult.WEREWOLF.displayName,
+            freeTextAnswer = "昨日の議論で怪しいと思っていました",
+        )
+        val human = HumanPlayer(Role.SEER, "Human", io)
+        val context = DiscussionContext.Open(1, 1, listOf(human), listOf(human, alice))
+
+        val statement = human.discuss(context)
+
+        assertEquals(
+            Statement.DivinationReport(human, alice, DivineResult.WEREWOLF, "昨日の議論で怪しいと思っていました"),
+            statement,
+        )
+    }
+
+    @Test
+    fun `speak with MEDIUM_REPORT attaches the entered comment`() {
+        val alice = NothingPlayer(Role.VILLAGER, "Alice")
+        val io = CapturingIO(
+            StatementType.MEDIUM_REPORT.displayName,
+            "Alice",
+            MediumResult.NOT_WEREWOLF.displayName,
+            freeTextAnswer = "無実の方を処刑してしまい申し訳ない気持ちです",
+        )
+        val human = HumanPlayer(Role.MEDIUM, "Human", io)
+        val context = DiscussionContext.Open(1, 1, listOf(human), listOf(human, alice))
+
+        val statement = human.discuss(context)
+
+        assertEquals(
+            Statement.MediumReport(human, alice, MediumResult.NOT_WEREWOLF, "無実の方を処刑してしまい申し訳ない気持ちです"),
+            statement,
+        )
+    }
+
+    @Test
     fun `watchEpilogue delegates to io`() {
         val io = CapturingIO()
         val human = HumanPlayer(Role.VILLAGER, "Human", io)


### PR DESCRIPTION
## Summary

- 占い報告・霊媒報告（DIVINATION_REPORT / MEDIUM_REPORT）に任意の補足コメントを付加できるようにした
- `Statement.DivinationReport` / `Statement.MediumReport` に `comment` フィールドを追加し、`text()` で固定文言の後ろに補足を付与する（空欄なら省略）
- 人間プレイヤーは対象・結果を選んだ後、`promptFreeText` で補足コメントを入力できる
- Web UIの発言送信ガードを撤廃し、空欄のまま送信ボタンで進められるようにした（通常発言・補足コメント共通）
- `processResources` が `npmBuild` に依存していなかったため、`./gradlew build` を実行してもフロントエンドの変更が反映されないことがあった問題を修正

## Test plan

- [x] `./gradlew build` が通る（Kotlinテスト・detekt・svelte-check含む）
- [ ] 占い報告・霊媒報告で補足コメントを入力して発言できることを確認
- [ ] 補足コメントを空欄のまま送信して補足なしで発言が進むことを確認
- [ ] 通常発言（PLAIN）も従来通り動作することを確認

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)