### PR TITLE
Support role declarations as a distinct statement type

### DIFF
--- a/src/main/kotlin/werewolf/ai/AiPlayer.kt
+++ b/src/main/kotlin/werewolf/ai/AiPlayer.kt
@@ -74,6 +74,12 @@ class AiPlayer(
                 ?: throw InvalidAiInputException("霊媒結果報告の結果が不正です: $resultLabel")
             Statement.MediumReport(this, resolveTarget(context, targetName), result, comment)
         }
+        StatementType.ROLE_CLAIM -> {
+            val (roleName, comment) = statementFormat.extractRoleClaimParts(content)
+            val role = Role.entries.singleOrNull { it.displayName == roleName }
+                ?: throw InvalidAiInputException("役職申告の役職が不正です: $roleName")
+            Statement.RoleClaim(this, role, comment)
+        }
     }
 
     private fun resolveTarget(context: DiscussionContext, targetName: String): Player =

--- a/src/main/kotlin/werewolf/ai/StatementFormat.kt
+++ b/src/main/kotlin/werewolf/ai/StatementFormat.kt
@@ -3,6 +3,7 @@ package werewolf.ai
 import werewolf.game.DiscussionContext
 import werewolf.game.DivineResult
 import werewolf.game.MediumResult
+import werewolf.game.Role
 import werewolf.game.StatementType
 
 data class ParsedStatement(val content: String, val typeLabel: String, val intent: String)
@@ -57,6 +58,8 @@ class StatementFormat {
             "${type.displayName}：対象のプレイヤー名/結果（${DivineResult.entries.joinToString("か") { it.displayName }}）/補足コメント（省略可）"
         StatementType.MEDIUM_REPORT ->
             "${type.displayName}：対象のプレイヤー名/結果（${MediumResult.entries.joinToString("か") { it.displayName }}）/補足コメント（省略可）"
+        StatementType.ROLE_CLAIM ->
+            "${type.displayName}：申告する役職名（${Role.entries.joinToString("か") { it.displayName }}）/補足コメント（省略可）"
     }
 
     fun extractReportParts(content: String): Triple<String, String, String> {
@@ -66,5 +69,12 @@ class StatementFormat {
         val resultLabel = parts.getOrNull(1)?.trim()
             ?: throw InvalidAiInputException("報告の形式が不正です: $content")
         return Triple(targetName, resultLabel, parts.getOrNull(2)?.trim().orEmpty())
+    }
+
+    fun extractRoleClaimParts(content: String): Pair<String, String> {
+        val parts = content.split("/")
+        val roleName = parts.getOrNull(0)?.trim()
+        if (roleName.isNullOrEmpty()) throw InvalidAiInputException("役職申告の形式が不正です: $content")
+        return roleName to parts.getOrNull(1)?.trim().orEmpty()
     }
 }

--- a/src/main/kotlin/werewolf/game/Statement.kt
+++ b/src/main/kotlin/werewolf/game/Statement.kt
@@ -28,6 +28,15 @@ sealed class Statement {
         override val type = StatementType.MEDIUM_REPORT
         override fun text() = "${target.name} は「${result.displayName}」です。".withComment(comment)
     }
+
+    data class RoleClaim(
+        val claimant: Player,
+        val role: Role,
+        val comment: String = "",
+    ) : Statement() {
+        override val type = StatementType.ROLE_CLAIM
+        override fun text() = "私の役職は「${role.displayName}」です。".withComment(comment)
+    }
 }
 
 private fun String.withComment(comment: String): String = if (comment.isBlank()) this else "$this $comment"

--- a/src/main/kotlin/werewolf/game/StatementType.kt
+++ b/src/main/kotlin/werewolf/game/StatementType.kt
@@ -4,4 +4,5 @@ enum class StatementType(val displayName: String) {
     PLAIN("発言する"),
     DIVINATION_REPORT("占い結果を報告する"),
     MEDIUM_REPORT("霊媒結果を報告する"),
+    ROLE_CLAIM("役職を開示する"),
 }

--- a/src/main/kotlin/werewolf/human/HumanPlayer.kt
+++ b/src/main/kotlin/werewolf/human/HumanPlayer.kt
@@ -50,6 +50,7 @@ class HumanPlayer(role: Role, override val name: String, private val io: HumanIO
             StatementType.PLAIN -> buildPlain(context)
             StatementType.DIVINATION_REPORT -> buildDivinationReport(context)
             StatementType.MEDIUM_REPORT -> buildMediumReport(context)
+            StatementType.ROLE_CLAIM -> buildRoleClaim()
         }
         return Claim(this, context, statement, "プレイヤーが発言")
     }
