### PR TITLE
Add role claim status panel to web UI

### DIFF
--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -16,7 +16,7 @@
     | { type: 'speak'; title: string; description: string }
 
   type PlayerStatus = 'alive' | 'executed' | 'attacked'
-  type SurvivalEntry = { name: string; status: PlayerStatus }
+  type PlayerEntry = { name: string; status: PlayerStatus; claimedRole: string | null }
 
   type ReportEntry = { source: string; targetName: string; isWerewolf: boolean }
   type DivinationData = {
@@ -27,16 +27,13 @@
     mediumReports: ReportEntry[]
   }
 
-  type RoleClaimEntry = { claimant: string; role: string }
-  type RoleClaimData = { roleClaims: RoleClaimEntry[] }
-
   let status = '接続中...'
   let entries: LogEntry[] = []
   let input: InputState = { type: 'idle' }
   let speakText = ''
   let logEl: HTMLElement
   let ws: WebSocket
-  let survivalPlayers: SurvivalEntry[] = []
+  let players: PlayerEntry[] = []
   let divination: DivinationData = {
     playerNames: [],
     divineResults: [],
@@ -44,7 +41,6 @@
     divineReports: [],
     mediumReports: [],
   }
-  let roleClaims: RoleClaimEntry[] = []
 
   onMount(() => {
     ws = new WebSocket(`ws://${location.host}/game`)
@@ -73,14 +69,11 @@
         input = { type: 'speak', title: msg.title as string, description: msg.description as string }
         speakText = ''
         break
-      case 'survival':
-        survivalPlayers = msg.players as SurvivalEntry[]
+      case 'playerStatus':
+        players = msg.players as PlayerEntry[]
         break
       case 'divination':
         divination = msg as unknown as DivinationData
-        break
-      case 'roleClaim':
-        roleClaims = (msg as unknown as RoleClaimData).roleClaims
         break
     }
   }
@@ -185,18 +178,24 @@
   </div>
 
   <aside class="panel">
