### PR TITLE
Prevent accidental message submission on Enter key in web UI

### DIFF
--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -154,7 +154,6 @@
             type="text"
             bind:value={speakText}
             placeholder="発言を入力..."
-            on:keydown={(e) => e.key === 'Enter' && speak()}
           />
           <button on:click={speak}>送信</button>
         </div>


### PR DESCRIPTION
## 変更内容
Web UIの発言入力欄で、Enterキー押下時に送信されないようにした。送信は「送信」ボタンのクリックのみで行う。

## 理由
入力途中にEnterキーを押すとうっかり発言が送信されてしまう事故が起きていたため。

Closes #271