### PR TITLE
Fix SonarCloud CI failure by upgrading analysis Java version to 21

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -18,7 +18,9 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
         with:
-          java-version: '17'
+          java-version: |
+            17
+            21
           distribution: 'temurin'
           cache: gradle
       - name: Run detekt


### PR DESCRIPTION
## 概要
SonarQube CloudがJava 17のサポートを終了したため、`sonarcloud` ワークフローの `sonar` タスクが `The version of Java (17) used to run this analysis is deprecated` で失敗するようになっていた（PR #278 で発覚）。`actions/setup-java` でJava 17と21の両方をインストールし、Gradle実行時のJAVA_HOMEを21にすることで解析を通す。`jvmToolchain(17)` によるKotlinコンパイルには影響しない。

Closes #279

## Test plan
- [x] `./gradlew check` がローカルで成功することを確認済み
- [ ] このPRの `sonarcloud` ジョブがGreenになることを確認する