### PR TITLE
Prevent the Seer from divining the same player twice

### DIFF
--- a/src/main/kotlin/werewolf/cpu/SeerCpuStrategy.kt
+++ b/src/main/kotlin/werewolf/cpu/SeerCpuStrategy.kt
@@ -15,10 +15,7 @@ class SeerCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Rol
     }
 
     override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
-        when (context) {
-            is SelectionContext.Divine -> selectDivineTarget(candidates)
-            else -> candidates.random()
-        }
+        candidates.random()
 
     private fun nextUnreportedDivination(): GameEvent.Divined? {
         val reported = reportedTargets()
@@ -29,10 +26,4 @@ class SeerCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Rol
         self.knowledge.filterIsInstance<GameEvent.StatementMade>()
             .map { it.statement }.filterIsInstance<Statement.DivinationReport>()
             .filter { it.claimant === self }.map { it.target }.toSet()
-
-    private fun selectDivineTarget(candidates: List<Player>): Player {
-        val divined = self.knowledge.filterIsInstance<GameEvent.Divined>().map { it.target }.toSet()
-        val undivined = candidates.filter { it !in divined }
-        return if (undivined.isNotEmpty()) undivined.random() else candidates.random()
-    }
 }

--- a/src/main/kotlin/werewolf/game/GameEvent.kt
+++ b/src/main/kotlin/werewolf/game/GameEvent.kt
@@ -63,6 +63,16 @@ sealed class GameEvent : Recallable() {
     }
 
     @ConsistentCopyVisibility