@@ -82,6 +83,13 @@ class HumanPlayer(role: Role, override val name: String, private val io: HumanIO
         val resultName = io.promptChoice(ChoiceView("霊媒報告 - 結果", "霊媒結果を選んでください", results.map { it.displayName }))
         val comment = io.promptFreeText("霊媒報告 - 補足", "補足があれば入力してください")
         return Statement.MediumReport(this, target, results.single { it.displayName == resultName }, comment)
+    }
+
+    private fun buildRoleClaim(): Statement {
+        val roles = Role.entries
+        val roleName = io.promptChoice(ChoiceView("役職申告 - 役職", "申告する役職を選んでください", roles.map { it.displayName }))
+        val comment = io.promptFreeText("役職申告 - 補足", "補足があれば入力してください")
+        return Statement.RoleClaim(this, roles.single { it.displayName == roleName }, comment)
     }
 
     override fun watchEpilogue(chronicles: List<ChronicleView>) {

--- a/src/main/kotlin/werewolf/human/HumanPlayer.kt
+++ b/src/main/kotlin/werewolf/human/HumanPlayer.kt
@@ -17,6 +17,10 @@ import werewolf.view.DivinationView
 import werewolf.view.SurvivalView
 
 class HumanPlayer(role: Role, override val name: String, private val io: HumanIO) : Player(role) {
+    companion object {
+        private const val COMMENT_PROMPT = "補足があれば入力してください"
+    }
+
     private val gameNote = GameNote()
     private var lastSummary: SurvivalView? = null
     private var lastDivinationSummary: DivinationView? = null
@@ -71,7 +75,7 @@ class HumanPlayer(role: Role, override val name: String, private val io: HumanIO
         val target = candidates.single { it.name == targetName }
         val results = DivineResult.entries
         val resultName = io.promptChoice(ChoiceView("占い報告 - 結果", "占い結果を選んでください", results.map { it.displayName }))
-        val comment = io.promptFreeText("占い報告 - 補足", "補足があれば入力してください")
+        val comment = io.promptFreeText("占い報告 - 補足", COMMENT_PROMPT)
         return Statement.DivinationReport(this, target, results.single { it.displayName == resultName }, comment)
     }
 
@@ -81,14 +85,14 @@ class HumanPlayer(role: Role, override val name: String, private val io: HumanIO
         val target = candidates.single { it.name == targetName }
         val results = MediumResult.entries
         val resultName = io.promptChoice(ChoiceView("霊媒報告 - 結果", "霊媒結果を選んでください", results.map { it.displayName }))
-        val comment = io.promptFreeText("霊媒報告 - 補足", "補足があれば入力してください")
+        val comment = io.promptFreeText("霊媒報告 - 補足", COMMENT_PROMPT)
         return Statement.MediumReport(this, target, results.single { it.displayName == resultName }, comment)
     }
 
     private fun buildRoleClaim(): Statement {
         val roles = Role.entries
         val roleName = io.promptChoice(ChoiceView("役職申告 - 役職", "申告する役職を選んでください", roles.map { it.displayName }))
-        val comment = io.promptFreeText("役職申告 - 補足", "補足があれば入力してください")
+        val comment = io.promptFreeText("役職申告 - 補足", COMMENT_PROMPT)
         return Statement.RoleClaim(this, roles.single { it.displayName == roleName }, comment)
     }
 

--- a/src/test/kotlin/werewolf/AiPlayerSpeakTest.kt
+++ b/src/test/kotlin/werewolf/AiPlayerSpeakTest.kt
@@ -61,6 +61,10 @@ class AiPlayerSpeakTest {
             lm.prompts.first(),
             "霊媒結果を報告する：対象のプレイヤー名/結果（人狼であるか人狼でない）/補足コメント（省略可）",
         )
+        assertContains(
+            lm.prompts.first(),
+            "役職を開示する：申告する役職名（人狼か占い師か霊能者か村人か狩人か狂人）/補足コメント（省略可）",
+        )
     }
 
     @Test
@@ -121,6 +125,38 @@ class AiPlayerSpeakTest {
         assertEquals(alice, report.target)
         assertEquals(MediumResult.NOT_WEREWOLF, report.result)
         assertEquals("", report.comment)
+    }
+
+    @Test
+    fun `discuss selects ROLE_CLAIM and builds a role claim with comment`() {
+        val lm = FakeLanguageModel("役職を開示する：占い師/信じてください[占い師として信頼を得るため]")
+        val madman = AiPlayer(Role.MADMAN, "Madman", lm, testInstruction("Madman"))
+        val result = madman.discuss(openContext(listOf(madman)))
+        val claim = assertIs<Statement.RoleClaim>(result)
+        assertEquals(Role.SEER, claim.role)
+        assertEquals("信じてください", claim.comment)
+    }
+
+    @Test
+    fun `discuss selects ROLE_CLAIM and omits comment when not provided`() {
+        val lm = FakeLanguageModel("役職を開示する：占い師[占い師として信頼を得るため]")
+        val seer = AiPlayer(Role.SEER, "Seer", lm, testInstruction("Seer"))
+        val result = seer.discuss(openContext(listOf(seer)))
+        val claim = assertIs<Statement.RoleClaim>(result)
+        assertEquals(Role.SEER, claim.role)
+        assertEquals("", claim.comment)
+    }
+
+    @Test
+    fun `discuss falls back when claimed role name is unknown`() {
+        val lm = FakeLanguageModel(
+            "役職を開示する：宇宙人[意図]",
+            "役職を開示する：宇宙人[意図]",
+        )
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm, testInstruction())
+        val result = villager.discuss(openContext(listOf(villager)))
+        assertIs<Statement.Plain>(result)
+        assertEquals("", result.text())
     }
 
     @Test

