### PR TITLE
Document develop sync prerequisite in WORKFLOW.md and track sync-develop command in git

### DIFF
--- a/.claude/commands/sync-develop.md
+++ b/.claude/commands/sync-develop.md
@@ -1,0 +1,12 @@
+---
+description: マージ済みのPRをローカルのdevelopに反映する（git checkout develop && git pull origin develop）
+---
+
+ローカルの `develop` ブランチをリモートの最新状態に同期する。以下の手順を必ずこの順番で実行すること。
+
+1. `git status` で作業ツリーに未コミット・未追跡の変更がないか確認する。
+   - コミットされていない変更がある場合は、勝手にstash/破棄せずユーザーに報告して指示を仰ぐ。
+2. 現在のブランチが `develop` でなければ `git checkout develop` する。
+3. `git pull origin develop` を実行する。
+4. `git log --oneline -5` で取得後の履歴を確認し、直近でマージされたはずのPRの内容が反映されているかを一言で報告する。
+   - 反映されていない場合（"Already up to date" なのに期待した変更が見当たらない等）は、その旨とありうる原因（PRがまだマージされていない、ブランチ名の勘違い等）を伝える。

--- a/.github/WORKFLOW.md
+++ b/.github/WORKFLOW.md
@@ -23,9 +23,10 @@
 ## 作業手順
 
 1. issueを立てる（テンプレートを使用）
-2. `develop` からブランチを切る（命名規則に従う）
-3. 実装する
-4. PRを作成し、`Closes #番号` でissueと紐づける
+2. ローカルの `develop` をリモート最新に同期する（`git checkout develop && git pull origin develop`。Claude Codeでは `/sync-develop` コマンドで実行できる）
+3. `develop` からブランチを切る（命名規則に従う）
+4. 実装する
+5. PRを作成し、`Closes #番号` でissueと紐づける
 
 ## issue
 


### PR DESCRIPTION
## 概要
WORKFLOW.mdの「developからブランチを切る」手順は、ローカルdevelopがリモート最新であることを暗黙の前提としていたが明文化されていなかった。手順にリモート同期のステップを追記し、それを実行する `/sync-develop` コマンド（`.claude/commands/sync-develop.md`）をgit管理下に置いてチームで共有できるようにした。

Closes #282

## Test plan
- [x] `./gradlew check` がローカルで成功することを確認済み（ドキュメント・コマンド定義のみの変更で挙動への影響なし）