### PR TITLE
Restrict selectable CO (role-claim) options based on player's role and prior claims

### DIFF
--- a/src/main/kotlin/werewolf/ai/AiPlayer.kt
+++ b/src/main/kotlin/werewolf/ai/AiPlayer.kt
@@ -17,6 +17,7 @@ import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
 import werewolf.game.StatementType
+import werewolf.game.selectableTypes
 
 class AiPlayer(
     role: Role,
@@ -37,16 +38,16 @@ class AiPlayer(
         _myMemories.add(event)
     }
 
-    override fun speak(context: DiscussionContext): Claim {
-        val instruction = statementFormat.buildInstruction(context)
+    override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim {
+        val instruction = statementFormat.buildInstruction(context, claimableRoles)
         repeat(2) {
             val completion = prompt(instruction)
             try {
                 val parsed = statementFormat.parse(completion.text)
-                val type = context.availableTypes.singleOrNull { it.displayName == parsed.typeLabel }
+                val type = context.selectableTypes(claimableRoles).singleOrNull { it.displayName == parsed.typeLabel }
                     ?: throw InvalidAiInputException("選択できない発言の種類です: ${parsed.typeLabel}")
                 val claim = Claim(
-                    this, context, buildStatement(context, type, parsed.content),
+                    this, context, buildStatement(context, type, parsed.content, claimableRoles), claimableRoles,
                     intentForRecall = parsed.intent,
                     intentForChronicle = withMetadata(parsed.intent, completion.metadata),
                 )
@@ -60,7 +61,12 @@ class AiPlayer(
         return FallbackClaim(this, context).also { _myMemories.add(it) }
     }
 
-    private fun buildStatement(context: DiscussionContext, type: StatementType, content: String): Statement = when (type) {
+    private fun buildStatement(
+        context: DiscussionContext,
+        type: StatementType,
+        content: String,
+        claimableRoles: Set<Role>,
+    ): Statement = when (type) {
         StatementType.PLAIN -> Statement.Plain(content)
         StatementType.DIVINATION_REPORT -> {
             val (targetName, resultLabel, comment) = statementFormat.extractReportParts(content)
@@ -76,7 +82,7 @@ class AiPlayer(
         }
         StatementType.ROLE_CLAIM -> {
             val (roleName, comment) = statementFormat.extractRoleClaimParts(content)
-            val role = Role.entries.singleOrNull { it.displayName == roleName }
+            val role = claimableRoles.singleOrNull { it.displayName == roleName }
                 ?: throw InvalidAiInputException("役職申告の役職が不正です: $roleName")
             Statement.RoleClaim(this, role, comment)
         }

--- a/src/main/kotlin/werewolf/ai/StatementFormat.kt
+++ b/src/main/kotlin/werewolf/ai/StatementFormat.kt
@@ -5,13 +5,14 @@ import werewolf.game.DivineResult
 import werewolf.game.MediumResult
 import werewolf.game.Role
 import werewolf.game.StatementType
+import werewolf.game.selectableTypes
 
 data class ParsedStatement(val content: String, val typeLabel: String, val intent: String)
 
 class StatementFormat {
-    fun buildInstruction(context: DiscussionContext): String {
-        val types = availableTypes(context)
-        val typeFormats = types.joinToString("\n") { "・${formatDescription(it)}" }
+    fun buildInstruction(context: DiscussionContext, claimableRoles: Set<Role>): String {
+        val types = availableTypes(context, claimableRoles)
+        val typeFormats = types.joinToString("\n") { "・${formatDescription(it, claimableRoles)}" }
         // trimIndent()はテンプレート内の複数行にまたがる補間値には対応できないため、行単位で組み立てる
         return listOf(
             "【${context.title}】${context.description}",
@@ -27,8 +28,8 @@ class StatementFormat {
         ).joinToString("\n")
     }
 
-    private fun availableTypes(context: DiscussionContext): List<StatementType> =
-        StatementType.entries.filter { it in context.availableTypes }
+    private fun availableTypes(context: DiscussionContext, claimableRoles: Set<Role>): List<StatementType> =
+        StatementType.entries.filter { it in context.selectableTypes(claimableRoles) }
 
     fun parse(input: String): ParsedStatement {
         val (body, intent) = parseBodyAndIntent(input)
@@ -52,14 +53,14 @@ class StatementFormat {
         return typeLabel to content
     }
 
-    private fun formatDescription(type: StatementType): String = when (type) {
+    private fun formatDescription(type: StatementType, claimableRoles: Set<Role>): String = when (type) {
         StatementType.PLAIN -> "${type.displayName}：ゲーム上の発言（50文字以内）"
         StatementType.DIVINATION_REPORT ->
             "${type.displayName}：対象のプレイヤー名/結果（${DivineResult.entries.joinToString("か") { it.displayName }}）/補足コメント（省略可）"
         StatementType.MEDIUM_REPORT ->
             "${type.displayName}：対象のプレイヤー名/結果（${MediumResult.entries.joinToString("か") { it.displayName }}）/補足コメント（省略可）"
         StatementType.ROLE_CLAIM ->
-            "${type.displayName}：申告する役職名（${Role.entries.joinToString("か") { it.displayName }}）/補足コメント（省略可）"
+            "${type.displayName}：申告する役職名（${claimableRoles.joinToString("か") { it.displayName }}）/補足コメント（省略可）"
     }
 
     fun extractReportParts(content: String): Triple<String, String, String> {

--- a/src/main/kotlin/werewolf/cpu/HonestCpuPlayer.kt
+++ b/src/main/kotlin/werewolf/cpu/HonestCpuPlayer.kt
@@ -16,9 +16,9 @@ class HonestCpuPlayer(role: Role, override val name: String) : CpuPlayer(role) {
         if (!event.isPublicKnowledge()) unspoken.add(event)
     }
 
-    override fun speak(context: DiscussionContext): Claim {
+    override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim {
         val statement = if (unspoken.isEmpty()) Statement.Plain("") else Statement.Plain(unspoken.removeFirst().body())
-        return Claim(this, context, statement, "受け取った非公開情報を順番に開示")
+        return Claim(this, context, statement, claimableRoles, "受け取った非公開情報を順番に開示")
     }
 
     override fun choose(context: SelectionContext): Choice {

--- a/src/main/kotlin/werewolf/cpu/HunterCpuStrategy.kt
+++ b/src/main/kotlin/werewolf/cpu/HunterCpuStrategy.kt
@@ -5,11 +5,12 @@ import werewolf.game.Player
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
+import werewolf.game.StatementType
 
 class HunterCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.HUNTER, CitizenVoting(self)) {
     private val query = KnowledgeQuery(self)
 
-    override fun buildStatement(context: DiscussionContext) = Statement.Plain("")
+    override fun buildStatement(context: DiscussionContext, availableTypes: Set<StatementType>) = Statement.Plain("")
 
     override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
         when (context) {

--- a/src/main/kotlin/werewolf/cpu/MadmanCpuStrategy.kt
+++ b/src/main/kotlin/werewolf/cpu/MadmanCpuStrategy.kt
@@ -8,14 +8,17 @@ import werewolf.game.Player
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
+import werewolf.game.StatementType
 
 class MadmanCpuStrategy(
     self: RoleAwareCpuPlayer,
     private val impersonating: Role = listOf(Role.SEER, Role.MEDIUM).random(),
 ) : RoleAwareCpuStrategy(self, Role.MADMAN, WerewolfVoting(self)) {
 
-    override fun buildStatement(context: DiscussionContext): Statement {
+    override fun buildStatement(context: DiscussionContext, availableTypes: Set<StatementType>): Statement {
         if (context.round > 1) return Statement.Plain("")
+        val impersonatedType = if (impersonating == Role.SEER) StatementType.DIVINATION_REPORT else StatementType.MEDIUM_REPORT
+        if (impersonatedType !in availableTypes) return Statement.Plain("")
         return if (impersonating == Role.SEER) fakeSeerStatement(context) else fakeMediumStatement()
     }
 

--- a/src/main/kotlin/werewolf/cpu/MediumCpuStrategy.kt
+++ b/src/main/kotlin/werewolf/cpu/MediumCpuStrategy.kt
@@ -6,10 +6,12 @@ import werewolf.game.Player
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
+import werewolf.game.StatementType
 
 class MediumCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.MEDIUM, CitizenVoting(self)) {
 
-    override fun buildStatement(context: DiscussionContext): Statement {
+    override fun buildStatement(context: DiscussionContext, availableTypes: Set<StatementType>): Statement {
+        if (StatementType.MEDIUM_REPORT !in availableTypes) return Statement.Plain("")
         val next = nextUnreportedReveal() ?: return Statement.Plain("")
         return Statement.MediumReport(self, next.target, next.result)
     }

--- a/src/main/kotlin/werewolf/cpu/RandomCpuPlayer.kt
+++ b/src/main/kotlin/werewolf/cpu/RandomCpuPlayer.kt
@@ -10,6 +10,7 @@ import werewolf.game.Statement
 
 class RandomCpuPlayer(role: Role, override val name: String) : CpuPlayer(role) {
     override fun choose(context: SelectionContext): Choice = Choice(this, context, context.candidates().random(), "ランダム選択")
-    override fun speak(context: DiscussionContext): Claim = Claim(this, context, Statement.Plain(""), "発言戦略なし")
+    override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim =
+        Claim(this, context, Statement.Plain(""), claimableRoles, "発言戦略なし")
     override fun onReceive(event: GameEvent) { /* does not use received events */ }
 }

--- a/src/main/kotlin/werewolf/cpu/RoleAwareCpuPlayer.kt
+++ b/src/main/kotlin/werewolf/cpu/RoleAwareCpuPlayer.kt
@@ -6,6 +6,7 @@ import werewolf.game.DiscussionContext
 import werewolf.game.GameEvent
 import werewolf.game.Role
 import werewolf.game.SelectionContext
+import werewolf.game.selectableTypes
 
 class RoleAwareCpuPlayer(val myRole: Role, override val name: String) : CpuPlayer(myRole) {
     private val _knowledge = mutableListOf<GameEvent>()
@@ -17,6 +18,9 @@ class RoleAwareCpuPlayer(val myRole: Role, override val name: String) : CpuPlaye
     ).single { it.appliesTo() }
 
     override fun onReceive(event: GameEvent) { _knowledge.add(event) }
-    override fun speak(context: DiscussionContext) = Claim(this, context, strategy.buildStatement(context), "役職戦略に基づく発言")
+    override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim {
+        val statement = strategy.buildStatement(context, context.selectableTypes(claimableRoles))
+        return Claim(this, context, statement, claimableRoles, "役職戦略に基づく発言")
+    }
     override fun choose(context: SelectionContext) = Choice(this, context, strategy.selectTarget(context), "戦略による選択")
 }

--- a/src/main/kotlin/werewolf/cpu/RoleAwareCpuStrategy.kt
+++ b/src/main/kotlin/werewolf/cpu/RoleAwareCpuStrategy.kt
@@ -5,6 +5,7 @@ import werewolf.game.Player
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
+import werewolf.game.StatementType
 
 abstract class RoleAwareCpuStrategy(
     protected val self: RoleAwareCpuPlayer,
@@ -13,7 +14,7 @@ abstract class RoleAwareCpuStrategy(
 ) {
     fun appliesTo() = self.myRole == targetRole
 
-    abstract fun buildStatement(context: DiscussionContext): Statement
+    abstract fun buildStatement(context: DiscussionContext, availableTypes: Set<StatementType>): Statement
 
     fun selectTarget(context: SelectionContext): Player {
         val candidates = context.candidates()

--- a/src/main/kotlin/werewolf/cpu/RollerCpuPlayer.kt
+++ b/src/main/kotlin/werewolf/cpu/RollerCpuPlayer.kt
@@ -16,6 +16,7 @@ class RollerCpuPlayer(role: Role, override val name: String) : CpuPlayer(role) {
         return Choice(this, context, candidates[selectCount++ % candidates.size], "順番通りに選択")
     }
 
-    override fun speak(context: DiscussionContext): Claim = Claim(this, context, Statement.Plain(""), "発言戦略なし")
+    override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim =
+        Claim(this, context, Statement.Plain(""), claimableRoles, "発言戦略なし")
     override fun onReceive(event: GameEvent) { /* does not use received events */ }
 }

--- a/src/main/kotlin/werewolf/cpu/SeerCpuStrategy.kt
+++ b/src/main/kotlin/werewolf/cpu/SeerCpuStrategy.kt
@@ -6,10 +6,12 @@ import werewolf.game.Player
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
+import werewolf.game.StatementType
 
 class SeerCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.SEER, SeerVoting(self)) {
 
-    override fun buildStatement(context: DiscussionContext): Statement {
+    override fun buildStatement(context: DiscussionContext, availableTypes: Set<StatementType>): Statement {
+        if (StatementType.DIVINATION_REPORT !in availableTypes) return Statement.Plain("")
         val next = nextUnreportedDivination() ?: return Statement.Plain("")
         return Statement.DivinationReport(self, next.target, next.result)
     }

--- a/src/main/kotlin/werewolf/cpu/VillagerCpuStrategy.kt
+++ b/src/main/kotlin/werewolf/cpu/VillagerCpuStrategy.kt
@@ -5,10 +5,11 @@ import werewolf.game.Player
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
+import werewolf.game.StatementType
 
 class VillagerCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.VILLAGER, CitizenVoting(self)) {
 
-    override fun buildStatement(context: DiscussionContext) = Statement.Plain("")
+    override fun buildStatement(context: DiscussionContext, availableTypes: Set<StatementType>) = Statement.Plain("")
 
     override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
         candidates.random()

--- a/src/main/kotlin/werewolf/cpu/WerewolfCpuStrategy.kt
+++ b/src/main/kotlin/werewolf/cpu/WerewolfCpuStrategy.kt
@@ -5,11 +5,12 @@ import werewolf.game.Player
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
+import werewolf.game.StatementType
 
 class WerewolfCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.WEREWOLF, WerewolfVoting(self)) {
     private val query = KnowledgeQuery(self)
 
-    override fun buildStatement(context: DiscussionContext) = Statement.Plain("")
+    override fun buildStatement(context: DiscussionContext, availableTypes: Set<StatementType>) = Statement.Plain("")
 
     override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
         when (context) {

--- a/src/main/kotlin/werewolf/game/Claim.kt
+++ b/src/main/kotlin/werewolf/game/Claim.kt
@@ -9,8 +9,11 @@ sealed class Claim(
     private val intentForChronicle: String,
 ) : Recallable() {
     init {
-        require(statement.type in context.selectableTypes(claimableRoles)) {
+        require(statement.type in context.availableTypes) {
             "${statement.type} is not available in ${context.title}"
+        }
+        require(statement.type in context.selectableTypes(claimableRoles)) {
+            "${statement.type} is not available for ${speaker.name} now. context:${context.title}, claimable roles: $claimableRoles."
         }
         if (statement is Statement.RoleClaim) {
             require(statement.role in claimableRoles) {

--- a/src/main/kotlin/werewolf/game/Claim.kt
+++ b/src/main/kotlin/werewolf/game/Claim.kt
@@ -4,11 +4,19 @@ sealed class Claim(
     val speaker: Player,
     val context: DiscussionContext,
     val statement: Statement,
+    claimableRoles: Set<Role>,
     private val intentForRecall: String,
     private val intentForChronicle: String,
 ) : Recallable() {
     init {
-        require(statement.type in context.availableTypes) { "${statement.type} is not available in ${context.title}" }
+        require(statement.type in context.selectableTypes(claimableRoles)) {
+            "${statement.type} is not available in ${context.title}"
+        }
+        if (statement is Statement.RoleClaim) {
+            require(statement.role in claimableRoles) {
+                "${statement.role} is not claimable by ${speaker.name}"
+            }
+        }
     }
 
     override fun toRecallView() = RecallView.SelfAction(context.title, statement.text(), intentForRecall)
@@ -19,16 +27,19 @@ sealed class Claim(
             speaker: Player,
             context: DiscussionContext,
             statement: Statement,
+            claimableRoles: Set<Role>,
             intent: String,
-        ): Claim = NormalClaim(speaker, context, statement, intent, intent)
+        ): Claim = NormalClaim(speaker, context, statement, claimableRoles, intent, intent)
 
+        @Suppress("LongParameterList")
         operator fun invoke(
             speaker: Player,
             context: DiscussionContext,
             statement: Statement,
+            claimableRoles: Set<Role>,
             intentForRecall: String,
             intentForChronicle: String,
-        ): Claim = NormalClaim(speaker, context, statement, intentForRecall, intentForChronicle)
+        ): Claim = NormalClaim(speaker, context, statement, claimableRoles, intentForRecall, intentForChronicle)
     }
 }
 
@@ -36,12 +47,13 @@ private class NormalClaim(
     speaker: Player,
     context: DiscussionContext,
     statement: Statement,
+    claimableRoles: Set<Role>,
     intentForRecall: String,
     intentForChronicle: String,
-) : Claim(speaker, context, statement, intentForRecall, intentForChronicle)
+) : Claim(speaker, context, statement, claimableRoles, intentForRecall, intentForChronicle)
 
 class FallbackClaim(speaker: Player, context: DiscussionContext) : Claim(
-    speaker, context, Statement.Plain(""),
+    speaker, context, Statement.Plain(""), emptySet(),
     intentForRecall = "回答取得に失敗したため空文字を返却",
     intentForChronicle = "回答取得に失敗したため空文字を返却",
 )

--- a/src/main/kotlin/werewolf/game/ClaimedRole.kt
+++ b/src/main/kotlin/werewolf/game/ClaimedRole.kt
@@ -1,7 +1,7 @@
 package werewolf.game
 
-class ClaimedRole(events: List<GameEvent>) {
-    private val statements = events.filterIsInstance<GameEvent.StatementMade>().map { it.statement }
+class ClaimedRole(memories: List<Recallable>) {
+    private val statements = memories.filterIsInstance<GameEvent.StatementMade>().map { it.statement }
 
     // 複数回申告された場合は最後の申告を優先する（人狼・狂人の騙り替えを想定）
     @Suppress("FunctionMinLength")

--- a/src/main/kotlin/werewolf/game/ClaimedRole.kt
+++ b/src/main/kotlin/werewolf/game/ClaimedRole.kt
@@ -1,0 +1,16 @@
+package werewolf.game
+
+class ClaimedRole(events: List<GameEvent>) {
+    private val statements = events.filterIsInstance<GameEvent.StatementMade>().map { it.statement }
+
+    // 複数回申告された場合は最後の申告を優先する（人狼・狂人の騙り替えを想定）
+    @Suppress("FunctionMinLength")
+    fun of(player: Player): Role? = statements.mapNotNull { roleFrom(it, player) }.lastOrNull()
+
+    private fun roleFrom(statement: Statement, player: Player): Role? = when {
+        statement is Statement.RoleClaim && statement.claimant === player -> statement.role
+        statement is Statement.DivinationReport && statement.claimant === player -> Role.SEER
+        statement is Statement.MediumReport && statement.claimant === player -> Role.MEDIUM
+        else -> null
+    }
+}

--- a/src/main/kotlin/werewolf/game/DiscussionContext.kt
+++ b/src/main/kotlin/werewolf/game/DiscussionContext.kt
@@ -31,3 +31,6 @@ sealed class DiscussionContext {
         override val availableTypes = setOf(StatementType.PLAIN)
     }
 }
+
+fun DiscussionContext.selectableTypes(claimableRoles: Set<Role>): Set<StatementType> =
+    if (claimableRoles.isEmpty()) availableTypes - StatementType.ROLE_CLAIM else availableTypes

--- a/src/main/kotlin/werewolf/game/Player.kt
+++ b/src/main/kotlin/werewolf/game/Player.kt
@@ -30,7 +30,7 @@ abstract class Player(private val role: Role) : Notifiable {
     protected abstract fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim
 
     private fun claimableRoles(): Set<Role> {
-        val alreadyRevealed = ClaimedRole(_memories.filterIsInstance<GameEvent>()).of(this) == role
+        val alreadyRevealed = ClaimedRole(_memories).of(this) == role
         return RoleClaimPolicy.claimableRoles(role, alreadyRevealed)
     }
     abstract fun watchEpilogue(chronicles: List<ChronicleView>)

--- a/src/main/kotlin/werewolf/game/Player.kt
+++ b/src/main/kotlin/werewolf/game/Player.kt
@@ -22,12 +22,17 @@ abstract class Player(private val role: Role) : Notifiable {
     }
     protected abstract fun choose(context: SelectionContext): Choice
     fun discuss(context: DiscussionContext): Statement {
-        val claim = speak(context)
+        val claim = speak(context, claimableRoles())
         require(claim.speaker === this) { "${claim.speaker.name} is not the speaking player" }
         _memories.add(claim)
         return claim.statement
     }
-    protected abstract fun speak(context: DiscussionContext): Claim
+    protected abstract fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim
+
+    private fun claimableRoles(): Set<Role> {
+        val alreadyRevealed = ClaimedRole(_memories.filterIsInstance<GameEvent>()).of(this) == role
+        return RoleClaimPolicy.claimableRoles(role, alreadyRevealed)
+    }
     abstract fun watchEpilogue(chronicles: List<ChronicleView>)
 
     protected fun memorize(recallable: Recallable) {

--- a/src/main/kotlin/werewolf/game/RoleClaimPolicy.kt
+++ b/src/main/kotlin/werewolf/game/RoleClaimPolicy.kt
@@ -1,0 +1,16 @@
+package werewolf.game
+
+object RoleClaimPolicy {
+    fun claimableRoles(role: Role, alreadyRevealed: Boolean): Set<Role> = when (role) {
+        Role.VILLAGER -> emptySet()
+        Role.SEER, Role.MEDIUM, Role.HUNTER -> denyReCo(trueRoleOnly(role), alreadyRevealed)
+        Role.WEREWOLF, Role.MADMAN -> Role.entries.toSet() - Role.VILLAGER
+    }
+
+    // 本当の役職しかCOできない
+    private fun trueRoleOnly(role: Role): Set<Role> = setOf(role)
+
+    // CO済みなら再COを許さない
+    private fun denyReCo(claimable: Set<Role>, alreadyRevealed: Boolean): Set<Role> =
+        if (alreadyRevealed) emptySet() else claimable
+}

--- a/src/main/kotlin/werewolf/human/HumanPlayer.kt
+++ b/src/main/kotlin/werewolf/human/HumanPlayer.kt
@@ -12,6 +12,7 @@ import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
 import werewolf.game.StatementType
+import werewolf.game.selectableTypes
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
 import werewolf.view.PlayerStatusView
@@ -48,19 +49,19 @@ class HumanPlayer(role: Role, override val name: String, private val io: HumanIO
         }
     }
 
-    override fun speak(context: DiscussionContext): Claim {
-        val type = selectType(context)
+    override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim {
+        val type = selectType(context, claimableRoles)
         val statement = when (type) {
             StatementType.PLAIN -> buildPlain(context)
             StatementType.DIVINATION_REPORT -> buildDivinationReport(context)
             StatementType.MEDIUM_REPORT -> buildMediumReport(context)
-            StatementType.ROLE_CLAIM -> buildRoleClaim()
+            StatementType.ROLE_CLAIM -> buildRoleClaim(claimableRoles)
         }
-        return Claim(this, context, statement, "プレイヤーが発言")
+        return Claim(this, context, statement, claimableRoles, "プレイヤーが発言")
     }
 
-    private fun selectType(context: DiscussionContext): StatementType {
-        val types = StatementType.entries.filter { it in context.availableTypes }
+    private fun selectType(context: DiscussionContext, claimableRoles: Set<Role>): StatementType {
+        val types = StatementType.entries.filter { it in context.selectableTypes(claimableRoles) }
         if (types.size == 1) return types.first()
         val selected = io.promptChoice(ChoiceView(context.title, context.description, types.map { it.displayName }))
         return types.single { it.displayName == selected }
@@ -89,11 +90,16 @@ class HumanPlayer(role: Role, override val name: String, private val io: HumanIO
         return Statement.MediumReport(this, target, results.single { it.displayName == resultName }, comment)
     }
 
-    private fun buildRoleClaim(): Statement {
-        val roles = Role.entries
-        val roleName = io.promptChoice(ChoiceView("役職申告 - 役職", "申告する役職を選んでください", roles.map { it.displayName }))
+    private fun buildRoleClaim(claimableRoles: Set<Role>): Statement {
+        val roles = claimableRoles.toList()
+        val role = if (roles.size == 1) {
+            roles.single()
+        } else {
+            val roleName = io.promptChoice(ChoiceView("役職申告 - 役職", "申告する役職を選んでください", roles.map { it.displayName }))
+            roles.single { it.displayName == roleName }
+        }
         val comment = io.promptFreeText("役職申告 - 補足", COMMENT_PROMPT)
-        return Statement.RoleClaim(this, roles.single { it.displayName == roleName }, comment)
+        return Statement.RoleClaim(this, role, comment)
     }
 
     override fun watchEpilogue(chronicles: List<ChronicleView>) {

--- a/src/test/kotlin/werewolf/AiPlayerSpeakTest.kt
+++ b/src/test/kotlin/werewolf/AiPlayerSpeakTest.kt
@@ -50,8 +50,8 @@ class AiPlayerSpeakTest {
     @Test
     fun `discuss prompt includes format instruction for every available type`() {
         val lm = FakeLanguageModel("発言する：hello[真意]")
-        val villager = AiPlayer(Role.VILLAGER, "Villager", lm, testInstruction())
-        villager.discuss(openContext())
+        val seer = AiPlayer(Role.SEER, "Seer", lm, testInstruction("Seer"))
+        seer.discuss(openContext())
         assertContains(lm.prompts.first(), "発言する：ゲーム上の発言（50文字以内）")
         assertContains(
             lm.prompts.first(),
@@ -63,8 +63,16 @@ class AiPlayerSpeakTest {
         )
         assertContains(
             lm.prompts.first(),
-            "役職を開示する：申告する役職名（人狼か占い師か霊能者か村人か狩人か狂人）/補足コメント（省略可）",
+            "役職を開示する：申告する役職名（占い師）/補足コメント（省略可）",
         )
+    }
+
+    @Test
+    fun `discuss prompt omits ROLE_CLAIM format when no role is claimable`() {
+        val lm = FakeLanguageModel("発言する：hello[真意]")
+        val villager = AiPlayer(Role.VILLAGER, "Villager", lm, testInstruction())
+        villager.discuss(openContext())
+        assertFalse(lm.prompts.first().contains("役職を開示する"))
     }
 
     @Test
@@ -152,6 +160,30 @@ class AiPlayerSpeakTest {
         val lm = FakeLanguageModel(
             "役職を開示する：宇宙人[意図]",
             "役職を開示する：宇宙人[意図]",
+        )
+        val seer = AiPlayer(Role.SEER, "Seer", lm, testInstruction("Seer"))
+        val result = seer.discuss(openContext(listOf(seer)))
+        assertIs<Statement.Plain>(result)
+        assertEquals("", result.text())
+    }
+
+    @Test
+    fun `discuss falls back when claimed role is not claimable by this player`() {
+        val lm = FakeLanguageModel(
+            "役職を開示する：霊能者[意図]",
+            "役職を開示する：霊能者[意図]",
+        )
+        val seer = AiPlayer(Role.SEER, "Seer", lm, testInstruction("Seer"))
+        val result = seer.discuss(openContext(listOf(seer)))
+        assertIs<Statement.Plain>(result)
+        assertEquals("", result.text())
+    }
+
+    @Test
+    fun `discuss falls back when villager attempts ROLE_CLAIM`() {
+        val lm = FakeLanguageModel(
+            "役職を開示する：占い師[意図]",
+            "役職を開示する：占い師[意図]",
         )
         val villager = AiPlayer(Role.VILLAGER, "Villager", lm, testInstruction())
         val result = villager.discuss(openContext(listOf(villager)))

--- a/src/test/kotlin/werewolf/ClaimTest.kt
+++ b/src/test/kotlin/werewolf/ClaimTest.kt
@@ -29,13 +29,25 @@ class ClaimTest {
     }
 
     @Test
-    fun `Claim throws when statement is RoleClaim for a role that is not claimable`() {
+    fun `Claim throws when statement type is ROLE_CLAIM but speaker has no claimable role`() {
         val speaker = NothingPlayer(Role.VILLAGER, "Speaker")
         val context = openContext(listOf(speaker))
         val statement = Statement.RoleClaim(speaker, Role.SEER)
-        assertFailsWith<IllegalArgumentException> {
+        val exception = assertFailsWith<IllegalArgumentException> {
             Claim(speaker, context, statement, emptySet(), "意図")
         }
+        assertContains(exception.message.orEmpty(), "is not available for")
+    }
+
+    @Test
+    fun `Claim throws when statement is RoleClaim for a role outside claimable roles`() {
+        val speaker = NothingPlayer(Role.SEER, "Speaker")
+        val context = openContext(listOf(speaker))
+        val statement = Statement.RoleClaim(speaker, Role.WEREWOLF)
+        val exception = assertFailsWith<IllegalArgumentException> {
+            Claim(speaker, context, statement, setOf(Role.SEER), "意図")
+        }
+        assertContains(exception.message.orEmpty(), "is not claimable by")
     }
 
     @Test

--- a/src/test/kotlin/werewolf/ClaimTest.kt
+++ b/src/test/kotlin/werewolf/ClaimTest.kt
@@ -17,7 +17,7 @@ class ClaimTest {
         val context = DiscussionContext.Conclave(1, 1, listOf(speaker), listOf(speaker))
         val statement = Statement.DivinationReport(speaker, speaker, DivineResult.WEREWOLF)
         assertFailsWith<IllegalArgumentException> {
-            Claim(speaker, context, statement, "意図")
+            Claim(speaker, context, statement, emptySet(), "意図")
         }
     }
 
@@ -25,14 +25,32 @@ class ClaimTest {
     fun `Claim does not throw when statement type is available`() {
         val speaker = NothingPlayer(Role.VILLAGER, "Speaker")
         val context = openContext(listOf(speaker))
-        assertNotNull(Claim(speaker, context, Statement.Plain("発言"), "意図"))
+        assertNotNull(Claim(speaker, context, Statement.Plain("発言"), emptySet(), "意図"))
+    }
+
+    @Test
+    fun `Claim throws when statement is RoleClaim for a role that is not claimable`() {
+        val speaker = NothingPlayer(Role.VILLAGER, "Speaker")
+        val context = openContext(listOf(speaker))
+        val statement = Statement.RoleClaim(speaker, Role.SEER)
+        assertFailsWith<IllegalArgumentException> {
+            Claim(speaker, context, statement, emptySet(), "意図")
+        }
+    }
+
+    @Test
+    fun `Claim does not throw when statement is RoleClaim for a claimable role`() {
+        val speaker = NothingPlayer(Role.SEER, "Speaker")
+        val context = openContext(listOf(speaker))
+        val statement = Statement.RoleClaim(speaker, Role.SEER)
+        assertNotNull(Claim(speaker, context, statement, setOf(Role.SEER), "意図"))
     }
 
     @Test
     fun `toRecallView returns action with context title, content and intent`() {
         val speaker = NothingPlayer(Role.VILLAGER, "Speaker")
         val context = openContext(listOf(speaker))
-        val claim = Claim(speaker, context, Statement.Plain("発言内容"), "真意内容")
+        val claim = Claim(speaker, context, Statement.Plain("発言内容"), emptySet(), "真意内容")
         assertEquals(RecallView.SelfAction("議論", "発言内容", "真意内容"), claim.toRecallView())
     }
 
@@ -40,7 +58,7 @@ class ClaimTest {
     fun `toChronicleView returns action with speaker, context title, content and intent`() {
         val speaker = NothingPlayer(Role.VILLAGER, "Speaker")
         val context = openContext(listOf(speaker))
-        val claim = Claim(speaker, context, Statement.Plain("発言内容"), "真意内容")
+        val claim = Claim(speaker, context, Statement.Plain("発言内容"), emptySet(), "真意内容")
         assertEquals(ChronicleView.Action("Speaker", "議論", "発言内容", "真意内容"), claim.toChronicleView())
     }
 

--- a/src/test/kotlin/werewolf/ClaimedRoleTest.kt
+++ b/src/test/kotlin/werewolf/ClaimedRoleTest.kt
@@ -8,8 +8,7 @@ import kotlin.test.assertNull
 
 class ClaimedRoleTest {
 
-    private fun eventsFor(player: Player): List<GameEvent> =
-        player.reveal(fakeCitizenWinSignal()).filterIsInstance<GameEvent>()
+    private fun eventsFor(player: Player): List<Recallable> = player.reveal(fakeCitizenWinSignal())
 
     @Test
     fun `returns null when player has not claimed anything`() {

--- a/src/test/kotlin/werewolf/ClaimedRoleTest.kt
+++ b/src/test/kotlin/werewolf/ClaimedRoleTest.kt
@@ -1,0 +1,71 @@
+package werewolf
+
+import werewolf.game.*
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ClaimedRoleTest {
+
+    private fun eventsFor(player: Player): List<GameEvent> =
+        player.reveal(fakeCitizenWinSignal()).filterIsInstance<GameEvent>()
+
+    @Test
+    fun `returns null when player has not claimed anything`() {
+        val player = ReceivingPlayer(Role.SEER, "Player")
+        val allPlayers = AllPlayers(TestLodge(player to Role.SEER).create().playerManager)
+        GameEvent.StatementMade.send(1, player.name, Statement.Plain("hello"), allPlayers)
+
+        assertNull(ClaimedRole(eventsFor(player)).of(player))
+    }
+
+    @Test
+    fun `returns role from RoleClaim statement`() {
+        val player = ReceivingPlayer(Role.MADMAN, "Player")
+        val allPlayers = AllPlayers(TestLodge(player to Role.MADMAN).create().playerManager)
+        GameEvent.StatementMade.send(1, player.name, Statement.RoleClaim(player, Role.SEER), allPlayers)
+
+        assertEquals(Role.SEER, ClaimedRole(eventsFor(player)).of(player))
+    }
+
+    @Test
+    fun `returns SEER from DivinationReport statement`() {
+        val player = ReceivingPlayer(Role.SEER, "Player")
+        val other = ReceivingPlayer(Role.VILLAGER, "Other")
+        val allPlayers = AllPlayers(TestLodge(player to Role.SEER, other to Role.VILLAGER).create().playerManager)
+        GameEvent.StatementMade.send(1, player.name, Statement.DivinationReport(player, other, DivineResult.NOT_WEREWOLF), allPlayers)
+
+        assertEquals(Role.SEER, ClaimedRole(eventsFor(player)).of(player))
+    }
+
+    @Test
+    fun `returns MEDIUM from MediumReport statement`() {
+        val player = ReceivingPlayer(Role.MEDIUM, "Player")
+        val other = ReceivingPlayer(Role.VILLAGER, "Other")
+        val allPlayers = AllPlayers(TestLodge(player to Role.MEDIUM, other to Role.VILLAGER).create().playerManager)
+        GameEvent.StatementMade.send(1, player.name, Statement.MediumReport(player, other, MediumResult.NOT_WEREWOLF), allPlayers)
+
+        assertEquals(Role.MEDIUM, ClaimedRole(eventsFor(player)).of(player))
+    }
+
+    @Test
+    fun `last claim wins when claimed multiple times`() {
+        val player = ReceivingPlayer(Role.MADMAN, "Player")
+        val allPlayers = AllPlayers(TestLodge(player to Role.MADMAN).create().playerManager)
+        GameEvent.StatementMade.send(1, player.name, Statement.RoleClaim(player, Role.SEER), allPlayers)
+        GameEvent.StatementMade.send(2, player.name, Statement.RoleClaim(player, Role.MEDIUM), allPlayers)
+
+        assertEquals(Role.MEDIUM, ClaimedRole(eventsFor(player)).of(player))
+    }
+
+    @Test
+    fun `ignores claims made by other players`() {
+        val player = ReceivingPlayer(Role.SEER, "Player")
+        val other = ReceivingPlayer(Role.MADMAN, "Other")
+        val allPlayers = AllPlayers(TestLodge(player to Role.SEER, other to Role.MADMAN).create().playerManager)
+        GameEvent.StatementMade.send(1, other.name, Statement.RoleClaim(other, Role.SEER), allPlayers)
+
+        assertNull(ClaimedRole(eventsFor(player)).of(player))
+    }
+}

--- a/src/test/kotlin/werewolf/ConclaveTest.kt
+++ b/src/test/kotlin/werewolf/ConclaveTest.kt
@@ -20,10 +20,10 @@ class ConclaveTest {
         var receivedStartedDay: Int? = null
         private var statementIndex = 0
 
-        override fun speak(context: DiscussionContext): Claim {
+        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim {
             val statement = statements[statementIndex++]
             _log.add("$name:said:$statement")
-            return Claim(this, context, Statement.Plain(statement), "")
+            return Claim(this, context, Statement.Plain(statement), claimableRoles, "")
         }
 
         override fun onReceive(event: GameEvent) {

--- a/src/test/kotlin/werewolf/DayPhaseTest.kt
+++ b/src/test/kotlin/werewolf/DayPhaseTest.kt
@@ -14,9 +14,9 @@ class DayPhaseTest {
         role: Role, name: String, private val voteTarget: Player? = null
     ) : ReceivingPlayer(role, name) {
         var discussedCount = 0
-        override fun speak(context: DiscussionContext): Claim {
+        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim {
             discussedCount++
-            return Claim(this, context, Statement.Plain(""), "")
+            return Claim(this, context, Statement.Plain(""), claimableRoles, "")
         }
         override fun choose(context: SelectionContext): Choice =
             Choice(this, context, voteTarget?.takeIf { it in context.candidates() } ?: context.candidates().first(), "テスト用投票")

--- a/src/test/kotlin/werewolf/DiscussionTest.kt
+++ b/src/test/kotlin/werewolf/DiscussionTest.kt
@@ -19,10 +19,10 @@ class DiscussionTest {
         var receivedStartedDay: Int? = null
         private var statementIndex = 0
 
-        override fun speak(context: DiscussionContext): Claim {
+        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim {
             val statement = statements[statementIndex++]
             _log.add("$name:said:$statement")
-            return Claim(this, context, Statement.Plain(statement), "")
+            return Claim(this, context, Statement.Plain(statement), claimableRoles, "")
         }
 
         override fun onReceive(event: GameEvent) {

--- a/src/test/kotlin/werewolf/GameRecapTest.kt
+++ b/src/test/kotlin/werewolf/GameRecapTest.kt
@@ -12,7 +12,8 @@ import kotlin.test.assertTrue
 class GameRecapTest {
 
     private class SpeakingPlayer(role: Role, name: String) : ReceivingPlayer(role, name) {
-        override fun speak(context: DiscussionContext): Claim = Claim(this, context, Statement.Plain("$name speaks"), "intent")
+        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim =
+            Claim(this, context, Statement.Plain("$name speaks"), claimableRoles, "intent")
     }
 
     private fun playerManager(vararg players: Player): PlayerManager =

--- a/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
@@ -29,8 +29,8 @@ class HumanPlayerEpilogueTest {
     private class SpeakingPlayer(role: Role, name: String) : NothingPlayer(role, name) {
         override fun onReceive(event: GameEvent) {}
         override fun watchEpilogue(chronicles: List<ChronicleView>) {}
-        override fun speak(context: DiscussionContext): Claim =
-            Claim(this, context, Statement.Plain("$name speaks"), "intent")
+        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim =
+            Claim(this, context, Statement.Plain("$name speaks"), claimableRoles, "intent")
     }
 
     @Test

--- a/src/test/kotlin/werewolf/HumanPlayerTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerTest.kt
@@ -3,9 +3,11 @@ package werewolf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import werewolf.game.AllPlayers
 import werewolf.game.ChronicleView
 import werewolf.game.DiscussionContext
 import werewolf.game.DivineResult
+import werewolf.game.GameEvent
 import werewolf.game.MediumResult
 import werewolf.game.RecallView
 import werewolf.game.Role
@@ -176,6 +178,42 @@ class HumanPlayerTest {
 
         assertEquals(Statement.RoleClaim(human, Role.SEER), statement)
         assertEquals(2, io.promptedChoices.size)
+    }
+
+    @Test
+    fun `villager is not offered ROLE_CLAIM as a statement type`() {
+        val io = CapturingIO(StatementType.PLAIN.displayName, freeTextAnswer = "hello")
+        val human = HumanPlayer(Role.VILLAGER, "Human", io)
+        val context = DiscussionContext.Open(1, 1, listOf(human), listOf(human))
+
+        human.discuss(context)
+
+        assertTrue(io.promptedChoices.single().options.none { it == StatementType.ROLE_CLAIM.displayName })
+    }
+
+    @Test
+    fun `speak with ROLE_CLAIM skips role prompt when only one role is claimable`() {
+        val io = CapturingIO(StatementType.ROLE_CLAIM.displayName)
+        val human = HumanPlayer(Role.SEER, "Human", io)
+        val context = DiscussionContext.Open(1, 1, listOf(human), listOf(human))
+
+        val statement = human.discuss(context)
+
+        assertEquals(Statement.RoleClaim(human, Role.SEER), statement)
+        assertEquals(1, io.promptedChoices.size)
+    }
+
+    @Test
+    fun `seer who already claimed is not offered ROLE_CLAIM again`() {
+        val io = CapturingIO(StatementType.PLAIN.displayName, freeTextAnswer = "hello")
+        val human = HumanPlayer(Role.SEER, "Human", io)
+        val allPlayers = AllPlayers(TestLodge(human to Role.SEER).create().playerManager)
+        GameEvent.StatementMade.send(1, human.name, Statement.RoleClaim(human, Role.SEER), allPlayers)
+        val context = DiscussionContext.Open(2, 1, listOf(human), listOf(human))
+
+        human.discuss(context)
+
+        assertTrue(io.promptedChoices.single().options.none { it == StatementType.ROLE_CLAIM.displayName })
     }
 
     @Test

--- a/src/test/kotlin/werewolf/MadmanCpuStrategyTest.kt
+++ b/src/test/kotlin/werewolf/MadmanCpuStrategyTest.kt
@@ -21,7 +21,7 @@ class MadmanCpuStrategyTest {
     @Test
     fun `fake seer reports NOT_WEREWOLF on first day`() {
         val strategy = MadmanCpuStrategy(madman, Role.SEER)
-        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2), day = 1))
+        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2), day = 1), StatementType.entries.toSet())
         assertTrue(result is Statement.DivinationReport)
         assertEquals(DivineResult.NOT_WEREWOLF, result.result)
         assertNotSame(madman, result.target)
@@ -30,7 +30,7 @@ class MadmanCpuStrategyTest {
     @Test
     fun `fake seer reports WEREWOLF from second day onwards`() {
         val strategy = MadmanCpuStrategy(madman, Role.SEER)
-        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2), day = 2))
+        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2), day = 2), StatementType.entries.toSet())
         assertTrue(result is Statement.DivinationReport)
         assertEquals(DivineResult.WEREWOLF, result.result)
         assertNotSame(madman, result.target)
@@ -39,7 +39,7 @@ class MadmanCpuStrategyTest {
     @Test
     fun `fake seer stays silent from round 2 onwards`() {
         val strategy = MadmanCpuStrategy(madman, Role.SEER)
-        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2), round = 2))
+        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2), round = 2), StatementType.entries.toSet())
         assertTrue(result is Statement.Plain)
     }
 
@@ -49,7 +49,7 @@ class MadmanCpuStrategyTest {
         GameEvent.StatementMade.send(1, madman.name, Statement.DivinationReport(madman, v1, DivineResult.WEREWOLF), allPlayers)
         GameEvent.StatementMade.send(1, madman.name, Statement.DivinationReport(madman, v2, DivineResult.WEREWOLF), allPlayers)
 
-        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2)))
+        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2)), StatementType.entries.toSet())
         assertTrue(result is Statement.Plain)
     }
 
@@ -58,7 +58,7 @@ class MadmanCpuStrategyTest {
         val strategy = MadmanCpuStrategy(madman, Role.MEDIUM)
         GameEvent.PlayerExecuted.send(v1, allPlayers)
 
-        val result = strategy.buildStatement(openContext(listOf(madman, v2)))
+        val result = strategy.buildStatement(openContext(listOf(madman, v2)), StatementType.entries.toSet())
         assertTrue(result is Statement.MediumReport)
         assertEquals(MediumResult.NOT_WEREWOLF, result.result)
         assertSame(v1, result.target)
@@ -67,7 +67,7 @@ class MadmanCpuStrategyTest {
     @Test
     fun `fake medium stays silent when no executions yet`() {
         val strategy = MadmanCpuStrategy(madman, Role.MEDIUM)
-        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2)))
+        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2)), StatementType.entries.toSet())
         assertTrue(result is Statement.Plain)
     }
 
@@ -75,7 +75,7 @@ class MadmanCpuStrategyTest {
     fun `fake medium stays silent from round 2 onwards`() {
         val strategy = MadmanCpuStrategy(madman, Role.MEDIUM)
         GameEvent.PlayerExecuted.send(v1, allPlayers)
-        val result = strategy.buildStatement(openContext(listOf(madman, v2), round = 2))
+        val result = strategy.buildStatement(openContext(listOf(madman, v2), round = 2), StatementType.entries.toSet())
         assertTrue(result is Statement.Plain)
     }
 
@@ -85,7 +85,7 @@ class MadmanCpuStrategyTest {
         GameEvent.PlayerExecuted.send(v1, allPlayers)
         GameEvent.StatementMade.send(1, madman.name, Statement.MediumReport(madman, v1, MediumResult.NOT_WEREWOLF), allPlayers)
 
-        val result = strategy.buildStatement(openContext(listOf(madman, v2)))
+        val result = strategy.buildStatement(openContext(listOf(madman, v2)), StatementType.entries.toSet())
         assertTrue(result is Statement.Plain)
     }
 }

--- a/src/test/kotlin/werewolf/NightPhaseTest.kt
+++ b/src/test/kotlin/werewolf/NightPhaseTest.kt
@@ -25,7 +25,8 @@ class NightPhaseTest {
 
     private class ConclaveWolf(name: String) : ReceivingPlayer(Role.WEREWOLF, name) {
         val heardStatements = mutableListOf<GameEvent.WerewolfStatementMade>()
-        override fun speak(context: DiscussionContext): Claim = Claim(this, context, Statement.Plain(""), "")
+        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim =
+            Claim(this, context, Statement.Plain(""), claimableRoles, "")
         override fun onReceive(event: GameEvent) {
             if (event is GameEvent.WerewolfStatementMade) heardStatements.add(event)
         }

--- a/src/test/kotlin/werewolf/NothingPlayer.kt
+++ b/src/test/kotlin/werewolf/NothingPlayer.kt
@@ -3,7 +3,7 @@ package werewolf
 import werewolf.game.*
 
 open class NothingPlayer(role: Role, override val name: String) : Player(role) {
-    override fun speak(context: DiscussionContext): Claim = error("speak not expected")
+    override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim = error("speak not expected")
     override fun onReceive(event: GameEvent) { error("onReceive not expected") }
     override fun choose(context: SelectionContext): Choice = error("choose not expected")
     override fun watchEpilogue(chronicles: List<ChronicleView>) { error("watchEpilogue not expected") }

--- a/src/test/kotlin/werewolf/PlayerTest.kt
+++ b/src/test/kotlin/werewolf/PlayerTest.kt
@@ -3,6 +3,7 @@ package werewolf
 import werewolf.game.*
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
@@ -25,13 +26,21 @@ class PlayerTest {
         name: String,
         private val speakerToSet: Player,
     ) : NothingPlayer(role, name) {
-        override fun speak(context: DiscussionContext): Claim =
-            Claim(speakerToSet, context, Statement.Plain(""), "")
+        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim =
+            Claim(speakerToSet, context, Statement.Plain(""), claimableRoles, "")
     }
 
     private class SpeakingPlayer(role: Role, name: String) : NothingPlayer(role, name) {
-        override fun speak(context: DiscussionContext): Claim =
-            Claim(this, context, Statement.Plain(""), "")
+        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim =
+            Claim(this, context, Statement.Plain(""), claimableRoles, "")
+    }
+
+    private class CapturingSpeakerPlayer(role: Role, name: String) : ReceivingPlayer(role, name) {
+        var receivedClaimableRoles: Set<Role>? = null
+        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim {
+            receivedClaimableRoles = claimableRoles
+            return Claim(this, context, Statement.Plain(""), claimableRoles, "")
+        }
     }
 
     @Test
@@ -64,5 +73,41 @@ class PlayerTest {
         val player = SpeakingPlayer(Role.VILLAGER, "Player")
         player.discuss(openContext(listOf(player)))
         assertTrue(player.reveal(fakeCitizenWinSignal()).any { it is Claim })
+    }
+
+    @Test
+    fun `villager cannot claim any role`() {
+        val player = CapturingSpeakerPlayer(Role.VILLAGER, "Player")
+        player.discuss(openContext(listOf(player)))
+        assertEquals(emptySet(), player.receivedClaimableRoles)
+    }
+
+    @Test
+    fun `seer can claim own role when not yet revealed`() {
+        val player = CapturingSpeakerPlayer(Role.SEER, "Player")
+        player.discuss(openContext(listOf(player)))
+        assertEquals(setOf(Role.SEER), player.receivedClaimableRoles)
+    }
+
+    @Test
+    fun `seer cannot claim again after already revealed`() {
+        val player = CapturingSpeakerPlayer(Role.SEER, "Player")
+        val allPlayers = AllPlayers(TestLodge(player to Role.SEER).create().playerManager)
+        GameEvent.StatementMade.send(1, player.name, Statement.RoleClaim(player, Role.SEER), allPlayers)
+
+        player.discuss(openContext(listOf(player)))
+
+        assertEquals(emptySet(), player.receivedClaimableRoles)
+    }
+
+    @Test
+    fun `werewolf can keep re-claiming roles after already claiming`() {
+        val player = CapturingSpeakerPlayer(Role.WEREWOLF, "Player")
+        val allPlayers = AllPlayers(TestLodge(player to Role.WEREWOLF).create().playerManager)
+        GameEvent.StatementMade.send(1, player.name, Statement.RoleClaim(player, Role.SEER), allPlayers)
+
+        player.discuss(openContext(listOf(player)))
+
+        assertEquals(Role.entries.toSet() - Role.VILLAGER, player.receivedClaimableRoles)
     }
 }

--- a/src/test/kotlin/werewolf/RoleClaimPolicyTest.kt
+++ b/src/test/kotlin/werewolf/RoleClaimPolicyTest.kt
@@ -1,0 +1,39 @@
+package werewolf
+
+import werewolf.game.Role
+import werewolf.game.RoleClaimPolicy
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RoleClaimPolicyTest {
+
+    @Test
+    fun `villager can never claim any role`() {
+        assertEquals(emptySet(), RoleClaimPolicy.claimableRoles(Role.VILLAGER, alreadyRevealed = false))
+        assertEquals(emptySet(), RoleClaimPolicy.claimableRoles(Role.VILLAGER, alreadyRevealed = true))
+    }
+
+    @Test
+    fun `seer medium hunter can claim only own role when not yet revealed`() {
+        assertEquals(setOf(Role.SEER), RoleClaimPolicy.claimableRoles(Role.SEER, alreadyRevealed = false))
+        assertEquals(setOf(Role.MEDIUM), RoleClaimPolicy.claimableRoles(Role.MEDIUM, alreadyRevealed = false))
+        assertEquals(setOf(Role.HUNTER), RoleClaimPolicy.claimableRoles(Role.HUNTER, alreadyRevealed = false))
+    }
+
+    @Test
+    fun `seer medium hunter cannot claim again once already revealed`() {
+        assertEquals(emptySet(), RoleClaimPolicy.claimableRoles(Role.SEER, alreadyRevealed = true))
+        assertEquals(emptySet(), RoleClaimPolicy.claimableRoles(Role.MEDIUM, alreadyRevealed = true))
+        assertEquals(emptySet(), RoleClaimPolicy.claimableRoles(Role.HUNTER, alreadyRevealed = true))
+    }
+
+    @Test
+    fun `werewolf and madman can claim any non-villager role regardless of prior claims`() {
+        val expected = Role.entries.toSet() - Role.VILLAGER
+        assertEquals(expected, RoleClaimPolicy.claimableRoles(Role.WEREWOLF, alreadyRevealed = false))
+        assertEquals(expected, RoleClaimPolicy.claimableRoles(Role.WEREWOLF, alreadyRevealed = true))
+        assertEquals(expected, RoleClaimPolicy.claimableRoles(Role.MADMAN, alreadyRevealed = false))
+        assertEquals(expected, RoleClaimPolicy.claimableRoles(Role.MADMAN, alreadyRevealed = true))
+    }
+}


### PR DESCRIPTION
## 変更内容

- 村人はCO（ROLE_CLAIM）を選択できないようにした
- 占い師・霊能者・狩人は自分の本当の役職しかCOできず、一度CO済み（占い師・霊能者は結果報告でも可）なら以後COを選択できないようにした
- 人狼・狂人は騙り替えのため、COの回数・対象役職に制限を受けない
- `ROLE_CLAIM`以外の発言型（占い結果報告など）自体への役職ベースの制限は今回のスコープ外

## 設計

- `Player.role`はサブクラス（Human/AI/CPU）に一切公開しない。`Player.discuss()`が`private`な`claimableRoles()`でCO可否を算出し、`speak(context, claimableRoles)`という形で値だけをそのプレイヤー自身の発言生成時に渡す
- `DiscussionContext.selectableTypes(claimableRoles)`という純粋関数で、`claimableRoles`が空ならROLE_CLAIMを選択肢から除外する。`Claim`・`HumanPlayer`・`AiPlayer`・`StatementFormat`・CPU戦略から共通利用
- `Claim`のコンストラクタで型・役職の両方を検証し、どの経路から来ても不正な発言を弾く最終防衛線とした
- `speak`のシグネチャ変更に伴い、CPU戦略クラス・テスト用ダブルにも機械的な波及あり（振る舞いは変更なし）

## テスト

- 新規: `RoleClaimPolicyTest`、`ClaimedRoleTest`
- 更新: `PlayerTest`、`ClaimTest`、`HumanPlayerTest`、`AiPlayerSpeakTest`、`MadmanCpuStrategyTest`ほか
- `./gradlew test`・`./gradlew detekt`ともにグリーン

Closes #277