### PR TITLE
Allow selecting Anthropic model (Haiku/Sonnet/Opus) from the lodge menu

### DIFF
--- a/src/main/kotlin/werewolf/Main.kt
+++ b/src/main/kotlin/werewolf/Main.kt
@@ -31,7 +31,10 @@ fun main() {
 }
 
 private fun selectLodge(connection: HumanConnection): Lodge {
-    println("Lodgeを選択してください: AllHuman / RollerCPU / RandomCPU / HonestCPU / RoleAwareCPU / PocAI / Gemini / Anthropic")
+    println(
+        "Lodgeを選択してください: AllHuman / RollerCPU / RandomCPU / HonestCPU / RoleAwareCPU / " +
+            "PocAI / Gemini / Haiku / Sonnet / Opus",
+    )
     return when (readLine()?.trim()) {
         "RollerCPU"    -> RollerCpuLodge(connection)
         "RandomCPU"    -> RandomCpuLodge(connection)
@@ -39,7 +42,9 @@ private fun selectLodge(connection: HumanConnection): Lodge {
         "RoleAwareCPU" -> RoleAwareCpuLodge(connection)
         "PocAI"        -> PocAiLodge(connection)
         "Gemini"       -> GeminiLodge(connection)
-        "Anthropic"    -> AnthropicLodge(connection)
+        "Haiku"        -> AnthropicLodge(connection, AnthropicLodge.HAIKU_MODEL)
+        "Sonnet"       -> AnthropicLodge(connection, AnthropicLodge.SONNET_MODEL)
+        "Opus"         -> AnthropicLodge(connection, AnthropicLodge.OPUS_MODEL)
         else           -> SmallLodge(connection)
     }
 }

--- a/src/main/kotlin/werewolf/lodge/AnthropicLodge.kt
+++ b/src/main/kotlin/werewolf/lodge/AnthropicLodge.kt
@@ -3,10 +3,15 @@ package werewolf.lodge
 import werewolf.ai.LanguageModel
 import werewolf.ai.anthropic.AnthropicLanguageModel
 
-class AnthropicLodge(humanConnection: HumanConnection) : AiLodge(humanConnection) {
-    override fun createLanguageModel(): LanguageModel = AnthropicLanguageModel(HAIKU_MODEL)
+class AnthropicLodge(
+    humanConnection: HumanConnection,
+    private val model: String = HAIKU_MODEL,
+) : AiLodge(humanConnection) {
+    override fun createLanguageModel(): LanguageModel = AnthropicLanguageModel(model)
 
     companion object {
-        private const val HAIKU_MODEL = "claude-haiku-4-5-20251001"
+        const val HAIKU_MODEL = "claude-haiku-4-5-20251001"
+        const val SONNET_MODEL = "claude-sonnet-5"
+        const val OPUS_MODEL = "claude-opus-4-8"
     }
 }


### PR DESCRIPTION
## Summary
- `AnthropicLodge` に `model` をコンストラクタ引数として追加し、外部からモデルを指定できるようにした
- `Main.kt` のLodge選択で `Haiku` / `Sonnet` / `Opus` を選べるようにし、それぞれ対応するモデルで `AnthropicLodge` を生成するようにした
- `Anthropic` という冗長なプレフィックスをやめ、タイプミス時に `SmallLodge` に落ちにくい短いキーワードにした

## Test plan
- [x] `./gradlew compileKotlin`
- [x] `./gradlew detekt`
- [x] `./gradlew check`（コミット時のpre-commitフックで実行済み）

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)