### PR TITLE
Unify wording of divination/medium result reports

### DIFF
--- a/src/main/kotlin/werewolf/game/DivineResult.kt
+++ b/src/main/kotlin/werewolf/game/DivineResult.kt
@@ -2,5 +2,5 @@ package werewolf.game
 
 enum class DivineResult(val displayName: String) {
     WEREWOLF("人狼"),
-    NOT_WEREWOLF("人狼でない"),
+    NOT_WEREWOLF("人狼以外"),
 }

--- a/src/main/kotlin/werewolf/game/MediumResult.kt
+++ b/src/main/kotlin/werewolf/game/MediumResult.kt
@@ -1,6 +1,6 @@
 package werewolf.game
 
 enum class MediumResult(val displayName: String) {
-    WEREWOLF("人狼である"),
-    NOT_WEREWOLF("人狼でない"),
+    WEREWOLF("人狼"),
+    NOT_WEREWOLF("人狼以外"),
 }

--- a/src/main/kotlin/werewolf/game/Statement.kt
+++ b/src/main/kotlin/werewolf/game/Statement.kt
@@ -16,7 +16,7 @@ sealed class Statement {
         val comment: String = "",
     ) : Statement() {
         override val type = StatementType.DIVINATION_REPORT
-        override fun text() = "${target.name} は「${result.displayName}」です。".withComment(comment)
+        override fun text() = "${target.name}を占ったところ、「${result.displayName}」でした。".withComment(comment)
     }
 
     data class MediumReport(
@@ -26,7 +26,7 @@ sealed class Statement {
         val comment: String = "",
     ) : Statement() {
         override val type = StatementType.MEDIUM_REPORT
-        override fun text() = "${target.name} は「${result.displayName}」です。".withComment(comment)
+        override fun text() = "${target.name}の霊能結果は、「${result.displayName}」でした。".withComment(comment)
     }
 
     data class RoleClaim(

--- a/src/test/kotlin/werewolf/AiPlayerSpeakTest.kt
+++ b/src/test/kotlin/werewolf/AiPlayerSpeakTest.kt
@@ -55,11 +55,11 @@ class AiPlayerSpeakTest {
         assertContains(lm.prompts.first(), "発言する：ゲーム上の発言（50文字以内）")
         assertContains(
             lm.prompts.first(),
-            "占い結果を報告する：対象のプレイヤー名/結果（人狼か人狼でない）/補足コメント（省略可）",
+            "占い結果を報告する：対象のプレイヤー名/結果（人狼か人狼以外）/補足コメント（省略可）",
         )
         assertContains(
             lm.prompts.first(),
-            "霊媒結果を報告する：対象のプレイヤー名/結果（人狼であるか人狼でない）/補足コメント（省略可）",
+            "霊媒結果を報告する：対象のプレイヤー名/結果（人狼か人狼以外）/補足コメント（省略可）",
         )
         assertContains(
             lm.prompts.first(),
@@ -126,7 +126,7 @@ class AiPlayerSpeakTest {
     @Test
     fun `discuss selects MEDIUM_REPORT and omits comment when not provided`() {
         val alice = NothingPlayer(Role.VILLAGER, "Alice")
-        val lm = FakeLanguageModel("霊媒結果を報告する：Alice/人狼でない[霊能者として信頼を得るため]")
+        val lm = FakeLanguageModel("霊媒結果を報告する：Alice/人狼以外[霊能者として信頼を得るため]")
         val medium = AiPlayer(Role.MEDIUM, "Medium", lm, testInstruction("Medium"))
         val result = medium.discuss(openContext(listOf(medium, alice)))
         val report = assertIs<Statement.MediumReport>(result)

--- a/src/test/kotlin/werewolf/ClaimTest.kt
+++ b/src/test/kotlin/werewolf/ClaimTest.kt
@@ -80,8 +80,8 @@ class ClaimTest {
         val target = NothingPlayer(Role.VILLAGER, "Target")
         val withComment = Statement.DivinationReport(speaker, target, DivineResult.WEREWOLF, "怪しいと思っていました")
         val withoutComment = Statement.DivinationReport(speaker, target, DivineResult.WEREWOLF)
-        assertEquals("Target は「人狼」です。 怪しいと思っていました", withComment.text())
-        assertEquals("Target は「人狼」です。", withoutComment.text())
+        assertEquals("Targetを占ったところ、「人狼」でした。 怪しいと思っていました", withComment.text())
+        assertEquals("Targetを占ったところ、「人狼」でした。", withoutComment.text())
     }
 
     @Test
@@ -90,8 +90,8 @@ class ClaimTest {
         val target = NothingPlayer(Role.VILLAGER, "Target")
         val withComment = Statement.MediumReport(speaker, target, MediumResult.NOT_WEREWOLF, "無実の方を処刑してしまい申し訳ない気持ちです")
         val withoutComment = Statement.MediumReport(speaker, target, MediumResult.NOT_WEREWOLF)
-        assertEquals("Target は「人狼でない」です。 無実の方を処刑してしまい申し訳ない気持ちです", withComment.text())
-        assertEquals("Target は「人狼でない」です。", withoutComment.text())
+        assertEquals("Targetの霊能結果は、「人狼以外」でした。 無実の方を処刑してしまい申し訳ない気持ちです", withComment.text())
+        assertEquals("Targetの霊能結果は、「人狼以外」でした。", withoutComment.text())
     }
 
     @Test


### PR DESCRIPTION
## Summary
`DivinationReport`・`MediumReport`の`Statement.text()`が同一の文言（`"${target.name} は「${result.displayName}」です。"`）だったため、発言ログを見ても占い結果報告なのか霊能結果報告なのか判別できなかった。それぞれ「〜を占ったところ、」「〜の霊能結果は、」という表現で報告種別を明示するようにした。

また`MediumResult.WEREWOLF`のdisplayNameが「人狼である」で`DivineResult`の「人狼」と表記が異なり、文中に埋め込むと「人狼であるです。」のようにコピュラが重複していた。`NOT_WEREWOLF`も含め、`AiPlayer`のgame descriptionで既に使われている「人狼」「人狼以外」という表現に両者のdisplayNameを統一した。

表示結果の変化：

| ケース | 修正前 | 修正後 |
|---|---|---|
| 占い・黒 | Aliceは「人狼」です。 | Aliceを占ったところ、「人狼」でした。 |
| 占い・白 | Aliceは「人狼でない」です。 | Aliceを占ったところ、「人狼以外」でした。 |
| 霊能・黒 | Aliceは「人狼である」です。 | Aliceの霊能結果は、「人狼」でした。 |
| 霊能・白 | Aliceは「人狼でない」です。 | Aliceの霊能結果は、「人狼以外」でした。 |

Closes #286

## Test plan
- [x] `./gradlew check` がローカルで成功することを確認済み
- [x] 影響を受けるテスト（`ClaimTest`・`AiPlayerSpeakTest`）を新しい文言に更新済み