+    data class NoDivineTargetLeft private constructor(private val recipient: Player) : GameEvent() {
+        override val title = "占い結果"
+        override fun body() = "占っていない相手がいないため、占うことができませんでした。"
+        override val recipients: Notifiable = recipient
+        companion object {
+            fun send(recipient: Player) = NoDivineTargetLeft(recipient).dispatch()
+        }
+    }
+
+    @ConsistentCopyVisibility
     data class MediumRevealed private constructor(val target: Player, val result: MediumResult, private val recipient: Player) : GameEvent() {
         override val title = "霊視結果"
         override fun body() = "${target.name}は「${result.displayName}」です。"

--- a/src/main/kotlin/werewolf/game/Role.kt
+++ b/src/main/kotlin/werewolf/game/Role.kt
@@ -13,8 +13,15 @@ enum class Role(val displayName: String, val side: Side, val divineResult: Divin
     SEER("占い師", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
         override fun firstNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction =
             NightAction.FirstNightDivine
-        override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction =
-            NightAction.Divine(self.selectTarget(SelectionContext.Divine(self, players)))
+        override fun normalNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction {
+            val alreadyDivined = knowledge.filterIsInstance<GameEvent.Divined>().map { it.target }
+            val context = SelectionContext.Divine(self, players, alreadyDivined)
+            if (context.candidates().isEmpty()) {
+                GameEvent.NoDivineTargetLeft.send(self)
+                return NightAction.None
+            }
+            return NightAction.Divine(self.selectTarget(context))
+        }
     },
     MEDIUM("霊能者", Side.CITIZEN, DivineResult.NOT_WEREWOLF, MediumResult.NOT_WEREWOLF) {
         override fun firstNightAction(self: Player, players: List<Player>, knowledge: List<GameEvent>): NightAction =

--- a/src/main/kotlin/werewolf/game/SelectionContext.kt
+++ b/src/main/kotlin/werewolf/game/SelectionContext.kt
@@ -8,9 +8,9 @@ sealed class SelectionContext(val title: String, val description: String) {
         override fun candidates() = players.filterNot { it === self || it in allies }
     }
 
-    class Divine(private val self: Player, private val players: List<Player>)
+    class Divine(private val self: Player, private val players: List<Player>, private val alreadyDivined: List<Player>)
         : SelectionContext("夜の行動", "占う対象を選んでください") {
-        override fun candidates() = players.filterNot { it === self }
+        override fun candidates() = players.filterNot { it === self || it in alreadyDivined }
     }
 
     class Guard(private val self: Player, private val players: List<Player>)

--- a/src/test/kotlin/werewolf/NightPhaseTest.kt
+++ b/src/test/kotlin/werewolf/NightPhaseTest.kt
@@ -115,6 +115,27 @@ class NightPhaseTest {
     }
 
     @Test
+    fun `seer is notified when every other player has already been divined`() {
+        val villager1 = ReceivingPlayer(Role.VILLAGER, "V1")
+        val villager2 = ReceivingPlayer(Role.VILLAGER, "V2")
+        val wolf = FixedTargetPlayer(Role.WEREWOLF, "Wolf", villager1)
+        val seer = RecordingPlayer(Role.SEER, "Seer")
+        val setup = TestLodge(
+            wolf to Role.WEREWOLF, seer to Role.SEER,
+            villager1 to Role.VILLAGER, villager2 to Role.VILLAGER,
+        ).create()
+        setup.oracle.divine(seer, wolf)
+        setup.oracle.divine(seer, villager1)
+        setup.oracle.divine(seer, villager2)
+
+        NightPhase(setup.playerManager, setup.oracle, 3).proceed()
+
+        val divined = seer.received.filterIsInstance<GameEvent.Divined>()
+        assertEquals(3, divined.size)
+        assertTrue(seer.received.any { it is GameEvent.NoDivineTargetLeft })
+    }
+
+    @Test
     fun `guard protecting different player does not prevent wolf attack`() {
         val villager1 = ReceivingPlayer(Role.VILLAGER, "V1")
         val villager2 = ReceivingPlayer(Role.VILLAGER, "V2")

--- a/src/test/kotlin/werewolf/SelectionContextDivineTest.kt
+++ b/src/test/kotlin/werewolf/SelectionContextDivineTest.kt
@@ -1,0 +1,47 @@
+package werewolf
+
+import werewolf.game.*
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SelectionContextDivineTest {
+
+    @Test
+    fun `excludes self from candidates`() {
+        val seer = NothingPlayer(Role.SEER, "Seer")
+        val villager = NothingPlayer(Role.VILLAGER, "Villager")
+        val players = listOf(seer, villager)
+
+        val candidates = SelectionContext.Divine(seer, players, emptyList()).candidates()
+
+        assertFalse(seer in candidates)
+        assertTrue(villager in candidates)
+    }
+
+    @Test
+    fun `excludes already divined players from candidates`() {
+        val seer = NothingPlayer(Role.SEER, "Seer")
+        val villager1 = NothingPlayer(Role.VILLAGER, "V1")
+        val villager2 = NothingPlayer(Role.VILLAGER, "V2")
+        val players = listOf(seer, villager1, villager2)
+
+        val candidates = SelectionContext.Divine(seer, players, alreadyDivined = listOf(villager1)).candidates()
+
+        assertEquals(listOf(villager2), candidates)
+    }
+
+    @Test
+    fun `includes all non-self players when no one is divined yet`() {
+        val seer = NothingPlayer(Role.SEER, "Seer")
+        val villager1 = NothingPlayer(Role.VILLAGER, "V1")
+        val villager2 = NothingPlayer(Role.VILLAGER, "V2")
+        val players = listOf(seer, villager1, villager2)
+
+        val candidates = SelectionContext.Divine(seer, players, emptyList()).candidates()
+
+        assertEquals(listOf(villager1, villager2), candidates)
+    }
+}


### PR DESCRIPTION
## 変更内容
占い師が一度占ったことのある生存者を、以降の占い対象として選べないようにした。生存者全員が占い済みで占える対象がいない場合は、対象選択を行わず、占える相手がいなかった旨を占い師に通知する。

エンジン側(SelectionContext.Divine)で占い済みの除外を行うようになったため、SeerCpuStrategy内にあった重複回避ロジックは不要になり削除した。

## 理由
占い師は一度占った相手の役職を既に知っているため、同じ相手を再度占う情報的価値はない。現状のルールでは禁止されていないため、AIがなぜか過去に占った相手を再度占う無駄な行動を取ることがあった。人間プレイヤーにとってもうっかり同じ相手を二度占ってしまうミスを防げる。

## テスト
- `SelectionContextDivineTest.kt`（新規）: 占い済みプレイヤーが候補から除外されることを確認
- `NightPhaseTest.kt`: 生存者全員が占い済みの場合に`GameEvent.NoDivineTargetLeft`が通知され、新たな占いが発生しないことを確認
- 手動でもWeb UI上で動作確認済み

Closes #272