-    <h2>生存状況</h2>
-    {#if survivalPlayers.length === 0}
+    <h2>生存状況・CO</h2>
+    {#if players.length === 0}
       <p class="panel-empty">ゲーム開始前</p>
     {:else}
-      <ul class="survival-list">
-        {#each survivalPlayers as p}
-          <li class="survival-entry {p.status}">
-            <span class="player-name">{p.name}</span>
-            <span class="player-status">{statusLabel(p.status)}</span>
-          </li>
-        {/each}
-      </ul>
+      <table class="status-table">
+        <thead>
+          <tr><th>プレイヤー</th><th>状態</th><th>CO</th></tr>
+        </thead>
+        <tbody>
+          {#each players as p}
+            <tr class={p.status}>
+              <td class="row-label">{p.name}</td>
+              <td><span class="player-status">{statusLabel(p.status)}</span></td>
+              <td class:co-empty={!p.claimedRole}>{p.claimedRole ?? '-'}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
     {/if}
 
     {#if divination.divineResults.length > 0}
@@ -282,18 +281,6 @@
         </table>
       </div>
     {/if}
-
-    {#if roleClaims.length > 0}
-      <h2 class="panel-section">役職申告</h2>
-      <ul class="result-list">
-        {#each roleClaims as c}
-          <li class="result-entry">
-            <span class="result-name">{c.claimant}</span>
-            <span>{c.role}</span>
-          </li>
-        {/each}
-      </ul>
-    {/if}
   </aside>
 </div>
 
@@ -318,11 +305,12 @@
   input[type='text'] { width: 70%; padding: 6px; font-size: 1em; }
 
   .panel-empty { color: #999; font-size: 0.9em; }
-  .survival-list { list-style: none; margin: 0; padding: 0; }
-  .survival-entry { display: flex; justify-content: space-between; align-items: center; padding: 4px 0; border-bottom: 1px solid #eee; font-size: 0.9em; }
-  .survival-entry:last-child { border-bottom: none; }
-  .player-name { flex: 1; }
-  .player-status { font-size: 0.8em; padding: 1px 6px; border-radius: 3px; }
+  .status-table { border-collapse: collapse; font-size: 0.85em; width: 100%; }
+  .status-table th { font-weight: normal; color: #666; padding: 3px 4px; text-align: left; }
+  .status-table td { padding: 4px 4px; border-bottom: 1px solid #eee; }
+  .status-table tr:last-child td { border-bottom: none; }
+  .co-empty { color: #999; }
+  .player-status { font-size: 0.8em; padding: 1px 6px; border-radius: 3px; white-space: nowrap; }
   .alive .player-status { background: #d4f7d4; color: #2a6e2a; }
   .executed .player-status { background: #f7d4d4; color: #6e2a2a; }
   .attacked .player-status { background: #f7ead4; color: #6e4a2a; }

--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -27,6 +27,9 @@
     mediumReports: ReportEntry[]
   }
 
+  type RoleClaimEntry = { claimant: string; role: string }
+  type RoleClaimData = { roleClaims: RoleClaimEntry[] }
+
   let status = '接続中...'
   let entries: LogEntry[] = []
   let input: InputState = { type: 'idle' }
@@ -41,6 +44,7 @@
     divineReports: [],
     mediumReports: [],
   }
+  let roleClaims: RoleClaimEntry[] = []
 
   onMount(() => {
     ws = new WebSocket(`ws://${location.host}/game`)
@@ -74,6 +78,9 @@
         break
       case 'divination':
         divination = msg as unknown as DivinationData
+        break
+      case 'roleClaim':
+        roleClaims = (msg as unknown as RoleClaimData).roleClaims
         break
     }
   }
@@ -274,6 +281,18 @@
           </tbody>
         </table>
       </div>
+    {/if}
+
+    {#if roleClaims.length > 0}
+      <h2 class="panel-section">役職申告</h2>
+      <ul class="result-list">
+        {#each roleClaims as c}
+          <li class="result-entry">
+            <span class="result-name">{c.claimant}</span>
+            <span>{c.role}</span>
+          </li>
+        {/each}
+      </ul>
     {/if}
   </aside>
 </div>

--- a/src/main/kotlin/werewolf/human/GameNote.kt
+++ b/src/main/kotlin/werewolf/human/GameNote.kt
@@ -3,10 +3,13 @@ package werewolf.human
 import werewolf.game.DivineResult
 import werewolf.game.GameEvent
 import werewolf.game.MediumResult
+import werewolf.game.Role
 import werewolf.game.Statement
 import werewolf.view.DivinationView
 import werewolf.view.PlayerStatus
 import werewolf.view.ReportEntry
+import werewolf.view.RoleClaimEntry
+import werewolf.view.RoleClaimView
 import werewolf.view.SurvivalView
 
 class GameNote {
@@ -16,6 +19,7 @@ class GameNote {
     private val mediumResults = mutableMapOf<String, Boolean>()
     private val divineReports = mutableSetOf<ReportEntry>()
     private val mediumReports = mutableSetOf<ReportEntry>()
+    private val roleClaims = mutableSetOf<RoleClaimEntry>()
 
     fun post(event: GameEvent) {
         when (event) {
@@ -28,10 +32,15 @@ class GameNote {
             is GameEvent.Divined -> divineResults[event.target.name] = event.result == DivineResult.WEREWOLF
             is GameEvent.MediumRevealed -> mediumResults[event.target.name] = event.result == MediumResult.WEREWOLF
             is GameEvent.StatementMade -> when (val stmt = event.statement) {
-                is Statement.DivinationReport ->
+                is Statement.DivinationReport -> {
                     divineReports += ReportEntry(event.speakerName, stmt.target.name, stmt.result == DivineResult.WEREWOLF)
-                is Statement.MediumReport ->
+                    roleClaims += RoleClaimEntry(event.speakerName, Role.SEER.displayName)
+                }
+                is Statement.MediumReport -> {
                     mediumReports += ReportEntry(event.speakerName, stmt.target.name, stmt.result == MediumResult.WEREWOLF)
+                    roleClaims += RoleClaimEntry(event.speakerName, Role.MEDIUM.displayName)
+                }
+                is Statement.RoleClaim -> roleClaims += RoleClaimEntry(event.speakerName, stmt.role.displayName)
                 else -> Unit
             }
             else -> Unit
@@ -47,4 +56,6 @@ class GameNote {
         divineReports = divineReports.toList(),
         mediumReports = mediumReports.toList(),
     )
+
+    fun roleClaimSummary(): RoleClaimView = RoleClaimView(roleClaims.toList())
 }

--- a/src/main/kotlin/werewolf/human/GameNote.kt
+++ b/src/main/kotlin/werewolf/human/GameNote.kt
@@ -7,10 +7,9 @@ import werewolf.game.Role
 import werewolf.game.Statement
 import werewolf.view.DivinationView
 import werewolf.view.PlayerStatus
+import werewolf.view.PlayerStatusView
+import werewolf.view.PlayerSummary
 import werewolf.view.ReportEntry
-import werewolf.view.RoleClaimEntry
-import werewolf.view.RoleClaimView
-import werewolf.view.SurvivalView
 
 class GameNote {
     private val playerStatuses = mutableMapOf<String, PlayerStatus>()
@@ -19,7 +18,7 @@ class GameNote {
     private val mediumResults = mutableMapOf<String, Boolean>()
     private val divineReports = mutableSetOf<ReportEntry>()
     private val mediumReports = mutableSetOf<ReportEntry>()
-    private val roleClaims = mutableSetOf<RoleClaimEntry>()
+    private val claimedRoles = mutableMapOf<String, String>()
 
     fun post(event: GameEvent) {
         when (event) {
@@ -34,20 +33,22 @@ class GameNote {
             is GameEvent.StatementMade -> when (val stmt = event.statement) {
                 is Statement.DivinationReport -> {
                     divineReports += ReportEntry(event.speakerName, stmt.target.name, stmt.result == DivineResult.WEREWOLF)
-                    roleClaims += RoleClaimEntry(event.speakerName, Role.SEER.displayName)
+                    claimedRoles[event.speakerName] = Role.SEER.displayName
                 }
                 is Statement.MediumReport -> {
                     mediumReports += ReportEntry(event.speakerName, stmt.target.name, stmt.result == MediumResult.WEREWOLF)
-                    roleClaims += RoleClaimEntry(event.speakerName, Role.MEDIUM.displayName)
+                    claimedRoles[event.speakerName] = Role.MEDIUM.displayName
                 }
-                is Statement.RoleClaim -> roleClaims += RoleClaimEntry(event.speakerName, stmt.role.displayName)
+                is Statement.RoleClaim -> claimedRoles[event.speakerName] = stmt.role.displayName
                 else -> Unit
             }
             else -> Unit
         }
     }
 
-    fun summary(): SurvivalView = SurvivalView(playerStatuses.toMap())
+    fun playerStatusSummary(): PlayerStatusView = PlayerStatusView(
+        playerNames.map { name -> PlayerSummary(name, playerStatuses.getValue(name), claimedRoles[name]) },
+    )
 
     fun divinationSummary(): DivinationView = DivinationView(
         playerNames = playerNames.toList(),
@@ -56,6 +57,4 @@ class GameNote {
         divineReports = divineReports.toList(),
         mediumReports = mediumReports.toList(),
     )
-
-    fun roleClaimSummary(): RoleClaimView = RoleClaimView(roleClaims.toList())
 }

--- a/src/main/kotlin/werewolf/human/HumanIO.kt
+++ b/src/main/kotlin/werewolf/human/HumanIO.kt
@@ -4,14 +4,12 @@ import werewolf.game.ChronicleView
 import werewolf.game.RecallView
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
-import werewolf.view.RoleClaimView
-import werewolf.view.SurvivalView
+import werewolf.view.PlayerStatusView
 
 interface HumanIO {
     fun display(view: RecallView)
-    fun updatePanel(view: SurvivalView)
+    fun updatePlayerStatusPanel(view: PlayerStatusView)
     fun updateDivinationPanel(view: DivinationView)
-    fun updateRoleClaimPanel(view: RoleClaimView)
     fun promptChoice(view: ChoiceView): String
     fun promptFreeText(title: String, description: String): String
     fun watchEpilogue(chronicles: List<ChronicleView>)

--- a/src/main/kotlin/werewolf/human/HumanIO.kt
+++ b/src/main/kotlin/werewolf/human/HumanIO.kt
@@ -4,12 +4,14 @@ import werewolf.game.ChronicleView
 import werewolf.game.RecallView
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
+import werewolf.view.RoleClaimView
 import werewolf.view.SurvivalView
 
 interface HumanIO {
     fun display(view: RecallView)
     fun updatePanel(view: SurvivalView)
     fun updateDivinationPanel(view: DivinationView)
+    fun updateRoleClaimPanel(view: RoleClaimView)
     fun promptChoice(view: ChoiceView): String
     fun promptFreeText(title: String, description: String): String
     fun watchEpilogue(chronicles: List<ChronicleView>)

--- a/src/main/kotlin/werewolf/human/HumanPlayer.kt
+++ b/src/main/kotlin/werewolf/human/HumanPlayer.kt
@@ -14,8 +14,7 @@ import werewolf.game.Statement
 import werewolf.game.StatementType
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
-import werewolf.view.RoleClaimView
-import werewolf.view.SurvivalView
+import werewolf.view.PlayerStatusView
 
 class HumanPlayer(role: Role, override val name: String, private val io: HumanIO) : Player(role) {
     companion object {
@@ -23,9 +22,8 @@ class HumanPlayer(role: Role, override val name: String, private val io: HumanIO
     }
 
     private val gameNote = GameNote()
-    private var lastSummary: SurvivalView? = null
+    private var lastPlayerStatus: PlayerStatusView? = null
     private var lastDivinationSummary: DivinationView? = null
-    private var lastRoleClaimSummary: RoleClaimView? = null
 
     override fun choose(context: SelectionContext): Choice {
         val candidates = context.candidates()
@@ -38,20 +36,15 @@ class HumanPlayer(role: Role, override val name: String, private val io: HumanIO
     override fun onReceive(event: GameEvent) {
         io.display(event.toRecallView())
         gameNote.post(event)
-        val current = gameNote.summary()
-        if (current != lastSummary) {
-            lastSummary = current
-            io.updatePanel(current)
+        val current = gameNote.playerStatusSummary()
+        if (current != lastPlayerStatus) {
+            lastPlayerStatus = current
+            io.updatePlayerStatusPanel(current)
         }
         val currentDivination = gameNote.divinationSummary()
         if (currentDivination != lastDivinationSummary) {
             lastDivinationSummary = currentDivination
             io.updateDivinationPanel(currentDivination)
-        }
-        val currentRoleClaim = gameNote.roleClaimSummary()
-        if (currentRoleClaim != lastRoleClaimSummary) {
-            lastRoleClaimSummary = currentRoleClaim
-            io.updateRoleClaimPanel(currentRoleClaim)
         }
     }
 

--- a/src/main/kotlin/werewolf/human/HumanPlayer.kt
+++ b/src/main/kotlin/werewolf/human/HumanPlayer.kt
@@ -14,6 +14,7 @@ import werewolf.game.Statement
 import werewolf.game.StatementType
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
+import werewolf.view.RoleClaimView
 import werewolf.view.SurvivalView
 
 class HumanPlayer(role: Role, override val name: String, private val io: HumanIO) : Player(role) {
@@ -24,6 +25,7 @@ class HumanPlayer(role: Role, override val name: String, private val io: HumanIO
     private val gameNote = GameNote()
     private var lastSummary: SurvivalView? = null
     private var lastDivinationSummary: DivinationView? = null
+    private var lastRoleClaimSummary: RoleClaimView? = null
 
     override fun choose(context: SelectionContext): Choice {
         val candidates = context.candidates()
@@ -45,6 +47,11 @@ class HumanPlayer(role: Role, override val name: String, private val io: HumanIO
         if (currentDivination != lastDivinationSummary) {
             lastDivinationSummary = currentDivination
             io.updateDivinationPanel(currentDivination)
+        }
+        val currentRoleClaim = gameNote.roleClaimSummary()
+        if (currentRoleClaim != lastRoleClaimSummary) {
+            lastRoleClaimSummary = currentRoleClaim
+            io.updateRoleClaimPanel(currentRoleClaim)
         }
     }
 

--- a/src/main/kotlin/werewolf/human/console/ConsoleHumanIO.kt
+++ b/src/main/kotlin/werewolf/human/console/ConsoleHumanIO.kt
@@ -6,6 +6,7 @@ import werewolf.game.RecallView
 import werewolf.human.HumanIO
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
+import werewolf.view.RoleClaimView
 import werewolf.view.SurvivalView
 
 class ConsoleHumanIO : HumanIO {
@@ -20,6 +21,10 @@ class ConsoleHumanIO : HumanIO {
 
     override fun updateDivinationPanel(view: DivinationView) {
         // Console has no persistent panel; divination info is visible in the event log
+    }
+
+    override fun updateRoleClaimPanel(view: RoleClaimView) {
+        // Console has no persistent panel; role claim info is visible in the event log
     }
 
     override fun display(view: RecallView) = when (view) {

--- a/src/main/kotlin/werewolf/human/console/ConsoleHumanIO.kt
+++ b/src/main/kotlin/werewolf/human/console/ConsoleHumanIO.kt
@@ -6,8 +6,7 @@ import werewolf.game.RecallView
 import werewolf.human.HumanIO
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
-import werewolf.view.RoleClaimView
-import werewolf.view.SurvivalView
+import werewolf.view.PlayerStatusView
 
 class ConsoleHumanIO : HumanIO {
 
@@ -15,16 +14,12 @@ class ConsoleHumanIO : HumanIO {
         private const val ABORT_PASSWORD = 4423
     }
 
-    override fun updatePanel(view: SurvivalView) {
-        // Console has no persistent panel; survival info is visible in the event log
+    override fun updatePlayerStatusPanel(view: PlayerStatusView) {
+        // Console has no persistent panel; player status info is visible in the event log
     }
 
     override fun updateDivinationPanel(view: DivinationView) {
         // Console has no persistent panel; divination info is visible in the event log
-    }
-
-    override fun updateRoleClaimPanel(view: RoleClaimView) {
-        // Console has no persistent panel; role claim info is visible in the event log
     }
 
     override fun display(view: RecallView) = when (view) {

--- a/src/main/kotlin/werewolf/human/web/WebHumanIO.kt
+++ b/src/main/kotlin/werewolf/human/web/WebHumanIO.kt
@@ -9,9 +9,9 @@ import werewolf.human.HumanIO
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
 import werewolf.view.PlayerStatus
+import werewolf.view.PlayerStatusView
+import werewolf.view.PlayerSummary
 import werewolf.view.ReportEntry
-import werewolf.view.RoleClaimView
-import werewolf.view.SurvivalView
 
 class WebHumanIO : HumanIO {
     val outgoing = Channel<String>(Channel.UNLIMITED)
@@ -39,18 +39,9 @@ class WebHumanIO : HumanIO {
         )
     }
 
-    override fun updatePanel(view: SurvivalView) {
-        val playersJson = view.players.entries.joinToString(",") {
-            """{"name":${it.key.jsonEncode()},"status":${it.value.toJson()}}"""
-        }
-        enqueue("""{"type":"survival","players":[$playersJson]}""")
-    }
-
-    override fun updateRoleClaimPanel(view: RoleClaimView) {
-        val roleClaimsJson = view.roleClaims.joinToString(",") {
-            """{"claimant":${it.claimant.jsonEncode()},"role":${it.role.jsonEncode()}}"""
-        }
-        enqueue("""{"type":"roleClaim","roleClaims":[$roleClaimsJson]}""")
+    override fun updatePlayerStatusPanel(view: PlayerStatusView) {
+        val playersJson = view.players.joinToString(",") { it.toJson() }
+        enqueue("""{"type":"playerStatus","players":[$playersJson]}""")
     }
 
     override fun display(view: RecallView) {
@@ -89,6 +80,9 @@ class WebHumanIO : HumanIO {
 
 private fun ReportEntry.toJson(): String =
     """{"source":${source.jsonEncode()},"targetName":${targetName.jsonEncode()},"isWerewolf":$isWerewolf}"""
+
+private fun PlayerSummary.toJson(): String =
+    """{"name":${name.jsonEncode()},"status":${status.toJson()},"claimedRole":${claimedRole?.jsonEncode() ?: "null"}}"""
 
 private fun PlayerStatus.toJson(): String = when (this) {
     PlayerStatus.ALIVE -> "\"alive\""

--- a/src/main/kotlin/werewolf/human/web/WebHumanIO.kt
+++ b/src/main/kotlin/werewolf/human/web/WebHumanIO.kt
@@ -10,6 +10,7 @@ import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
 import werewolf.view.PlayerStatus
 import werewolf.view.ReportEntry
+import werewolf.view.RoleClaimView
 import werewolf.view.SurvivalView
 
 class WebHumanIO : HumanIO {
@@ -43,6 +44,13 @@ class WebHumanIO : HumanIO {
             """{"name":${it.key.jsonEncode()},"status":${it.value.toJson()}}"""
         }
         enqueue("""{"type":"survival","players":[$playersJson]}""")
+    }
+
+    override fun updateRoleClaimPanel(view: RoleClaimView) {
+        val roleClaimsJson = view.roleClaims.joinToString(",") {
+            """{"claimant":${it.claimant.jsonEncode()},"role":${it.role.jsonEncode()}}"""
+        }
+        enqueue("""{"type":"roleClaim","roleClaims":[$roleClaimsJson]}""")
     }
 
     override fun display(view: RecallView) {

--- a/src/main/kotlin/werewolf/view/PlayerStatusView.kt
+++ b/src/main/kotlin/werewolf/view/PlayerStatusView.kt
@@ -1,0 +1,7 @@
+package werewolf.view
+
+enum class PlayerStatus { ALIVE, EXECUTED, ATTACKED }
+
+data class PlayerSummary(val name: String, val status: PlayerStatus, val claimedRole: String? = null)
+
+data class PlayerStatusView(val players: List<PlayerSummary>)

--- a/src/main/kotlin/werewolf/view/RoleClaimView.kt
+++ b/src/main/kotlin/werewolf/view/RoleClaimView.kt
@@ -1,5 +1,0 @@
-package werewolf.view
-
-data class RoleClaimEntry(val claimant: String, val role: String)
-
-data class RoleClaimView(val roleClaims: List<RoleClaimEntry>)

--- a/src/main/kotlin/werewolf/view/RoleClaimView.kt
+++ b/src/main/kotlin/werewolf/view/RoleClaimView.kt
@@ -1,0 +1,5 @@
+package werewolf.view
+
+data class RoleClaimEntry(val claimant: String, val role: String)
+
+data class RoleClaimView(val roleClaims: List<RoleClaimEntry>)

--- a/src/main/kotlin/werewolf/view/SurvivalView.kt
+++ b/src/main/kotlin/werewolf/view/SurvivalView.kt
@@ -1,5 +1,0 @@
-package werewolf.view
-
-enum class PlayerStatus { ALIVE, EXECUTED, ATTACKED }
-
-data class SurvivalView(val players: Map<String, PlayerStatus>)

--- a/src/test/kotlin/werewolf/GameNoteTest.kt
+++ b/src/test/kotlin/werewolf/GameNoteTest.kt
@@ -18,21 +18,17 @@ import werewolf.phase.InitialPhase
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
 import werewolf.view.PlayerStatus
+import werewolf.view.PlayerStatusView
 import werewolf.view.ReportEntry
-import werewolf.view.RoleClaimEntry
-import werewolf.view.RoleClaimView
-import werewolf.view.SurvivalView
 
 class GameNoteTest {
 
     private class CapturingIO : HumanIO {
-        val panels = mutableListOf<SurvivalView>()
+        val panels = mutableListOf<PlayerStatusView>()
         val divinationPanels = mutableListOf<DivinationView>()
-        val roleClaimPanels = mutableListOf<RoleClaimView>()
         override fun display(view: RecallView) {}
-        override fun updatePanel(view: SurvivalView) { panels += view }
+        override fun updatePlayerStatusPanel(view: PlayerStatusView) { panels += view }
         override fun updateDivinationPanel(view: DivinationView) { divinationPanels += view }
-        override fun updateRoleClaimPanel(view: RoleClaimView) { roleClaimPanels += view }
         override fun promptChoice(view: ChoiceView): String = error("not expected")
         override fun promptFreeText(title: String, description: String): String = error("not expected")
         override fun watchEpilogue(chronicles: List<ChronicleView>) {}
@@ -48,6 +44,10 @@ class GameNoteTest {
         return TestLodge(*otherPlayers.toTypedArray(), human to Role.VILLAGER).create()
     }
 
+    private fun statusOf(view: PlayerStatusView, name: String): PlayerStatus = view.players.single { it.name == name }.status
+
+    private fun claimedRoleOf(view: PlayerStatusView, name: String): String? = view.players.single { it.name == name }.claimedRole
+
     @Test
     fun `all players appear as alive at game start`() {
         val io = CapturingIO()
@@ -56,7 +56,7 @@ class GameNoteTest {
         InitialPhase(gameSetup.playerManager, gameSetup.oracle).proceed()
 
         val summary = io.panels.last()
-        assertTrue(summary.players.values.all { it == PlayerStatus.ALIVE })
+        assertTrue(summary.players.all { it.status == PlayerStatus.ALIVE })
         assertEquals(3, summary.players.size)
     }
 
@@ -70,8 +70,8 @@ class GameNoteTest {
 
         gameSetup.playerManager.execute(v2)
 
-        assertEquals(PlayerStatus.EXECUTED, io.panels.last().players["V2"])
-        assertEquals(PlayerStatus.ALIVE, io.panels.last().players["V1"])
+        assertEquals(PlayerStatus.EXECUTED, statusOf(io.panels.last(), "V2"))
+        assertEquals(PlayerStatus.ALIVE, statusOf(io.panels.last(), "V1"))
     }
 
     @Test
@@ -84,7 +84,7 @@ class GameNoteTest {
 
         gameSetup.playerManager.kill(v2)
 
-        assertEquals(PlayerStatus.ATTACKED, io.panels.last().players["V2"])
+        assertEquals(PlayerStatus.ATTACKED, statusOf(io.panels.last(), "V2"))
     }
 
     @Test
@@ -155,7 +155,7 @@ class GameNoteTest {
     }
 
     @Test
-    fun `ROLE_CLAIM statement appears in role claim panel`() {
+    fun `ROLE_CLAIM statement appears as the player's claimed role`() {
         val io = CapturingIO()
         val gameSetup = createGameWithHuman(io, "V2" to Role.VILLAGER, "Wolf" to Role.WEREWOLF)
         InitialPhase(gameSetup.playerManager, gameSetup.oracle).proceed()
@@ -164,14 +164,11 @@ class GameNoteTest {
 
         GameEvent.StatementMade.send(1, "V2", Statement.RoleClaim(v2, Role.SEER), allPlayers)
 
-        assertEquals(
-            listOf(RoleClaimEntry("V2", Role.SEER.displayName)),
-            io.roleClaimPanels.last().roleClaims,
-        )
+        assertEquals(Role.SEER.displayName, claimedRoleOf(io.panels.last(), "V2"))
     }
 
     @Test
-    fun `DivinationReport is treated as a seer claim in the role claim panel`() {
+    fun `DivinationReport is treated as a seer claim`() {
         val io = CapturingIO()
         val gameSetup = createGameWithHuman(io, "V2" to Role.VILLAGER, "Wolf" to Role.WEREWOLF)
         InitialPhase(gameSetup.playerManager, gameSetup.oracle).proceed()
@@ -181,14 +178,11 @@ class GameNoteTest {
 
         GameEvent.StatementMade.send(1, "V2", Statement.DivinationReport(v2, wolf, DivineResult.WEREWOLF), allPlayers)
 
-        assertEquals(
-            listOf(RoleClaimEntry("V2", Role.SEER.displayName)),
-            io.roleClaimPanels.last().roleClaims,
-        )
+        assertEquals(Role.SEER.displayName, claimedRoleOf(io.panels.last(), "V2"))
     }
 
     @Test
-    fun `MediumReport is treated as a medium claim in the role claim panel`() {
+    fun `MediumReport is treated as a medium claim`() {
         val io = CapturingIO()
         val gameSetup = createGameWithHuman(io, "V2" to Role.VILLAGER, "Wolf" to Role.WEREWOLF)
         InitialPhase(gameSetup.playerManager, gameSetup.oracle).proceed()
@@ -198,21 +192,32 @@ class GameNoteTest {
 
         GameEvent.StatementMade.send(1, "V2", Statement.MediumReport(v2, wolf, MediumResult.WEREWOLF), allPlayers)
 
-        assertEquals(
-            listOf(RoleClaimEntry("V2", Role.MEDIUM.displayName)),
-            io.roleClaimPanels.last().roleClaims,
-        )
+        assertEquals(Role.MEDIUM.displayName, claimedRoleOf(io.panels.last(), "V2"))
     }
 
     @Test
-    fun `role claim panel is not updated for unrelated events`() {
+    fun `later claim overrides an earlier one for the same player`() {
         val io = CapturingIO()
         val gameSetup = createGameWithHuman(io, "V2" to Role.VILLAGER, "Wolf" to Role.WEREWOLF)
         InitialPhase(gameSetup.playerManager, gameSetup.oracle).proceed()
-        val countAfterStart = io.roleClaimPanels.size
+        val v2 = gameSetup.playerManager.allPlayers.single { it.name == "V2" }
+        val allPlayers = AllPlayers(gameSetup.playerManager)
 
-        GameEvent.DiscussionStarted.send(1, AllPlayers(gameSetup.playerManager))
+        GameEvent.StatementMade.send(1, "V2", Statement.RoleClaim(v2, Role.SEER), allPlayers)
+        GameEvent.StatementMade.send(1, "V2", Statement.RoleClaim(v2, Role.VILLAGER), allPlayers)
 
-        assertEquals(countAfterStart, io.roleClaimPanels.size)
+        assertEquals(Role.VILLAGER.displayName, claimedRoleOf(io.panels.last(), "V2"))
+    }
+
+    @Test
+    fun `mentioning a role in a PLAIN statement is not treated as a claim`() {
+        val io = CapturingIO()
+        val gameSetup = createGameWithHuman(io, "V2" to Role.VILLAGER, "Wolf" to Role.WEREWOLF)
+        InitialPhase(gameSetup.playerManager, gameSetup.oracle).proceed()
+        val allPlayers = AllPlayers(gameSetup.playerManager)
+
+        GameEvent.StatementMade.send(1, "V2", Statement.Plain("私は${Role.SEER.displayName}です"), allPlayers)
+
+        assertEquals(null, claimedRoleOf(io.panels.last(), "V2"))
     }
 }

--- a/src/test/kotlin/werewolf/GameNoteTest.kt
+++ b/src/test/kotlin/werewolf/GameNoteTest.kt
@@ -19,6 +19,8 @@ import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
 import werewolf.view.PlayerStatus
 import werewolf.view.ReportEntry
+import werewolf.view.RoleClaimEntry
+import werewolf.view.RoleClaimView
 import werewolf.view.SurvivalView
 
 class GameNoteTest {
@@ -26,9 +28,11 @@ class GameNoteTest {
     private class CapturingIO : HumanIO {
         val panels = mutableListOf<SurvivalView>()
         val divinationPanels = mutableListOf<DivinationView>()
+        val roleClaimPanels = mutableListOf<RoleClaimView>()
         override fun display(view: RecallView) {}
         override fun updatePanel(view: SurvivalView) { panels += view }
         override fun updateDivinationPanel(view: DivinationView) { divinationPanels += view }
+        override fun updateRoleClaimPanel(view: RoleClaimView) { roleClaimPanels += view }
         override fun promptChoice(view: ChoiceView): String = error("not expected")
         override fun promptFreeText(title: String, description: String): String = error("not expected")
         override fun watchEpilogue(chronicles: List<ChronicleView>) {}
@@ -148,5 +152,67 @@ class GameNoteTest {
         GameEvent.DiscussionStarted.send(1, AllPlayers(gameSetup.playerManager))
 
         assertEquals(countAfterStart, io.divinationPanels.size)
+    }
+
+    @Test
+    fun `ROLE_CLAIM statement appears in role claim panel`() {
+        val io = CapturingIO()
+        val gameSetup = createGameWithHuman(io, "V2" to Role.VILLAGER, "Wolf" to Role.WEREWOLF)
+        InitialPhase(gameSetup.playerManager, gameSetup.oracle).proceed()
+        val v2 = gameSetup.playerManager.allPlayers.single { it.name == "V2" }
+        val allPlayers = AllPlayers(gameSetup.playerManager)
+
+        GameEvent.StatementMade.send(1, "V2", Statement.RoleClaim(v2, Role.SEER), allPlayers)
+
+        assertEquals(
+            listOf(RoleClaimEntry("V2", Role.SEER.displayName)),
+            io.roleClaimPanels.last().roleClaims,
+        )
+    }
+
+    @Test
+    fun `DivinationReport is treated as a seer claim in the role claim panel`() {
+        val io = CapturingIO()
+        val gameSetup = createGameWithHuman(io, "V2" to Role.VILLAGER, "Wolf" to Role.WEREWOLF)
+        InitialPhase(gameSetup.playerManager, gameSetup.oracle).proceed()
+        val v2 = gameSetup.playerManager.allPlayers.single { it.name == "V2" }
+        val wolf = gameSetup.playerManager.allPlayers.single { it.name == "Wolf" }
+        val allPlayers = AllPlayers(gameSetup.playerManager)
+
+        GameEvent.StatementMade.send(1, "V2", Statement.DivinationReport(v2, wolf, DivineResult.WEREWOLF), allPlayers)
+
+        assertEquals(
+            listOf(RoleClaimEntry("V2", Role.SEER.displayName)),
+            io.roleClaimPanels.last().roleClaims,
+        )
+    }
+
+    @Test
+    fun `MediumReport is treated as a medium claim in the role claim panel`() {
+        val io = CapturingIO()
+        val gameSetup = createGameWithHuman(io, "V2" to Role.VILLAGER, "Wolf" to Role.WEREWOLF)
+        InitialPhase(gameSetup.playerManager, gameSetup.oracle).proceed()
+        val v2 = gameSetup.playerManager.allPlayers.single { it.name == "V2" }
+        val wolf = gameSetup.playerManager.allPlayers.single { it.name == "Wolf" }
+        val allPlayers = AllPlayers(gameSetup.playerManager)
+
+        GameEvent.StatementMade.send(1, "V2", Statement.MediumReport(v2, wolf, MediumResult.WEREWOLF), allPlayers)
+
+        assertEquals(
+            listOf(RoleClaimEntry("V2", Role.MEDIUM.displayName)),
+            io.roleClaimPanels.last().roleClaims,
+        )
+    }
+
+    @Test
+    fun `role claim panel is not updated for unrelated events`() {
+        val io = CapturingIO()
+        val gameSetup = createGameWithHuman(io, "V2" to Role.VILLAGER, "Wolf" to Role.WEREWOLF)
+        InitialPhase(gameSetup.playerManager, gameSetup.oracle).proceed()
+        val countAfterStart = io.roleClaimPanels.size
+
+        GameEvent.DiscussionStarted.send(1, AllPlayers(gameSetup.playerManager))
+
+        assertEquals(countAfterStart, io.roleClaimPanels.size)
     }
 }

--- a/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
@@ -5,8 +5,7 @@ import werewolf.human.HumanPlayer
 import werewolf.human.HumanIO
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
-import werewolf.view.RoleClaimView
-import werewolf.view.SurvivalView
+import werewolf.view.PlayerStatusView
 import werewolf.phase.Conclave
 import werewolf.phase.Epilogue
 import werewolf.phase.OpenDiscussion
@@ -20,9 +19,8 @@ class HumanPlayerEpilogueTest {
     private class SpeakingIO : HumanIO {
         var capturedChronicles: List<ChronicleView> = emptyList()
         override fun display(view: RecallView) {}
-        override fun updatePanel(view: SurvivalView) {}
+        override fun updatePlayerStatusPanel(view: PlayerStatusView) {}
         override fun updateDivinationPanel(view: DivinationView) {}
-        override fun updateRoleClaimPanel(view: RoleClaimView) {}
         override fun promptFreeText(title: String, description: String): String = "human speaks"
         override fun promptChoice(view: ChoiceView): String = view.options.first()
         override fun watchEpilogue(chronicles: List<ChronicleView>) { capturedChronicles = chronicles }

--- a/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
@@ -5,6 +5,7 @@ import werewolf.human.HumanPlayer
 import werewolf.human.HumanIO
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
+import werewolf.view.RoleClaimView
 import werewolf.view.SurvivalView
 import werewolf.phase.Conclave
 import werewolf.phase.Epilogue
@@ -21,6 +22,7 @@ class HumanPlayerEpilogueTest {
         override fun display(view: RecallView) {}
         override fun updatePanel(view: SurvivalView) {}
         override fun updateDivinationPanel(view: DivinationView) {}
+        override fun updateRoleClaimPanel(view: RoleClaimView) {}
         override fun promptFreeText(title: String, description: String): String = "human speaks"
         override fun promptChoice(view: ChoiceView): String = view.options.first()
         override fun watchEpilogue(chronicles: List<ChronicleView>) { capturedChronicles = chronicles }

--- a/src/test/kotlin/werewolf/HumanPlayerTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerTest.kt
@@ -16,8 +16,7 @@ import werewolf.human.HumanIO
 import werewolf.human.HumanPlayer
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
-import werewolf.view.RoleClaimView
-import werewolf.view.SurvivalView
+import werewolf.view.PlayerStatusView
 
 class HumanPlayerTest {
 
@@ -31,9 +30,8 @@ class HumanPlayerTest {
         var capturedChronicles: List<ChronicleView> = emptyList()
 
         override fun display(view: RecallView) { displayedViews += view }
-        override fun updatePanel(view: SurvivalView) {}
+        override fun updatePlayerStatusPanel(view: PlayerStatusView) {}
         override fun updateDivinationPanel(view: DivinationView) {}
-        override fun updateRoleClaimPanel(view: RoleClaimView) {}
         override fun promptChoice(view: ChoiceView): String {
             promptedChoices += view
             return queue.removeFirst()

--- a/src/test/kotlin/werewolf/HumanPlayerTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerTest.kt
@@ -16,6 +16,7 @@ import werewolf.human.HumanIO
 import werewolf.human.HumanPlayer
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
+import werewolf.view.RoleClaimView
 import werewolf.view.SurvivalView
 
 class HumanPlayerTest {
@@ -32,6 +33,7 @@ class HumanPlayerTest {
         override fun display(view: RecallView) { displayedViews += view }
         override fun updatePanel(view: SurvivalView) {}
         override fun updateDivinationPanel(view: DivinationView) {}
+        override fun updateRoleClaimPanel(view: RoleClaimView) {}
         override fun promptChoice(view: ChoiceView): String {
             promptedChoices += view
             return queue.removeFirst()


### PR DESCRIPTION
## 概要

- Web UI に役職申告状況パネルを追加した
- パネル表示用に `RoleClaimView` を新設し、既存の `updatePanel`/`updateDivinationPanel` と同様の仕組みで `HumanIO` 経由で更新するようにした
- 占い結果報告・霊媒結果報告は、パネル上ではそれぞれ占い師・霊能者のCO（役職申告）とみなして統合表示する

Closes #256

## Test plan

- [x] `./gradlew check`