### PR TITLE
Ignore .scratch/ scratch directory in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ bin/
 ### Frontend ###
 frontend/svelte/node_modules/
 frontend/svelte/dist/
+
+### Scratch ###
+.scratch/


### PR DESCRIPTION
## 概要

作業用の一時ファイルを置く`.scratch/`ディレクトリが追跡対象外のまま`git status`に表示され続けていたため、`.gitignore`に追加した。

Closes #269

## テスト計画

- [x] `./gradlew check`が成功
- [x] `.scratch/`が`git status`に表示されなくなることを確認