--- a/src/test/kotlin/werewolf/ClaimTest.kt
+++ b/src/test/kotlin/werewolf/ClaimTest.kt
@@ -65,6 +65,15 @@ class ClaimTest {
     }
 
     @Test
+    fun `RoleClaim text appends comment when present and omits it when blank`() {
+        val speaker = NothingPlayer(Role.MADMAN, "Speaker")
+        val withComment = Statement.RoleClaim(speaker, Role.SEER, "信じてください")
+        val withoutComment = Statement.RoleClaim(speaker, Role.SEER)
+        assertEquals("私の役職は「占い師」です。 信じてください", withComment.text())
+        assertEquals("私の役職は「占い師」です。", withoutComment.text())
+    }
+
+    @Test
     fun `FallbackClaim has empty statement and failure reason in chronicle`() {
         val speaker = NothingPlayer(Role.VILLAGER, "Speaker")
         val context = openContext(listOf(speaker))

--- a/src/test/kotlin/werewolf/HumanPlayerTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerTest.kt
@@ -167,6 +167,33 @@ class HumanPlayerTest {
     }
 
     @Test
+    fun `speak with ROLE_CLAIM prompts for role`() {
+        val io = CapturingIO(StatementType.ROLE_CLAIM.displayName, Role.SEER.displayName)
+        val human = HumanPlayer(Role.MADMAN, "Human", io)
+        val context = DiscussionContext.Open(1, 1, listOf(human), listOf(human))
+
+        val statement = human.discuss(context)
+
+        assertEquals(Statement.RoleClaim(human, Role.SEER), statement)
+        assertEquals(2, io.promptedChoices.size)
+    }
+
+    @Test
+    fun `speak with ROLE_CLAIM attaches the entered comment`() {
+        val io = CapturingIO(
+            StatementType.ROLE_CLAIM.displayName,
+            Role.SEER.displayName,
+            freeTextAnswer = "信じてください",
+        )
+        val human = HumanPlayer(Role.MADMAN, "Human", io)
+        val context = DiscussionContext.Open(1, 1, listOf(human), listOf(human))
+
+        val statement = human.discuss(context)
+
+        assertEquals(Statement.RoleClaim(human, Role.SEER, "信じてください"), statement)
+    }
+
+    @Test
     fun `watchEpilogue delegates to io`() {
         val io = CapturingIO()
         val human = HumanPlayer(Role.VILLAGER, "Human", io)


### PR DESCRIPTION
## 概要

- `StatementType.ROLE_CLAIM` と `Statement.RoleClaim(claimant, role, comment)` を追加
- 人間・AIプレイヤーが議論中に ROLE_CLAIM を選択し、役職を申告できるようにした（占い/霊媒報告と同様、補足コメントを付けられる）

Closes #253

## Test plan

- [x] `./gradlew check`