### PR TITLE
Restrict divination/medium report statements based on player's role and actual results

### DIFF
--- a/src/main/kotlin/werewolf/ai/AiPlayer.kt
+++ b/src/main/kotlin/werewolf/ai/AiPlayer.kt
@@ -13,6 +13,7 @@ import werewolf.game.MediumResult
 import werewolf.game.Player
 import werewolf.game.Recallable
 import werewolf.game.RecallView
+import werewolf.game.ReportEligibility
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
@@ -38,16 +39,17 @@ class AiPlayer(
         _myMemories.add(event)
     }
 
-    override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim {
-        val instruction = statementFormat.buildInstruction(context, claimableRoles)
+    override fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim {
+        val instruction = statementFormat.buildInstruction(context, claimableRoles, reportEligibility)
         repeat(2) {
             val completion = prompt(instruction)
             try {
                 val parsed = statementFormat.parse(completion.text)
-                val type = context.selectableTypes(claimableRoles).singleOrNull { it.displayName == parsed.typeLabel }
+                val type = context.selectableTypes(claimableRoles, reportEligibility).singleOrNull { it.displayName == parsed.typeLabel }
                     ?: throw InvalidAiInputException("選択できない発言の種類です: ${parsed.typeLabel}")
+                val statement = buildStatement(context, type, parsed.content, claimableRoles, reportEligibility)
                 val claim = Claim(
-                    this, context, buildStatement(context, type, parsed.content, claimableRoles), claimableRoles,
+                    this, context, statement, claimableRoles, reportEligibility,
                     intentForRecall = parsed.intent,
                     intentForChronicle = withMetadata(parsed.intent, completion.metadata),
                 )
@@ -66,19 +68,24 @@ class AiPlayer(
         type: StatementType,
         content: String,
         claimableRoles: Set<Role>,
+        reportEligibility: ReportEligibility,
     ): Statement = when (type) {
-        StatementType.PLAIN -> Statement.Plain(content)
+        StatementType.PLAIN -> Statement.Plain(this, content)
         StatementType.DIVINATION_REPORT -> {
             val (targetName, resultLabel, comment) = statementFormat.extractReportParts(content)
             val result = DivineResult.entries.singleOrNull { it.displayName == resultLabel }
                 ?: throw InvalidAiInputException("占い結果報告の結果が不正です: $resultLabel")
-            Statement.DivinationReport(this, resolveTarget(context, targetName), result, comment)
+            val statement = Statement.DivinationReport(this, resolveTarget(context, targetName), result, comment)
+            if (reportEligibility.disqualifies(statement)) throw InvalidAiInputException("報告可能な対象・結果ではありません: ${statement.text()}")
+            statement
         }
         StatementType.MEDIUM_REPORT -> {
             val (targetName, resultLabel, comment) = statementFormat.extractReportParts(content)
             val result = MediumResult.entries.singleOrNull { it.displayName == resultLabel }
                 ?: throw InvalidAiInputException("霊媒結果報告の結果が不正です: $resultLabel")
-            Statement.MediumReport(this, resolveTarget(context, targetName), result, comment)
+            val statement = Statement.MediumReport(this, resolveTarget(context, targetName), result, comment)
+            if (reportEligibility.disqualifies(statement)) throw InvalidAiInputException("報告可能な対象・結果ではありません: ${statement.text()}")
+            statement
         }
         StatementType.ROLE_CLAIM -> {
             val (roleName, comment) = statementFormat.extractRoleClaimParts(content)

--- a/src/main/kotlin/werewolf/ai/AiPlayer.kt
+++ b/src/main/kotlin/werewolf/ai/AiPlayer.kt
@@ -47,7 +47,10 @@ class AiPlayer(
                 val parsed = statementFormat.parse(completion.text)
                 val type = context.selectableTypes(claimableRoles, reportEligibility).singleOrNull { it.displayName == parsed.typeLabel }
                     ?: throw InvalidAiInputException("選択できない発言の種類です: ${parsed.typeLabel}")
-                val statement = buildStatement(context, type, parsed.content, claimableRoles, reportEligibility)
+                val statement = buildStatement(context, type, parsed.content, claimableRoles)
+                if (reportEligibility.disqualifies(statement)) {
+                    throw InvalidAiInputException("報告可能な対象・結果ではありません: ${statement.text()}")
+                }
                 val claim = Claim(
                     this, context, statement, claimableRoles, reportEligibility,
                     intentForRecall = parsed.intent,
@@ -68,24 +71,19 @@ class AiPlayer(
         type: StatementType,
         content: String,
         claimableRoles: Set<Role>,
-        reportEligibility: ReportEligibility,
     ): Statement = when (type) {
         StatementType.PLAIN -> Statement.Plain(this, content)
         StatementType.DIVINATION_REPORT -> {
             val (targetName, resultLabel, comment) = statementFormat.extractReportParts(content)
             val result = DivineResult.entries.singleOrNull { it.displayName == resultLabel }
                 ?: throw InvalidAiInputException("占い結果報告の結果が不正です: $resultLabel")
-            val statement = Statement.DivinationReport(this, resolveTarget(context, targetName), result, comment)
-            if (reportEligibility.disqualifies(statement)) throw InvalidAiInputException("報告可能な対象・結果ではありません: ${statement.text()}")
-            statement
+            Statement.DivinationReport(this, resolveTarget(context, targetName), result, comment)
         }
         StatementType.MEDIUM_REPORT -> {
             val (targetName, resultLabel, comment) = statementFormat.extractReportParts(content)
             val result = MediumResult.entries.singleOrNull { it.displayName == resultLabel }
                 ?: throw InvalidAiInputException("霊媒結果報告の結果が不正です: $resultLabel")
-            val statement = Statement.MediumReport(this, resolveTarget(context, targetName), result, comment)
-            if (reportEligibility.disqualifies(statement)) throw InvalidAiInputException("報告可能な対象・結果ではありません: ${statement.text()}")
-            statement
+            Statement.MediumReport(this, resolveTarget(context, targetName), result, comment)
         }
         StatementType.ROLE_CLAIM -> {
             val (roleName, comment) = statementFormat.extractRoleClaimParts(content)

--- a/src/main/kotlin/werewolf/ai/StatementFormat.kt
+++ b/src/main/kotlin/werewolf/ai/StatementFormat.kt
@@ -3,6 +3,7 @@ package werewolf.ai
 import werewolf.game.DiscussionContext
 import werewolf.game.DivineResult
 import werewolf.game.MediumResult
+import werewolf.game.ReportEligibility
 import werewolf.game.Role
 import werewolf.game.StatementType
 import werewolf.game.selectableTypes
@@ -10,9 +11,9 @@ import werewolf.game.selectableTypes
 data class ParsedStatement(val content: String, val typeLabel: String, val intent: String)
 
 class StatementFormat {
-    fun buildInstruction(context: DiscussionContext, claimableRoles: Set<Role>): String {
-        val types = availableTypes(context, claimableRoles)
-        val typeFormats = types.joinToString("\n") { "・${formatDescription(it, claimableRoles)}" }
+    fun buildInstruction(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): String {
+        val types = availableTypes(context, claimableRoles, reportEligibility)
+        val typeFormats = types.joinToString("\n") { "・${formatDescription(it, claimableRoles, reportEligibility)}" }
         // trimIndent()はテンプレート内の複数行にまたがる補間値には対応できないため、行単位で組み立てる
         return listOf(
             "【${context.title}】${context.description}",
@@ -28,8 +29,8 @@ class StatementFormat {
         ).joinToString("\n")
     }
 
-    private fun availableTypes(context: DiscussionContext, claimableRoles: Set<Role>): List<StatementType> =
-        StatementType.entries.filter { it in context.selectableTypes(claimableRoles) }
+    private fun availableTypes(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): List<StatementType> =
+        StatementType.entries.filter { it in context.selectableTypes(claimableRoles, reportEligibility) }
 
     fun parse(input: String): ParsedStatement {
         val (body, intent) = parseBodyAndIntent(input)
@@ -53,14 +54,34 @@ class StatementFormat {
         return typeLabel to content
     }
 
-    private fun formatDescription(type: StatementType, claimableRoles: Set<Role>): String = when (type) {
+    private fun formatDescription(type: StatementType, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): String = when (type) {
         StatementType.PLAIN -> "${type.displayName}：ゲーム上の発言（50文字以内）"
-        StatementType.DIVINATION_REPORT ->
-            "${type.displayName}：対象のプレイヤー名/結果（${DivineResult.entries.joinToString("か") { it.displayName }}）/補足コメント（省略可）"
-        StatementType.MEDIUM_REPORT ->
-            "${type.displayName}：対象のプレイヤー名/結果（${MediumResult.entries.joinToString("か") { it.displayName }}）/補足コメント（省略可）"
+        StatementType.DIVINATION_REPORT -> divinationReportFormat(reportEligibility)
+        StatementType.MEDIUM_REPORT -> mediumReportFormat(reportEligibility)
         StatementType.ROLE_CLAIM ->
             "${type.displayName}：申告する役職名（${claimableRoles.joinToString("か") { it.displayName }}）/補足コメント（省略可）"
+    }
+
+    private fun divinationReportFormat(reportEligibility: ReportEligibility): String = when (reportEligibility) {
+        is ReportEligibility.Honest -> {
+            val reportable = reportEligibility.divinations.entries.joinToString("、") { "${it.key.name}は${it.value.displayName}" }
+            "${StatementType.DIVINATION_REPORT.displayName}：対象のプレイヤー名/実際の占い結果/補足コメント（省略可）。報告できる対象と結果：$reportable"
+        }
+        is ReportEligibility.CanLie ->
+            "${StatementType.DIVINATION_REPORT.displayName}：対象のプレイヤー名/結果（${
+                DivineResult.entries.joinToString("か") { it.displayName }
+            }）/補足コメント（省略可）"
+    }
+
+    private fun mediumReportFormat(reportEligibility: ReportEligibility): String = when (reportEligibility) {
+        is ReportEligibility.Honest -> {
+            val reportable = reportEligibility.mediums.entries.joinToString("、") { "${it.key.name}は${it.value.displayName}" }
+            "${StatementType.MEDIUM_REPORT.displayName}：対象のプレイヤー名/実際の霊媒結果/補足コメント（省略可）。報告できる対象と結果：$reportable"
+        }
+        is ReportEligibility.CanLie ->
+            "${StatementType.MEDIUM_REPORT.displayName}：対象のプレイヤー名/結果（${
+                MediumResult.entries.joinToString("か") { it.displayName }
+            }）/補足コメント（省略可）"
     }
 
     fun extractReportParts(content: String): Triple<String, String, String> {

--- a/src/main/kotlin/werewolf/cpu/HonestCpuPlayer.kt
+++ b/src/main/kotlin/werewolf/cpu/HonestCpuPlayer.kt
@@ -4,6 +4,7 @@ import werewolf.game.Choice
 import werewolf.game.Claim
 import werewolf.game.DiscussionContext
 import werewolf.game.GameEvent
+import werewolf.game.ReportEligibility
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
@@ -16,9 +17,9 @@ class HonestCpuPlayer(role: Role, override val name: String) : CpuPlayer(role) {
         if (!event.isPublicKnowledge()) unspoken.add(event)
     }
 
-    override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim {
-        val statement = if (unspoken.isEmpty()) Statement.Plain("") else Statement.Plain(unspoken.removeFirst().body())
-        return Claim(this, context, statement, claimableRoles, "受け取った非公開情報を順番に開示")
+    override fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim {
+        val statement = if (unspoken.isEmpty()) Statement.Plain(this, "") else Statement.Plain(this, unspoken.removeFirst().body())
+        return Claim(this, context, statement, claimableRoles, reportEligibility, "受け取った非公開情報を順番に開示")
     }
 
     override fun choose(context: SelectionContext): Choice {

--- a/src/main/kotlin/werewolf/cpu/HunterCpuStrategy.kt
+++ b/src/main/kotlin/werewolf/cpu/HunterCpuStrategy.kt
@@ -2,15 +2,16 @@ package werewolf.cpu
 
 import werewolf.game.DiscussionContext
 import werewolf.game.Player
+import werewolf.game.ReportEligibility
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
-import werewolf.game.StatementType
 
 class HunterCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.HUNTER, CitizenVoting(self)) {
     private val query = KnowledgeQuery(self)
 
-    override fun buildStatement(context: DiscussionContext, availableTypes: Set<StatementType>) = Statement.Plain("")
+    override fun buildStatement(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility) =
+        Statement.Plain(self, "")
 
     override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
         when (context) {

--- a/src/main/kotlin/werewolf/cpu/MadmanCpuStrategy.kt
+++ b/src/main/kotlin/werewolf/cpu/MadmanCpuStrategy.kt
@@ -5,20 +5,22 @@ import werewolf.game.DivineResult
 import werewolf.game.GameEvent
 import werewolf.game.MediumResult
 import werewolf.game.Player
+import werewolf.game.ReportEligibility
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
 import werewolf.game.StatementType
+import werewolf.game.selectableTypes
 
 class MadmanCpuStrategy(
     self: RoleAwareCpuPlayer,
     private val impersonating: Role = listOf(Role.SEER, Role.MEDIUM).random(),
 ) : RoleAwareCpuStrategy(self, Role.MADMAN, WerewolfVoting(self)) {
 
-    override fun buildStatement(context: DiscussionContext, availableTypes: Set<StatementType>): Statement {
-        if (context.round > 1) return Statement.Plain("")
+    override fun buildStatement(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Statement {
+        if (context.round > 1) return Statement.Plain(self, "")
         val impersonatedType = if (impersonating == Role.SEER) StatementType.DIVINATION_REPORT else StatementType.MEDIUM_REPORT
-        if (impersonatedType !in availableTypes) return Statement.Plain("")
+        if (impersonatedType !in context.selectableTypes(claimableRoles, reportEligibility)) return Statement.Plain(self, "")
         return if (impersonating == Role.SEER) fakeSeerStatement(context) else fakeMediumStatement()
     }
 
@@ -28,7 +30,7 @@ class MadmanCpuStrategy(
     private fun fakeSeerStatement(context: DiscussionContext): Statement {
         val result = if (context.day == 1) DivineResult.NOT_WEREWOLF else DivineResult.WEREWOLF
         val target = context.players.filter { it !== self && it !in accusedByMe() }.randomOrNull()
-            ?: return Statement.Plain("")
+            ?: return Statement.Plain(self, "")
         return Statement.DivinationReport(self, target, result)
     }
 
@@ -36,7 +38,7 @@ class MadmanCpuStrategy(
         val target = self.knowledge.filterIsInstance<GameEvent.PlayerExecuted>()
             .map { it.executed }
             .firstOrNull { it !in fakeMediumedByMe() }
-            ?: return Statement.Plain("")
+            ?: return Statement.Plain(self, "")
         return Statement.MediumReport(self, target, MediumResult.NOT_WEREWOLF)
     }
 

--- a/src/main/kotlin/werewolf/cpu/MediumCpuStrategy.kt
+++ b/src/main/kotlin/werewolf/cpu/MediumCpuStrategy.kt
@@ -1,31 +1,22 @@
 package werewolf.cpu
 
 import werewolf.game.DiscussionContext
-import werewolf.game.GameEvent
 import werewolf.game.Player
+import werewolf.game.ReportEligibility
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
 import werewolf.game.StatementType
+import werewolf.game.selectableTypes
 
 class MediumCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.MEDIUM, CitizenVoting(self)) {
 
-    override fun buildStatement(context: DiscussionContext, availableTypes: Set<StatementType>): Statement {
-        if (StatementType.MEDIUM_REPORT !in availableTypes) return Statement.Plain("")
-        val next = nextUnreportedReveal() ?: return Statement.Plain("")
-        return Statement.MediumReport(self, next.target, next.result)
+    override fun buildStatement(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Statement {
+        if (StatementType.MEDIUM_REPORT !in context.selectableTypes(claimableRoles, reportEligibility)) return Statement.Plain(self, "")
+        val (target, result) = (reportEligibility as ReportEligibility.Honest).mediums.entries.first()
+        return Statement.MediumReport(self, target, result)
     }
 
     override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
         candidates.random()
-
-    private fun nextUnreportedReveal(): GameEvent.MediumRevealed? {
-        val reported = reportedTargets()
-        return self.knowledge.filterIsInstance<GameEvent.MediumRevealed>().firstOrNull { it.target !in reported }
-    }
-
-    private fun reportedTargets(): Set<Player> =
-        self.knowledge.filterIsInstance<GameEvent.StatementMade>()
-            .map { it.statement }.filterIsInstance<Statement.MediumReport>()
-            .filter { it.claimant === self }.map { it.target }.toSet()
 }

--- a/src/main/kotlin/werewolf/cpu/RandomCpuPlayer.kt
+++ b/src/main/kotlin/werewolf/cpu/RandomCpuPlayer.kt
@@ -4,13 +4,14 @@ import werewolf.game.Choice
 import werewolf.game.Claim
 import werewolf.game.DiscussionContext
 import werewolf.game.GameEvent
+import werewolf.game.ReportEligibility
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
 
 class RandomCpuPlayer(role: Role, override val name: String) : CpuPlayer(role) {
     override fun choose(context: SelectionContext): Choice = Choice(this, context, context.candidates().random(), "ランダム選択")
-    override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim =
-        Claim(this, context, Statement.Plain(""), claimableRoles, "発言戦略なし")
+    override fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim =
+        Claim(this, context, Statement.Plain(this, ""), claimableRoles, reportEligibility, "発言戦略なし")
     override fun onReceive(event: GameEvent) { /* does not use received events */ }
 }

--- a/src/main/kotlin/werewolf/cpu/RoleAwareCpuPlayer.kt
+++ b/src/main/kotlin/werewolf/cpu/RoleAwareCpuPlayer.kt
@@ -4,9 +4,9 @@ import werewolf.game.Choice
 import werewolf.game.Claim
 import werewolf.game.DiscussionContext
 import werewolf.game.GameEvent
+import werewolf.game.ReportEligibility
 import werewolf.game.Role
 import werewolf.game.SelectionContext
-import werewolf.game.selectableTypes
 
 class RoleAwareCpuPlayer(val myRole: Role, override val name: String) : CpuPlayer(myRole) {
     private val _knowledge = mutableListOf<GameEvent>()
@@ -18,9 +18,9 @@ class RoleAwareCpuPlayer(val myRole: Role, override val name: String) : CpuPlaye
     ).single { it.appliesTo() }
 
     override fun onReceive(event: GameEvent) { _knowledge.add(event) }
-    override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim {
-        val statement = strategy.buildStatement(context, context.selectableTypes(claimableRoles))
-        return Claim(this, context, statement, claimableRoles, "役職戦略に基づく発言")
+    override fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim {
+        val statement = strategy.buildStatement(context, claimableRoles, reportEligibility)
+        return Claim(this, context, statement, claimableRoles, reportEligibility, "役職戦略に基づく発言")
     }
     override fun choose(context: SelectionContext) = Choice(this, context, strategy.selectTarget(context), "戦略による選択")
 }

--- a/src/main/kotlin/werewolf/cpu/RoleAwareCpuStrategy.kt
+++ b/src/main/kotlin/werewolf/cpu/RoleAwareCpuStrategy.kt
@@ -2,10 +2,10 @@ package werewolf.cpu
 
 import werewolf.game.DiscussionContext
 import werewolf.game.Player
+import werewolf.game.ReportEligibility
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
-import werewolf.game.StatementType
 
 abstract class RoleAwareCpuStrategy(
     protected val self: RoleAwareCpuPlayer,
@@ -14,7 +14,7 @@ abstract class RoleAwareCpuStrategy(
 ) {
     fun appliesTo() = self.myRole == targetRole
 
-    abstract fun buildStatement(context: DiscussionContext, availableTypes: Set<StatementType>): Statement
+    abstract fun buildStatement(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Statement
 
     fun selectTarget(context: SelectionContext): Player {
         val candidates = context.candidates()

--- a/src/main/kotlin/werewolf/cpu/RollerCpuPlayer.kt
+++ b/src/main/kotlin/werewolf/cpu/RollerCpuPlayer.kt
@@ -4,6 +4,7 @@ import werewolf.game.Choice
 import werewolf.game.Claim
 import werewolf.game.DiscussionContext
 import werewolf.game.GameEvent
+import werewolf.game.ReportEligibility
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
@@ -16,7 +17,7 @@ class RollerCpuPlayer(role: Role, override val name: String) : CpuPlayer(role) {
         return Choice(this, context, candidates[selectCount++ % candidates.size], "順番通りに選択")
     }
 
-    override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim =
-        Claim(this, context, Statement.Plain(""), claimableRoles, "発言戦略なし")
+    override fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim =
+        Claim(this, context, Statement.Plain(this, ""), claimableRoles, reportEligibility, "発言戦略なし")
     override fun onReceive(event: GameEvent) { /* does not use received events */ }
 }

--- a/src/main/kotlin/werewolf/cpu/SeerCpuStrategy.kt
+++ b/src/main/kotlin/werewolf/cpu/SeerCpuStrategy.kt
@@ -1,31 +1,22 @@
 package werewolf.cpu
 
 import werewolf.game.DiscussionContext
-import werewolf.game.GameEvent
 import werewolf.game.Player
+import werewolf.game.ReportEligibility
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
 import werewolf.game.StatementType
+import werewolf.game.selectableTypes
 
 class SeerCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.SEER, SeerVoting(self)) {
 
-    override fun buildStatement(context: DiscussionContext, availableTypes: Set<StatementType>): Statement {
-        if (StatementType.DIVINATION_REPORT !in availableTypes) return Statement.Plain("")
-        val next = nextUnreportedDivination() ?: return Statement.Plain("")
-        return Statement.DivinationReport(self, next.target, next.result)
+    override fun buildStatement(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Statement {
+        if (StatementType.DIVINATION_REPORT !in context.selectableTypes(claimableRoles, reportEligibility)) return Statement.Plain(self, "")
+        val (target, result) = (reportEligibility as ReportEligibility.Honest).divinations.entries.first()
+        return Statement.DivinationReport(self, target, result)
     }
 
     override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
         candidates.random()
-
-    private fun nextUnreportedDivination(): GameEvent.Divined? {
-        val reported = reportedTargets()
-        return self.knowledge.filterIsInstance<GameEvent.Divined>().firstOrNull { it.target !in reported }
-    }
-
-    private fun reportedTargets(): Set<Player> =
-        self.knowledge.filterIsInstance<GameEvent.StatementMade>()
-            .map { it.statement }.filterIsInstance<Statement.DivinationReport>()
-            .filter { it.claimant === self }.map { it.target }.toSet()
 }

--- a/src/main/kotlin/werewolf/cpu/VillagerCpuStrategy.kt
+++ b/src/main/kotlin/werewolf/cpu/VillagerCpuStrategy.kt
@@ -2,14 +2,15 @@ package werewolf.cpu
 
 import werewolf.game.DiscussionContext
 import werewolf.game.Player
+import werewolf.game.ReportEligibility
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
-import werewolf.game.StatementType
 
 class VillagerCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.VILLAGER, CitizenVoting(self)) {
 
-    override fun buildStatement(context: DiscussionContext, availableTypes: Set<StatementType>) = Statement.Plain("")
+    override fun buildStatement(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility) =
+        Statement.Plain(self, "")
 
     override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
         candidates.random()

--- a/src/main/kotlin/werewolf/cpu/WerewolfCpuStrategy.kt
+++ b/src/main/kotlin/werewolf/cpu/WerewolfCpuStrategy.kt
@@ -2,15 +2,16 @@ package werewolf.cpu
 
 import werewolf.game.DiscussionContext
 import werewolf.game.Player
+import werewolf.game.ReportEligibility
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
-import werewolf.game.StatementType
 
 class WerewolfCpuStrategy(self: RoleAwareCpuPlayer) : RoleAwareCpuStrategy(self, Role.WEREWOLF, WerewolfVoting(self)) {
     private val query = KnowledgeQuery(self)
 
-    override fun buildStatement(context: DiscussionContext, availableTypes: Set<StatementType>) = Statement.Plain("")
+    override fun buildStatement(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility) =
+        Statement.Plain(self, "")
 
     override fun selectTargetForOthers(context: SelectionContext, candidates: List<Player>): Player =
         when (context) {

--- a/src/main/kotlin/werewolf/game/Claim.kt
+++ b/src/main/kotlin/werewolf/game/Claim.kt
@@ -1,10 +1,12 @@
 package werewolf.game
 
+@Suppress("LongParameterList")
 sealed class Claim(
     val speaker: Player,
     val context: DiscussionContext,
     val statement: Statement,
     claimableRoles: Set<Role>,
+    reportEligibility: ReportEligibility,
     private val intentForRecall: String,
     private val intentForChronicle: String,
 ) : Recallable() {
@@ -12,8 +14,11 @@ sealed class Claim(
         require(statement.type in context.availableTypes) {
             "${statement.type} is not available in ${context.title}"
         }
-        require(statement.type in context.selectableTypes(claimableRoles)) {
+        require(statement.type in context.selectableTypes(claimableRoles, reportEligibility)) {
             "${statement.type} is not available for ${speaker.name} now. context:${context.title}, claimable roles: $claimableRoles."
+        }
+        require(!reportEligibility.disqualifies(statement)) {
+            "${statement.type} is not reportable by ${speaker.name} with the given target/result: ${statement.text()}"
         }
         if (statement is Statement.RoleClaim) {
             require(statement.role in claimableRoles) {
@@ -26,13 +31,15 @@ sealed class Claim(
     override fun toChronicleView() = ChronicleView.Action(speaker.name, context.title, statement.text(), intentForChronicle)
 
     companion object {
+        @Suppress("LongParameterList")
         operator fun invoke(
             speaker: Player,
             context: DiscussionContext,
             statement: Statement,
             claimableRoles: Set<Role>,
+            reportEligibility: ReportEligibility,
             intent: String,
-        ): Claim = NormalClaim(speaker, context, statement, claimableRoles, intent, intent)
+        ): Claim = NormalClaim(speaker, context, statement, claimableRoles, reportEligibility, intent, intent)
 
         @Suppress("LongParameterList")
         operator fun invoke(
@@ -40,23 +47,26 @@ sealed class Claim(
             context: DiscussionContext,
             statement: Statement,
             claimableRoles: Set<Role>,
+            reportEligibility: ReportEligibility,
             intentForRecall: String,
             intentForChronicle: String,
-        ): Claim = NormalClaim(speaker, context, statement, claimableRoles, intentForRecall, intentForChronicle)
+        ): Claim = NormalClaim(speaker, context, statement, claimableRoles, reportEligibility, intentForRecall, intentForChronicle)
     }
 }
 
+@Suppress("LongParameterList")
 private class NormalClaim(
     speaker: Player,
     context: DiscussionContext,
     statement: Statement,
     claimableRoles: Set<Role>,
+    reportEligibility: ReportEligibility,
     intentForRecall: String,
     intentForChronicle: String,
-) : Claim(speaker, context, statement, claimableRoles, intentForRecall, intentForChronicle)
+) : Claim(speaker, context, statement, claimableRoles, reportEligibility, intentForRecall, intentForChronicle)
 
 class FallbackClaim(speaker: Player, context: DiscussionContext) : Claim(
-    speaker, context, Statement.Plain(""), emptySet(),
+    speaker, context, Statement.Plain(speaker, ""), emptySet(), ReportEligibility.Honest(),
     intentForRecall = "回答取得に失敗したため空文字を返却",
     intentForChronicle = "回答取得に失敗したため空文字を返却",
 )

--- a/src/main/kotlin/werewolf/game/DiscussionContext.kt
+++ b/src/main/kotlin/werewolf/game/DiscussionContext.kt
@@ -32,5 +32,7 @@ sealed class DiscussionContext {
     }
 }
 
-fun DiscussionContext.selectableTypes(claimableRoles: Set<Role>): Set<StatementType> =
-    if (claimableRoles.isEmpty()) availableTypes - StatementType.ROLE_CLAIM else availableTypes
+fun DiscussionContext.selectableTypes(claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Set<StatementType> {
+    val types = if (claimableRoles.isEmpty()) availableTypes - StatementType.ROLE_CLAIM else availableTypes
+    return types - reportEligibility.disallowedTypes()
+}

--- a/src/main/kotlin/werewolf/game/Player.kt
+++ b/src/main/kotlin/werewolf/game/Player.kt
@@ -22,17 +22,18 @@ abstract class Player(private val role: Role) : Notifiable {
     }
     protected abstract fun choose(context: SelectionContext): Choice
     fun discuss(context: DiscussionContext): Statement {
-        val claim = speak(context, claimableRoles())
+        val claim = speak(context, claimableRoles(), ReportEligibility.forRole(role, _memories, this))
         require(claim.speaker === this) { "${claim.speaker.name} is not the speaking player" }
         _memories.add(claim)
         return claim.statement
     }
-    protected abstract fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim
+    protected abstract fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim
 
     private fun claimableRoles(): Set<Role> {
         val alreadyRevealed = ClaimedRole(_memories).of(this) == role
         return RoleClaimPolicy.claimableRoles(role, alreadyRevealed)
     }
+
     abstract fun watchEpilogue(chronicles: List<ChronicleView>)
 
     protected fun memorize(recallable: Recallable) {

--- a/src/main/kotlin/werewolf/game/Player.kt
+++ b/src/main/kotlin/werewolf/game/Player.kt
@@ -24,6 +24,7 @@ abstract class Player(private val role: Role) : Notifiable {
     fun discuss(context: DiscussionContext): Statement {
         val claim = speak(context, claimableRoles(), ReportEligibility.forRole(role, _memories, this))
         require(claim.speaker === this) { "${claim.speaker.name} is not the speaking player" }
+        require(claim.statement.claimant === this) { "${claim.statement.claimant.name} is not the statement's claimant" }
         _memories.add(claim)
         return claim.statement
     }

--- a/src/main/kotlin/werewolf/game/ReportEligibility.kt
+++ b/src/main/kotlin/werewolf/game/ReportEligibility.kt
@@ -1,0 +1,55 @@
+package werewolf.game
+
+sealed class ReportEligibility {
+    abstract fun disallowedTypes(): Set<StatementType>
+    abstract fun disqualifies(statement: Statement): Boolean
+    abstract fun divinationCandidates(): List<Player>
+    abstract fun mediumCandidates(): List<Player>
+    abstract fun divinationResults(target: Player): List<DivineResult>
+    abstract fun mediumResults(target: Player): List<MediumResult>
+
+    data class Honest(
+        val divinations: Map<Player, DivineResult> = emptyMap(),
+        val mediums: Map<Player, MediumResult> = emptyMap(),
+    ) : ReportEligibility() {
+        override fun disallowedTypes(): Set<StatementType> = buildSet {
+            if (divinations.isEmpty()) add(StatementType.DIVINATION_REPORT)
+            if (mediums.isEmpty()) add(StatementType.MEDIUM_REPORT)
+        }
+
+        override fun disqualifies(statement: Statement): Boolean = when (statement) {
+            is Statement.DivinationReport -> divinations[statement.target] != statement.result
+            is Statement.MediumReport -> mediums[statement.target] != statement.result
+            else -> false
+        }
+
+        override fun divinationCandidates(): List<Player> = divinations.keys.toList()
+        override fun mediumCandidates(): List<Player> = mediums.keys.toList()
+        override fun divinationResults(target: Player): List<DivineResult> = listOf(divinations.getValue(target))
+        override fun mediumResults(target: Player): List<MediumResult> = listOf(mediums.getValue(target))
+    }
+
+    data class CanLie(private val otherPlayers: List<Player>) : ReportEligibility() {
+        override fun disallowedTypes(): Set<StatementType> = emptySet()
+        override fun disqualifies(statement: Statement): Boolean = false
+        override fun divinationCandidates(): List<Player> = otherPlayers
+        override fun mediumCandidates(): List<Player> = otherPlayers
+        override fun divinationResults(target: Player): List<DivineResult> = DivineResult.entries
+        override fun mediumResults(target: Player): List<MediumResult> = MediumResult.entries
+    }
+
+    companion object {
+        fun forRole(role: Role, memories: List<Recallable>, self: Player): ReportEligibility {
+            val unreported = UnreportedResults(memories, self)
+            return when (role) {
+                Role.SEER -> Honest(divinations = unreported.divinations)
+                Role.MEDIUM -> Honest(mediums = unreported.mediums)
+                Role.WEREWOLF, Role.MADMAN -> CanLie(otherPlayers(memories, self))
+                Role.VILLAGER, Role.HUNTER -> Honest()
+            }
+        }
+
+        private fun otherPlayers(memories: List<Recallable>, self: Player): List<Player> =
+            memories.filterIsInstance<GameEvent.PlayersAnnounced>().firstOrNull()?.players.orEmpty().filter { it !== self }
+    }
+}

--- a/src/main/kotlin/werewolf/game/Statement.kt
+++ b/src/main/kotlin/werewolf/game/Statement.kt
@@ -1,16 +1,17 @@
 package werewolf.game
 
 sealed class Statement {
+    abstract val claimant: Player
     abstract val type: StatementType
     abstract fun text(): String
 
-    data class Plain(private val content: String) : Statement() {
+    data class Plain(override val claimant: Player, private val content: String) : Statement() {
         override val type = StatementType.PLAIN
         override fun text() = content
     }
 
     data class DivinationReport(
-        val claimant: Player,
+        override val claimant: Player,
         val target: Player,
         val result: DivineResult,
         val comment: String = "",
@@ -20,7 +21,7 @@ sealed class Statement {
     }
 
     data class MediumReport(
-        val claimant: Player,
+        override val claimant: Player,
         val target: Player,
         val result: MediumResult,
         val comment: String = "",
@@ -30,7 +31,7 @@ sealed class Statement {
     }
 
     data class RoleClaim(
-        val claimant: Player,
+        override val claimant: Player,
         val role: Role,
         val comment: String = "",
     ) : Statement() {

--- a/src/main/kotlin/werewolf/game/UnreportedResults.kt
+++ b/src/main/kotlin/werewolf/game/UnreportedResults.kt
@@ -1,0 +1,20 @@
+package werewolf.game
+
+class UnreportedResults(memories: List<Recallable>, self: Player) {
+    private val divined = memories.filterIsInstance<GameEvent.Divined>().associate { it.target to it.result }
+    private val mediumRevealed = memories.filterIsInstance<GameEvent.MediumRevealed>().associate { it.target to it.result }
+    private val ownStatements = memories.filterIsInstance<GameEvent.StatementMade>()
+        .map { it.statement }.filter { it.claimant === self }
+
+    val divinations: Map<Player, DivineResult>
+        get() = divined - ownDivinationReports().keys
+
+    val mediums: Map<Player, MediumResult>
+        get() = mediumRevealed - ownMediumReports().keys
+
+    private fun ownDivinationReports(): Map<Player, DivineResult> =
+        ownStatements.filterIsInstance<Statement.DivinationReport>().associate { it.target to it.result }
+
+    private fun ownMediumReports(): Map<Player, MediumResult> =
+        ownStatements.filterIsInstance<Statement.MediumReport>().associate { it.target to it.result }
+}

--- a/src/main/kotlin/werewolf/human/HumanPlayer.kt
+++ b/src/main/kotlin/werewolf/human/HumanPlayer.kt
@@ -4,10 +4,9 @@ import werewolf.game.Choice
 import werewolf.game.Claim
 import werewolf.game.ChronicleView
 import werewolf.game.DiscussionContext
-import werewolf.game.DivineResult
 import werewolf.game.GameEvent
-import werewolf.game.MediumResult
 import werewolf.game.Player
+import werewolf.game.ReportEligibility
 import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
@@ -27,9 +26,8 @@ class HumanPlayer(role: Role, override val name: String, private val io: HumanIO
     private var lastDivinationSummary: DivinationView? = null
 
     override fun choose(context: SelectionContext): Choice {
-        val candidates = context.candidates()
-        val selected = io.promptChoice(ChoiceView(context.title, context.description, candidates.map { it.name }))
-        val choice = Choice(this, context, candidates.single { it.name == selected }, "プレイヤーが選択")
+        val selected = select(context.title, context.description, context.candidates()) { it.name }
+        val choice = Choice(this, context, selected, "プレイヤーが選択")
         io.display(choice.toRecallView())
         return choice
     }
@@ -49,57 +47,51 @@ class HumanPlayer(role: Role, override val name: String, private val io: HumanIO
         }
     }
 
-    override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim {
-        val type = selectType(context, claimableRoles)
+    override fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim {
+        val type = selectType(context, claimableRoles, reportEligibility)
         val statement = when (type) {
             StatementType.PLAIN -> buildPlain(context)
-            StatementType.DIVINATION_REPORT -> buildDivinationReport(context)
-            StatementType.MEDIUM_REPORT -> buildMediumReport(context)
+            StatementType.DIVINATION_REPORT -> buildDivinationReport(reportEligibility)
+            StatementType.MEDIUM_REPORT -> buildMediumReport(reportEligibility)
             StatementType.ROLE_CLAIM -> buildRoleClaim(claimableRoles)
         }
-        return Claim(this, context, statement, claimableRoles, "プレイヤーが発言")
+        return Claim(this, context, statement, claimableRoles, reportEligibility, "プレイヤーが発言")
     }
 
-    private fun selectType(context: DiscussionContext, claimableRoles: Set<Role>): StatementType {
-        val types = StatementType.entries.filter { it in context.selectableTypes(claimableRoles) }
-        if (types.size == 1) return types.first()
-        val selected = io.promptChoice(ChoiceView(context.title, context.description, types.map { it.displayName }))
-        return types.single { it.displayName == selected }
+    private fun selectType(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): StatementType {
+        val types = StatementType.entries.filter { it in context.selectableTypes(claimableRoles, reportEligibility) }
+        return select(context.title, context.description, types) { it.displayName }
     }
 
     private fun buildPlain(context: DiscussionContext): Statement =
-        Statement.Plain(io.promptFreeText(context.title, "発言してください"))
+        Statement.Plain(this, io.promptFreeText(context.title, "発言してください"))
 
-    private fun buildDivinationReport(context: DiscussionContext): Statement {
-        val candidates = context.allPlayers.filter { it !== this }
-        val targetName = io.promptChoice(ChoiceView("占い報告 - 対象", "誰の占い結果を報告しますか？", candidates.map { it.name }))
-        val target = candidates.single { it.name == targetName }
-        val results = DivineResult.entries
-        val resultName = io.promptChoice(ChoiceView("占い報告 - 結果", "占い結果を選んでください", results.map { it.displayName }))
+    private fun buildDivinationReport(reportEligibility: ReportEligibility): Statement {
+        val target = select("占い報告 - 対象", "誰の占い結果を報告しますか？", reportEligibility.divinationCandidates()) { it.name }
+        val result = select("占い報告 - 結果", "占い結果を選んでください", reportEligibility.divinationResults(target)) { it.displayName }
         val comment = io.promptFreeText("占い報告 - 補足", COMMENT_PROMPT)
-        return Statement.DivinationReport(this, target, results.single { it.displayName == resultName }, comment)
+        return Statement.DivinationReport(this, target, result, comment)
     }
 
-    private fun buildMediumReport(context: DiscussionContext): Statement {
-        val candidates = context.allPlayers.filter { it !== this }
-        val targetName = io.promptChoice(ChoiceView("霊媒報告 - 対象", "誰の霊媒結果を報告しますか？", candidates.map { it.name }))
-        val target = candidates.single { it.name == targetName }
-        val results = MediumResult.entries
-        val resultName = io.promptChoice(ChoiceView("霊媒報告 - 結果", "霊媒結果を選んでください", results.map { it.displayName }))
+    private fun buildMediumReport(reportEligibility: ReportEligibility): Statement {
+        val target = select("霊媒報告 - 対象", "誰の霊媒結果を報告しますか？", reportEligibility.mediumCandidates()) { it.name }
+        val result = select("霊媒報告 - 結果", "霊媒結果を選んでください", reportEligibility.mediumResults(target)) { it.displayName }
         val comment = io.promptFreeText("霊媒報告 - 補足", COMMENT_PROMPT)
-        return Statement.MediumReport(this, target, results.single { it.displayName == resultName }, comment)
+        return Statement.MediumReport(this, target, result, comment)
     }
 
     private fun buildRoleClaim(claimableRoles: Set<Role>): Statement {
-        val roles = claimableRoles.toList()
-        val role = if (roles.size == 1) {
-            roles.single()
-        } else {
-            val roleName = io.promptChoice(ChoiceView("役職申告 - 役職", "申告する役職を選んでください", roles.map { it.displayName }))
-            roles.single { it.displayName == roleName }
-        }
+        val role = select("役職申告 - 役職", "申告する役職を選んでください", claimableRoles.toList()) { it.displayName }
         val comment = io.promptFreeText("役職申告 - 補足", COMMENT_PROMPT)
         return Statement.RoleClaim(this, role, comment)
+    }
+
+    private fun <T> select(title: String, description: String, candidates: List<T>, label: (T) -> String): T =
+        if (candidates.size == 1) candidates.single() else promptChoice(title, description, candidates, label)
+
+    private fun <T> promptChoice(title: String, description: String, candidates: List<T>, label: (T) -> String): T {
+        val selected = io.promptChoice(ChoiceView(title, description, candidates.map(label)))
+        return candidates.single { label(it) == selected }
     }
 
     override fun watchEpilogue(chronicles: List<ChronicleView>) {

--- a/src/test/kotlin/werewolf/AiPlayerSpeakTest.kt
+++ b/src/test/kotlin/werewolf/AiPlayerSpeakTest.kt
@@ -3,10 +3,12 @@ package werewolf
 import werewolf.ai.AiPlayer
 import werewolf.ai.InvalidAiInput
 import werewolf.ai.ModelMetadata
+import werewolf.game.AllPlayers
 import werewolf.game.ChronicleView
 import werewolf.game.Claim
 import werewolf.game.DiscussionContext
 import werewolf.game.DivineResult
+import werewolf.game.GameEvent
 import werewolf.game.MediumResult
 import werewolf.game.Role
 import werewolf.game.Statement
@@ -50,17 +52,16 @@ class AiPlayerSpeakTest {
     @Test
     fun `discuss prompt includes format instruction for every available type`() {
         val lm = FakeLanguageModel("発言する：hello[真意]")
+        val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
         val seer = AiPlayer(Role.SEER, "Seer", lm, testInstruction("Seer"))
-        seer.discuss(openContext())
+        GameEvent.Divined.send(wolf, DivineResult.WEREWOLF, seer)
+        seer.discuss(openContext(listOf(seer, wolf)))
         assertContains(lm.prompts.first(), "発言する：ゲーム上の発言（50文字以内）")
         assertContains(
             lm.prompts.first(),
-            "占い結果を報告する：対象のプレイヤー名/結果（人狼か人狼以外）/補足コメント（省略可）",
+            "占い結果を報告する：対象のプレイヤー名/実際の占い結果/補足コメント（省略可）。報告できる対象と結果：Wolfは人狼",
         )
-        assertContains(
-            lm.prompts.first(),
-            "霊媒結果を報告する：対象のプレイヤー名/結果（人狼か人狼以外）/補足コメント（省略可）",
-        )
+        assertFalse(lm.prompts.first().contains("霊媒結果を報告する"))
         assertContains(
             lm.prompts.first(),
             "役職を開示する：申告する役職名（占い師）/補足コメント（省略可）",
@@ -113,24 +114,26 @@ class AiPlayerSpeakTest {
 
     @Test
     fun `discuss selects DIVINATION_REPORT and builds a report with target result and comment`() {
-        val alice = NothingPlayer(Role.WEREWOLF, "Alice")
-        val lm = FakeLanguageModel("占い結果を報告する：Alice/人狼/怪しい発言が多かったので[占い師として信頼を得るため]")
+        val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
+        val lm = FakeLanguageModel("占い結果を報告する：Wolf/人狼/怪しい発言が多かったので[占い師として信頼を得るため]")
         val seer = AiPlayer(Role.SEER, "Seer", lm, testInstruction("Seer"))
-        val result = seer.discuss(openContext(listOf(seer, alice)))
+        GameEvent.Divined.send(wolf, DivineResult.WEREWOLF, seer)
+        val result = seer.discuss(openContext(listOf(seer, wolf)))
         val report = assertIs<Statement.DivinationReport>(result)
-        assertEquals(alice, report.target)
+        assertEquals(wolf, report.target)
         assertEquals(DivineResult.WEREWOLF, report.result)
         assertEquals("怪しい発言が多かったので", report.comment)
     }
 
     @Test
     fun `discuss selects MEDIUM_REPORT and omits comment when not provided`() {
-        val alice = NothingPlayer(Role.VILLAGER, "Alice")
-        val lm = FakeLanguageModel("霊媒結果を報告する：Alice/人狼以外[霊能者として信頼を得るため]")
+        val villager = NothingPlayer(Role.VILLAGER, "Villager")
+        val lm = FakeLanguageModel("霊媒結果を報告する：Villager/人狼以外[霊能者として信頼を得るため]")
         val medium = AiPlayer(Role.MEDIUM, "Medium", lm, testInstruction("Medium"))
-        val result = medium.discuss(openContext(listOf(medium, alice)))
+        GameEvent.MediumRevealed.send(villager, MediumResult.NOT_WEREWOLF, medium)
+        val result = medium.discuss(openContext(listOf(medium, villager)))
         val report = assertIs<Statement.MediumReport>(result)
-        assertEquals(alice, report.target)
+        assertEquals(villager, report.target)
         assertEquals(MediumResult.NOT_WEREWOLF, report.result)
         assertEquals("", report.comment)
     }
@@ -187,6 +190,38 @@ class AiPlayerSpeakTest {
         )
         val villager = AiPlayer(Role.VILLAGER, "Villager", lm, testInstruction())
         val result = villager.discuss(openContext(listOf(villager)))
+        assertIs<Statement.Plain>(result)
+        assertEquals("", result.text())
+    }
+
+    @Test
+    fun `discuss falls back when reported divination result does not match the actual result`() {
+        val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
+        val lm = FakeLanguageModel(
+            "占い結果を報告する：Wolf/人狼以外/コメント[意図]",
+            "占い結果を報告する：Wolf/人狼以外/コメント[意図]",
+        )
+        val seer = AiPlayer(Role.SEER, "Seer", lm, testInstruction("Seer"))
+        GameEvent.Divined.send(wolf, DivineResult.WEREWOLF, seer)
+        val result = seer.discuss(openContext(listOf(seer, wolf)))
+        assertIs<Statement.Plain>(result)
+        assertEquals("", result.text())
+    }
+
+    @Test
+    fun `discuss falls back when reporting a divination target already reported`() {
+        val wolf = ReceivingPlayer(Role.WEREWOLF, "Wolf")
+        val lm = FakeLanguageModel(
+            "占い結果を報告する：Wolf/人狼/コメント[意図]",
+            "占い結果を報告する：Wolf/人狼/コメント[意図]",
+        )
+        val seer = AiPlayer(Role.SEER, "Seer", lm, testInstruction("Seer"))
+        val allPlayers = AllPlayers(TestLodge(seer to Role.SEER, wolf to Role.WEREWOLF).create().playerManager)
+        GameEvent.Divined.send(wolf, DivineResult.WEREWOLF, seer)
+        GameEvent.StatementMade.send(1, seer.name, Statement.DivinationReport(seer, wolf, DivineResult.WEREWOLF), allPlayers)
+
+        val result = seer.discuss(openContext(listOf(seer, wolf)))
+
         assertIs<Statement.Plain>(result)
         assertEquals("", result.text())
     }

--- a/src/test/kotlin/werewolf/AiPlayerTest.kt
+++ b/src/test/kotlin/werewolf/AiPlayerTest.kt
@@ -59,7 +59,7 @@ class AiPlayerTest {
         val setup = TestLodge(villager to Role.VILLAGER, alice to Role.VILLAGER).create()
         val allPlayers = AllPlayers(setup.playerManager)
 
-        GameEvent.StatementMade.send(1, "Alice", Statement.Plain("怪しい人がいます"), allPlayers)
+        GameEvent.StatementMade.send(1, "Alice", Statement.Plain(alice, "怪しい人がいます"), allPlayers)
         villager.discuss(openContext())
 
         assertContains(lm.prompts.first(), "Alice: 怪しい人がいます")

--- a/src/test/kotlin/werewolf/ClaimTest.kt
+++ b/src/test/kotlin/werewolf/ClaimTest.kt
@@ -17,7 +17,7 @@ class ClaimTest {
         val context = DiscussionContext.Conclave(1, 1, listOf(speaker), listOf(speaker))
         val statement = Statement.DivinationReport(speaker, speaker, DivineResult.WEREWOLF)
         assertFailsWith<IllegalArgumentException> {
-            Claim(speaker, context, statement, emptySet(), "意図")
+            Claim(speaker, context, statement, emptySet(), ReportEligibility.Honest(), "意図")
         }
     }
 
@@ -25,7 +25,7 @@ class ClaimTest {
     fun `Claim does not throw when statement type is available`() {
         val speaker = NothingPlayer(Role.VILLAGER, "Speaker")
         val context = openContext(listOf(speaker))
-        assertNotNull(Claim(speaker, context, Statement.Plain("発言"), emptySet(), "意図"))
+        assertNotNull(Claim(speaker, context, Statement.Plain(speaker, "発言"), emptySet(), ReportEligibility.Honest(), "意図"))
     }
 
     @Test
@@ -34,7 +34,7 @@ class ClaimTest {
         val context = openContext(listOf(speaker))
         val statement = Statement.RoleClaim(speaker, Role.SEER)
         val exception = assertFailsWith<IllegalArgumentException> {
-            Claim(speaker, context, statement, emptySet(), "意図")
+            Claim(speaker, context, statement, emptySet(), ReportEligibility.Honest(), "意図")
         }
         assertContains(exception.message.orEmpty(), "is not available for")
     }
@@ -45,7 +45,7 @@ class ClaimTest {
         val context = openContext(listOf(speaker))
         val statement = Statement.RoleClaim(speaker, Role.WEREWOLF)
         val exception = assertFailsWith<IllegalArgumentException> {
-            Claim(speaker, context, statement, setOf(Role.SEER), "意図")
+            Claim(speaker, context, statement, setOf(Role.SEER), ReportEligibility.Honest(), "意図")
         }
         assertContains(exception.message.orEmpty(), "is not claimable by")
     }
@@ -55,14 +55,27 @@ class ClaimTest {
         val speaker = NothingPlayer(Role.SEER, "Speaker")
         val context = openContext(listOf(speaker))
         val statement = Statement.RoleClaim(speaker, Role.SEER)
-        assertNotNull(Claim(speaker, context, statement, setOf(Role.SEER), "意図"))
+        assertNotNull(Claim(speaker, context, statement, setOf(Role.SEER), ReportEligibility.Honest(), "意図"))
+    }
+
+    @Test
+    fun `Claim throws when reportEligibility disqualifies the statement`() {
+        val speaker = NothingPlayer(Role.SEER, "Speaker")
+        val target = NothingPlayer(Role.VILLAGER, "Target")
+        val context = openContext(listOf(speaker, target))
+        val statement = Statement.DivinationReport(speaker, target, DivineResult.WEREWOLF)
+        val reportEligibility = ReportEligibility.Honest(divinations = mapOf(target to DivineResult.NOT_WEREWOLF))
+        val exception = assertFailsWith<IllegalArgumentException> {
+            Claim(speaker, context, statement, emptySet(), reportEligibility, "意図")
+        }
+        assertContains(exception.message.orEmpty(), "is not reportable by")
     }
 
     @Test
     fun `toRecallView returns action with context title, content and intent`() {
         val speaker = NothingPlayer(Role.VILLAGER, "Speaker")
         val context = openContext(listOf(speaker))
-        val claim = Claim(speaker, context, Statement.Plain("発言内容"), emptySet(), "真意内容")
+        val claim = Claim(speaker, context, Statement.Plain(speaker, "発言内容"), emptySet(), ReportEligibility.Honest(), "真意内容")
         assertEquals(RecallView.SelfAction("議論", "発言内容", "真意内容"), claim.toRecallView())
     }
 
@@ -70,7 +83,7 @@ class ClaimTest {
     fun `toChronicleView returns action with speaker, context title, content and intent`() {
         val speaker = NothingPlayer(Role.VILLAGER, "Speaker")
         val context = openContext(listOf(speaker))
-        val claim = Claim(speaker, context, Statement.Plain("発言内容"), emptySet(), "真意内容")
+        val claim = Claim(speaker, context, Statement.Plain(speaker, "発言内容"), emptySet(), ReportEligibility.Honest(), "真意内容")
         assertEquals(ChronicleView.Action("Speaker", "議論", "発言内容", "真意内容"), claim.toChronicleView())
     }
 

--- a/src/test/kotlin/werewolf/ClaimedRoleTest.kt
+++ b/src/test/kotlin/werewolf/ClaimedRoleTest.kt
@@ -14,7 +14,7 @@ class ClaimedRoleTest {
     fun `returns null when player has not claimed anything`() {
         val player = ReceivingPlayer(Role.SEER, "Player")
         val allPlayers = AllPlayers(TestLodge(player to Role.SEER).create().playerManager)
-        GameEvent.StatementMade.send(1, player.name, Statement.Plain("hello"), allPlayers)
+        GameEvent.StatementMade.send(1, player.name, Statement.Plain(player, "hello"), allPlayers)
 
         assertNull(ClaimedRole(eventsFor(player)).of(player))
     }

--- a/src/test/kotlin/werewolf/ConclaveTest.kt
+++ b/src/test/kotlin/werewolf/ConclaveTest.kt
@@ -20,10 +20,10 @@ class ConclaveTest {
         var receivedStartedDay: Int? = null
         private var statementIndex = 0
 
-        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim {
+        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim {
             val statement = statements[statementIndex++]
             _log.add("$name:said:$statement")
-            return Claim(this, context, Statement.Plain(statement), claimableRoles, "")
+            return Claim(this, context, Statement.Plain(this, statement), claimableRoles, reportEligibility, "")
         }
 
         override fun onReceive(event: GameEvent) {

--- a/src/test/kotlin/werewolf/DayPhaseTest.kt
+++ b/src/test/kotlin/werewolf/DayPhaseTest.kt
@@ -14,9 +14,9 @@ class DayPhaseTest {
         role: Role, name: String, private val voteTarget: Player? = null
     ) : ReceivingPlayer(role, name) {
         var discussedCount = 0
-        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim {
+        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim {
             discussedCount++
-            return Claim(this, context, Statement.Plain(""), claimableRoles, "")
+            return Claim(this, context, Statement.Plain(this, ""), claimableRoles, reportEligibility, "")
         }
         override fun choose(context: SelectionContext): Choice =
             Choice(this, context, voteTarget?.takeIf { it in context.candidates() } ?: context.candidates().first(), "テスト用投票")

--- a/src/test/kotlin/werewolf/DiscussionTest.kt
+++ b/src/test/kotlin/werewolf/DiscussionTest.kt
@@ -19,10 +19,10 @@ class DiscussionTest {
         var receivedStartedDay: Int? = null
         private var statementIndex = 0
 
-        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim {
+        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim {
             val statement = statements[statementIndex++]
             _log.add("$name:said:$statement")
-            return Claim(this, context, Statement.Plain(statement), claimableRoles, "")
+            return Claim(this, context, Statement.Plain(this, statement), claimableRoles, reportEligibility, "")
         }
 
         override fun onReceive(event: GameEvent) {

--- a/src/test/kotlin/werewolf/GameNoteTest.kt
+++ b/src/test/kotlin/werewolf/GameNoteTest.kt
@@ -214,9 +214,10 @@ class GameNoteTest {
         val io = CapturingIO()
         val gameSetup = createGameWithHuman(io, "V2" to Role.VILLAGER, "Wolf" to Role.WEREWOLF)
         InitialPhase(gameSetup.playerManager, gameSetup.oracle).proceed()
+        val v2 = gameSetup.playerManager.allPlayers.single { it.name == "V2" }
         val allPlayers = AllPlayers(gameSetup.playerManager)
 
-        GameEvent.StatementMade.send(1, "V2", Statement.Plain("私は${Role.SEER.displayName}です"), allPlayers)
+        GameEvent.StatementMade.send(1, "V2", Statement.Plain(v2, "私は${Role.SEER.displayName}です"), allPlayers)
 
         assertEquals(null, claimedRoleOf(io.panels.last(), "V2"))
     }

--- a/src/test/kotlin/werewolf/GameRecapTest.kt
+++ b/src/test/kotlin/werewolf/GameRecapTest.kt
@@ -12,8 +12,8 @@ import kotlin.test.assertTrue
 class GameRecapTest {
 
     private class SpeakingPlayer(role: Role, name: String) : ReceivingPlayer(role, name) {
-        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim =
-            Claim(this, context, Statement.Plain("$name speaks"), claimableRoles, "intent")
+        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim =
+            Claim(this, context, Statement.Plain(this, "$name speaks"), claimableRoles, reportEligibility, "intent")
     }
 
     private fun playerManager(vararg players: Player): PlayerManager =

--- a/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
@@ -29,8 +29,8 @@ class HumanPlayerEpilogueTest {
     private class SpeakingPlayer(role: Role, name: String) : NothingPlayer(role, name) {
         override fun onReceive(event: GameEvent) {}
         override fun watchEpilogue(chronicles: List<ChronicleView>) {}
-        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim =
-            Claim(this, context, Statement.Plain("$name speaks"), claimableRoles, "intent")
+        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim =
+            Claim(this, context, Statement.Plain(this, "$name speaks"), claimableRoles, reportEligibility, "intent")
     }
 
     @Test

--- a/src/test/kotlin/werewolf/HumanPlayerTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerTest.kt
@@ -45,14 +45,28 @@ class HumanPlayerTest {
     @Test
     fun `choose presents non-self candidates as names and returns matching player`() {
         val alice = NothingPlayer(Role.VILLAGER, "Alice")
+        val bob = NothingPlayer(Role.VILLAGER, "Bob")
         val io = CapturingIO("Alice")
+        val human = HumanPlayer(Role.VILLAGER, "Human", io)
+        val context = SelectionContext.Vote(human, listOf(human, alice, bob))
+
+        val selected = human.selectTarget(context)
+
+        assertEquals(alice, selected)
+        assertEquals(listOf("Alice", "Bob"), io.promptedChoices.single().options)
+    }
+
+    @Test
+    fun `choose auto-selects without prompting when only one candidate exists`() {
+        val alice = NothingPlayer(Role.VILLAGER, "Alice")
+        val io = CapturingIO()
         val human = HumanPlayer(Role.VILLAGER, "Human", io)
         val context = SelectionContext.Vote(human, listOf(human, alice))
 
         val selected = human.selectTarget(context)
 
         assertEquals(alice, selected)
-        assertEquals(listOf("Alice"), io.promptedChoices.single().options)
+        assertTrue(io.promptedChoices.isEmpty())
     }
 
     @Test
@@ -78,94 +92,112 @@ class HumanPlayerTest {
 
         val statement = human.discuss(context)
 
-        assertEquals(Statement.Plain("hello"), statement)
+        assertEquals(Statement.Plain(human, "hello"), statement)
         assertTrue(io.promptedChoices.isEmpty())
     }
 
     @Test
     fun `speak in open discussion prompts for type then returns plain statement`() {
         val io = CapturingIO(StatementType.PLAIN.displayName, freeTextAnswer = "hello")
-        val human = HumanPlayer(Role.VILLAGER, "Human", io)
+        val human = HumanPlayer(Role.WEREWOLF, "Human", io)
         val context = DiscussionContext.Open(1, 1, listOf(human), listOf(human))
 
         val statement = human.discuss(context)
 
-        assertEquals(Statement.Plain("hello"), statement)
+        assertEquals(Statement.Plain(human, "hello"), statement)
         assertTrue(io.promptedChoices.single().options.contains(StatementType.PLAIN.displayName))
     }
 
     @Test
-    fun `speak with DIVINATION_REPORT prompts for target and result`() {
-        val alice = NothingPlayer(Role.VILLAGER, "Alice")
-        val io = CapturingIO(
-            StatementType.DIVINATION_REPORT.displayName,
-            "Alice",
-            DivineResult.WEREWOLF.displayName,
-        )
+    fun `speak with DIVINATION_REPORT prompts for target among multiple divinations and auto-fills the true result`() {
+        val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
+        val villager = NothingPlayer(Role.VILLAGER, "Villager")
+        val io = CapturingIO(StatementType.DIVINATION_REPORT.displayName, "Wolf")
         val human = HumanPlayer(Role.SEER, "Human", io)
-        val context = DiscussionContext.Open(1, 1, listOf(human), listOf(human, alice))
+        GameEvent.Divined.send(wolf, DivineResult.WEREWOLF, human)
+        GameEvent.Divined.send(villager, DivineResult.NOT_WEREWOLF, human)
+        val context = DiscussionContext.Open(1, 1, listOf(human), listOf(human, wolf, villager))
 
         val statement = human.discuss(context)
 
-        assertEquals(Statement.DivinationReport(human, alice, DivineResult.WEREWOLF), statement)
-        assertEquals(3, io.promptedChoices.size)
+        assertEquals(Statement.DivinationReport(human, wolf, DivineResult.WEREWOLF), statement)
+        assertEquals(2, io.promptedChoices.size)
     }
 
     @Test
-    fun `speak with MEDIUM_REPORT prompts for target and result`() {
-        val alice = NothingPlayer(Role.VILLAGER, "Alice")
-        val io = CapturingIO(
-            StatementType.MEDIUM_REPORT.displayName,
-            "Alice",
-            MediumResult.NOT_WEREWOLF.displayName,
-        )
+    fun `speak with MEDIUM_REPORT prompts for target among multiple mediums and auto-fills the true result`() {
+        val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
+        val villager = NothingPlayer(Role.VILLAGER, "Villager")
+        val io = CapturingIO(StatementType.MEDIUM_REPORT.displayName, "Wolf")
         val human = HumanPlayer(Role.MEDIUM, "Human", io)
-        val context = DiscussionContext.Open(1, 1, listOf(human), listOf(human, alice))
+        GameEvent.MediumRevealed.send(wolf, MediumResult.WEREWOLF, human)
+        GameEvent.MediumRevealed.send(villager, MediumResult.NOT_WEREWOLF, human)
+        val context = DiscussionContext.Open(1, 1, listOf(human), listOf(human, wolf, villager))
 
         val statement = human.discuss(context)
 
-        assertEquals(Statement.MediumReport(human, alice, MediumResult.NOT_WEREWOLF), statement)
-        assertEquals(3, io.promptedChoices.size)
+        assertEquals(Statement.MediumReport(human, wolf, MediumResult.WEREWOLF), statement)
+        assertEquals(2, io.promptedChoices.size)
     }
 
     @Test
     fun `speak with DIVINATION_REPORT attaches the entered comment`() {
-        val alice = NothingPlayer(Role.VILLAGER, "Alice")
+        val wolf = NothingPlayer(Role.WEREWOLF, "Wolf")
         val io = CapturingIO(
             StatementType.DIVINATION_REPORT.displayName,
-            "Alice",
-            DivineResult.WEREWOLF.displayName,
             freeTextAnswer = "昨日の議論で怪しいと思っていました",
         )
         val human = HumanPlayer(Role.SEER, "Human", io)
-        val context = DiscussionContext.Open(1, 1, listOf(human), listOf(human, alice))
+        GameEvent.Divined.send(wolf, DivineResult.WEREWOLF, human)
+        val context = DiscussionContext.Open(1, 1, listOf(human), listOf(human, wolf))
 
         val statement = human.discuss(context)
 
         assertEquals(
-            Statement.DivinationReport(human, alice, DivineResult.WEREWOLF, "昨日の議論で怪しいと思っていました"),
+            Statement.DivinationReport(human, wolf, DivineResult.WEREWOLF, "昨日の議論で怪しいと思っていました"),
             statement,
         )
     }
 
     @Test
     fun `speak with MEDIUM_REPORT attaches the entered comment`() {
-        val alice = NothingPlayer(Role.VILLAGER, "Alice")
+        val villager = NothingPlayer(Role.VILLAGER, "Villager")
         val io = CapturingIO(
             StatementType.MEDIUM_REPORT.displayName,
-            "Alice",
-            MediumResult.NOT_WEREWOLF.displayName,
             freeTextAnswer = "無実の方を処刑してしまい申し訳ない気持ちです",
         )
         val human = HumanPlayer(Role.MEDIUM, "Human", io)
-        val context = DiscussionContext.Open(1, 1, listOf(human), listOf(human, alice))
+        GameEvent.MediumRevealed.send(villager, MediumResult.NOT_WEREWOLF, human)
+        val context = DiscussionContext.Open(1, 1, listOf(human), listOf(human, villager))
 
         val statement = human.discuss(context)
 
         assertEquals(
-            Statement.MediumReport(human, alice, MediumResult.NOT_WEREWOLF, "無実の方を処刑してしまい申し訳ない気持ちです"),
+            Statement.MediumReport(human, villager, MediumResult.NOT_WEREWOLF, "無実の方を処刑してしまい申し訳ない気持ちです"),
             statement,
         )
+    }
+
+    @Test
+    fun `speak with DIVINATION_REPORT as werewolf allows freely choosing any target and result`() {
+        val villager1 = ReceivingPlayer(Role.VILLAGER, "V1")
+        val villager2 = ReceivingPlayer(Role.VILLAGER, "V2")
+        val io = CapturingIO(
+            StatementType.DIVINATION_REPORT.displayName,
+            "V1",
+            DivineResult.WEREWOLF.displayName,
+        )
+        val wolf = HumanPlayer(Role.WEREWOLF, "Wolf", io)
+        val allPlayers = AllPlayers(
+            TestLodge(wolf to Role.WEREWOLF, villager1 to Role.VILLAGER, villager2 to Role.VILLAGER).create().playerManager
+        )
+        GameEvent.PlayersAnnounced.send(listOf(wolf, villager1, villager2), allPlayers)
+        val context = DiscussionContext.Open(1, 1, listOf(wolf), listOf(wolf, villager1, villager2))
+
+        val statement = wolf.discuss(context)
+
+        assertEquals(Statement.DivinationReport(wolf, villager1, DivineResult.WEREWOLF), statement)
+        assertEquals(3, io.promptedChoices.size)
     }
 
     @Test
@@ -181,14 +213,15 @@ class HumanPlayerTest {
     }
 
     @Test
-    fun `villager is not offered ROLE_CLAIM as a statement type`() {
-        val io = CapturingIO(StatementType.PLAIN.displayName, freeTextAnswer = "hello")
+    fun `villager has only PLAIN available and is not prompted for type`() {
+        val io = CapturingIO(freeTextAnswer = "hello")
         val human = HumanPlayer(Role.VILLAGER, "Human", io)
         val context = DiscussionContext.Open(1, 1, listOf(human), listOf(human))
 
-        human.discuss(context)
+        val statement = human.discuss(context)
 
-        assertTrue(io.promptedChoices.single().options.none { it == StatementType.ROLE_CLAIM.displayName })
+        assertEquals(Statement.Plain(human, "hello"), statement)
+        assertTrue(io.promptedChoices.isEmpty())
     }
 
     @Test
@@ -204,16 +237,17 @@ class HumanPlayerTest {
     }
 
     @Test
-    fun `seer who already claimed is not offered ROLE_CLAIM again`() {
-        val io = CapturingIO(StatementType.PLAIN.displayName, freeTextAnswer = "hello")
+    fun `seer who already claimed and has nothing new to report is not prompted for type`() {
+        val io = CapturingIO(freeTextAnswer = "hello")
         val human = HumanPlayer(Role.SEER, "Human", io)
         val allPlayers = AllPlayers(TestLodge(human to Role.SEER).create().playerManager)
         GameEvent.StatementMade.send(1, human.name, Statement.RoleClaim(human, Role.SEER), allPlayers)
         val context = DiscussionContext.Open(2, 1, listOf(human), listOf(human))
 
-        human.discuss(context)
+        val statement = human.discuss(context)
 
-        assertTrue(io.promptedChoices.single().options.none { it == StatementType.ROLE_CLAIM.displayName })
+        assertEquals(Statement.Plain(human, "hello"), statement)
+        assertTrue(io.promptedChoices.isEmpty())
     }
 
     @Test

--- a/src/test/kotlin/werewolf/MadmanCpuStrategyTest.kt
+++ b/src/test/kotlin/werewolf/MadmanCpuStrategyTest.kt
@@ -21,7 +21,7 @@ class MadmanCpuStrategyTest {
     @Test
     fun `fake seer reports NOT_WEREWOLF on first day`() {
         val strategy = MadmanCpuStrategy(madman, Role.SEER)
-        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2), day = 1), StatementType.entries.toSet())
+        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2), day = 1), emptySet(), ReportEligibility.CanLie(emptyList()))
         assertTrue(result is Statement.DivinationReport)
         assertEquals(DivineResult.NOT_WEREWOLF, result.result)
         assertNotSame(madman, result.target)
@@ -30,7 +30,7 @@ class MadmanCpuStrategyTest {
     @Test
     fun `fake seer reports WEREWOLF from second day onwards`() {
         val strategy = MadmanCpuStrategy(madman, Role.SEER)
-        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2), day = 2), StatementType.entries.toSet())
+        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2), day = 2), emptySet(), ReportEligibility.CanLie(emptyList()))
         assertTrue(result is Statement.DivinationReport)
         assertEquals(DivineResult.WEREWOLF, result.result)
         assertNotSame(madman, result.target)
@@ -39,7 +39,7 @@ class MadmanCpuStrategyTest {
     @Test
     fun `fake seer stays silent from round 2 onwards`() {
         val strategy = MadmanCpuStrategy(madman, Role.SEER)
-        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2), round = 2), StatementType.entries.toSet())
+        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2), round = 2), emptySet(), ReportEligibility.CanLie(emptyList()))
         assertTrue(result is Statement.Plain)
     }
 
@@ -49,7 +49,7 @@ class MadmanCpuStrategyTest {
         GameEvent.StatementMade.send(1, madman.name, Statement.DivinationReport(madman, v1, DivineResult.WEREWOLF), allPlayers)
         GameEvent.StatementMade.send(1, madman.name, Statement.DivinationReport(madman, v2, DivineResult.WEREWOLF), allPlayers)
 
-        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2)), StatementType.entries.toSet())
+        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2)), emptySet(), ReportEligibility.CanLie(emptyList()))
         assertTrue(result is Statement.Plain)
     }
 
@@ -58,7 +58,7 @@ class MadmanCpuStrategyTest {
         val strategy = MadmanCpuStrategy(madman, Role.MEDIUM)
         GameEvent.PlayerExecuted.send(v1, allPlayers)
 
-        val result = strategy.buildStatement(openContext(listOf(madman, v2)), StatementType.entries.toSet())
+        val result = strategy.buildStatement(openContext(listOf(madman, v2)), emptySet(), ReportEligibility.CanLie(emptyList()))
         assertTrue(result is Statement.MediumReport)
         assertEquals(MediumResult.NOT_WEREWOLF, result.result)
         assertSame(v1, result.target)
@@ -67,7 +67,7 @@ class MadmanCpuStrategyTest {
     @Test
     fun `fake medium stays silent when no executions yet`() {
         val strategy = MadmanCpuStrategy(madman, Role.MEDIUM)
-        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2)), StatementType.entries.toSet())
+        val result = strategy.buildStatement(openContext(listOf(madman, v1, v2)), emptySet(), ReportEligibility.CanLie(emptyList()))
         assertTrue(result is Statement.Plain)
     }
 
@@ -75,7 +75,7 @@ class MadmanCpuStrategyTest {
     fun `fake medium stays silent from round 2 onwards`() {
         val strategy = MadmanCpuStrategy(madman, Role.MEDIUM)
         GameEvent.PlayerExecuted.send(v1, allPlayers)
-        val result = strategy.buildStatement(openContext(listOf(madman, v2), round = 2), StatementType.entries.toSet())
+        val result = strategy.buildStatement(openContext(listOf(madman, v2), round = 2), emptySet(), ReportEligibility.CanLie(emptyList()))
         assertTrue(result is Statement.Plain)
     }
 
@@ -85,7 +85,7 @@ class MadmanCpuStrategyTest {
         GameEvent.PlayerExecuted.send(v1, allPlayers)
         GameEvent.StatementMade.send(1, madman.name, Statement.MediumReport(madman, v1, MediumResult.NOT_WEREWOLF), allPlayers)
 
-        val result = strategy.buildStatement(openContext(listOf(madman, v2)), StatementType.entries.toSet())
+        val result = strategy.buildStatement(openContext(listOf(madman, v2)), emptySet(), ReportEligibility.CanLie(emptyList()))
         assertTrue(result is Statement.Plain)
     }
 }

--- a/src/test/kotlin/werewolf/NightPhaseTest.kt
+++ b/src/test/kotlin/werewolf/NightPhaseTest.kt
@@ -25,8 +25,8 @@ class NightPhaseTest {
 
     private class ConclaveWolf(name: String) : ReceivingPlayer(Role.WEREWOLF, name) {
         val heardStatements = mutableListOf<GameEvent.WerewolfStatementMade>()
-        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim =
-            Claim(this, context, Statement.Plain(""), claimableRoles, "")
+        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim =
+            Claim(this, context, Statement.Plain(this, ""), claimableRoles, reportEligibility, "")
         override fun onReceive(event: GameEvent) {
             if (event is GameEvent.WerewolfStatementMade) heardStatements.add(event)
         }

--- a/src/test/kotlin/werewolf/NothingPlayer.kt
+++ b/src/test/kotlin/werewolf/NothingPlayer.kt
@@ -3,7 +3,7 @@ package werewolf
 import werewolf.game.*
 
 open class NothingPlayer(role: Role, override val name: String) : Player(role) {
-    override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim = error("speak not expected")
+    override fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim = error("speak not expected")
     override fun onReceive(event: GameEvent) { error("onReceive not expected") }
     override fun choose(context: SelectionContext): Choice = error("choose not expected")
     override fun watchEpilogue(chronicles: List<ChronicleView>) { error("watchEpilogue not expected") }

--- a/src/test/kotlin/werewolf/PlayerTest.kt
+++ b/src/test/kotlin/werewolf/PlayerTest.kt
@@ -30,6 +30,15 @@ class PlayerTest {
             Claim(speakerToSet, context, Statement.Plain(speakerToSet, ""), claimableRoles, reportEligibility, "")
     }
 
+    private class ArbitraryClaimantSetter(
+        role: Role,
+        name: String,
+        private val claimantToSet: Player,
+    ) : NothingPlayer(role, name) {
+        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim =
+            Claim(this, context, Statement.Plain(claimantToSet, ""), claimableRoles, reportEligibility, "")
+    }
+
     private class SpeakingPlayer(role: Role, name: String) : NothingPlayer(role, name) {
         override fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim =
             Claim(this, context, Statement.Plain(this, ""), claimableRoles, reportEligibility, "")
@@ -66,6 +75,14 @@ class PlayerTest {
     fun `discuss throws when speak returns a claim with wrong speaker`() {
         val otherPlayer = NothingPlayer(Role.VILLAGER, "OtherPlayer")
         val player = ArbitrarySpeakerSetter(Role.VILLAGER, "Player", speakerToSet = otherPlayer)
+        val context = openContext(listOf(player, otherPlayer))
+        assertFailsWith<IllegalArgumentException> { player.discuss(context) }
+    }
+
+    @Test
+    fun `discuss throws when speak returns a claim whose statement has wrong claimant`() {
+        val otherPlayer = NothingPlayer(Role.VILLAGER, "OtherPlayer")
+        val player = ArbitraryClaimantSetter(Role.VILLAGER, "Player", claimantToSet = otherPlayer)
         val context = openContext(listOf(player, otherPlayer))
         assertFailsWith<IllegalArgumentException> { player.discuss(context) }
     }

--- a/src/test/kotlin/werewolf/PlayerTest.kt
+++ b/src/test/kotlin/werewolf/PlayerTest.kt
@@ -26,20 +26,22 @@ class PlayerTest {
         name: String,
         private val speakerToSet: Player,
     ) : NothingPlayer(role, name) {
-        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim =
-            Claim(speakerToSet, context, Statement.Plain(""), claimableRoles, "")
+        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim =
+            Claim(speakerToSet, context, Statement.Plain(speakerToSet, ""), claimableRoles, reportEligibility, "")
     }
 
     private class SpeakingPlayer(role: Role, name: String) : NothingPlayer(role, name) {
-        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim =
-            Claim(this, context, Statement.Plain(""), claimableRoles, "")
+        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim =
+            Claim(this, context, Statement.Plain(this, ""), claimableRoles, reportEligibility, "")
     }
 
     private class CapturingSpeakerPlayer(role: Role, name: String) : ReceivingPlayer(role, name) {
         var receivedClaimableRoles: Set<Role>? = null
-        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>): Claim {
+        var receivedReportEligibility: ReportEligibility? = null
+        override fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim {
             receivedClaimableRoles = claimableRoles
-            return Claim(this, context, Statement.Plain(""), claimableRoles, "")
+            receivedReportEligibility = reportEligibility
+            return Claim(this, context, Statement.Plain(this, ""), claimableRoles, reportEligibility, "")
         }
     }
 

--- a/src/test/kotlin/werewolf/UnreportedResultsTest.kt
+++ b/src/test/kotlin/werewolf/UnreportedResultsTest.kt
@@ -1,0 +1,77 @@
+package werewolf
+
+import werewolf.game.*
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UnreportedResultsTest {
+
+    private fun memoriesFor(player: Player): List<Recallable> = player.reveal(fakeCitizenWinSignal())
+
+    @Test
+    fun `divinations returns all divined targets when none reported yet`() {
+        val self = ReceivingPlayer(Role.SEER, "Self")
+        val wolf = ReceivingPlayer(Role.WEREWOLF, "Wolf")
+        val villager = ReceivingPlayer(Role.VILLAGER, "Villager")
+        GameEvent.Divined.send(wolf, DivineResult.WEREWOLF, self)
+        GameEvent.Divined.send(villager, DivineResult.NOT_WEREWOLF, self)
+
+        val result = UnreportedResults(memoriesFor(self), self)
+
+        assertEquals(mapOf<Player, DivineResult>(wolf to DivineResult.WEREWOLF, villager to DivineResult.NOT_WEREWOLF), result.divinations)
+    }
+
+    @Test
+    fun `divinations excludes targets already reported by self`() {
+        val self = ReceivingPlayer(Role.SEER, "Self")
+        val wolf = ReceivingPlayer(Role.WEREWOLF, "Wolf")
+        val allPlayers = AllPlayers(TestLodge(self to Role.SEER, wolf to Role.WEREWOLF).create().playerManager)
+        GameEvent.Divined.send(wolf, DivineResult.WEREWOLF, self)
+        GameEvent.StatementMade.send(1, self.name, Statement.DivinationReport(self, wolf, DivineResult.WEREWOLF), allPlayers)
+
+        val result = UnreportedResults(memoriesFor(self), self)
+
+        assertEquals(emptyMap(), result.divinations)
+    }
+
+    @Test
+    fun `divinations ignores divination reports made by other players`() {
+        val self = ReceivingPlayer(Role.SEER, "Self")
+        val madman = ReceivingPlayer(Role.MADMAN, "Madman")
+        val wolf = ReceivingPlayer(Role.WEREWOLF, "Wolf")
+        val allPlayers = AllPlayers(
+            TestLodge(self to Role.SEER, madman to Role.MADMAN, wolf to Role.WEREWOLF).create().playerManager
+        )
+        GameEvent.Divined.send(wolf, DivineResult.WEREWOLF, self)
+        GameEvent.StatementMade.send(1, madman.name, Statement.DivinationReport(madman, wolf, DivineResult.WEREWOLF), allPlayers)
+
+        val result = UnreportedResults(memoriesFor(self), self)
+
+        assertEquals(mapOf<Player, DivineResult>(wolf to DivineResult.WEREWOLF), result.divinations)
+    }
+
+    @Test
+    fun `mediums returns all revealed targets when none reported yet`() {
+        val self = ReceivingPlayer(Role.MEDIUM, "Self")
+        val wolf = ReceivingPlayer(Role.WEREWOLF, "Wolf")
+        GameEvent.MediumRevealed.send(wolf, MediumResult.WEREWOLF, self)
+
+        val result = UnreportedResults(memoriesFor(self), self)
+
+        assertEquals(mapOf<Player, MediumResult>(wolf to MediumResult.WEREWOLF), result.mediums)
+    }
+
+    @Test
+    fun `mediums excludes targets already reported by self`() {
+        val self = ReceivingPlayer(Role.MEDIUM, "Self")
+        val wolf = ReceivingPlayer(Role.WEREWOLF, "Wolf")
+        val allPlayers = AllPlayers(TestLodge(self to Role.MEDIUM, wolf to Role.WEREWOLF).create().playerManager)
+        GameEvent.MediumRevealed.send(wolf, MediumResult.WEREWOLF, self)
+        GameEvent.StatementMade.send(1, self.name, Statement.MediumReport(self, wolf, MediumResult.WEREWOLF), allPlayers)
+
+        val result = UnreportedResults(memoriesFor(self), self)
+
+        assertEquals(emptyMap(), result.mediums)
+    }
+}


### PR DESCRIPTION
## Summary
- 占い師/霊能者は、自分が実際に占って(見て)未報告の相手についてのみ、それぞれ`DIVINATION_REPORT`/`MEDIUM_REPORT`を報告できるようにした。報告済みの相手は再度報告できない
- 占い師は`MEDIUM_REPORT`を、霊能者は`DIVINATION_REPORT`を報告できないようにした
- 村人/狩人はどちらの報告型も選択できないようにした
- 人狼/狂人は対象・結果の制限を受けずに両方の報告型を選択できる(従来通り)
- 上記を`ReportEligibility`(役職ごとの報告可否)と`UnreportedResults`(実際の結果のうち未報告のものを算出)として切り出し、`Claim`の初期化チェックと`DiscussionContext.selectableTypes`から参照する形にした

Closes #285

## Test plan
- [x] `./gradlew test` (占い師/霊能者の報告可否・虚偽報告のブロック・AIが虚偽報告を試みた際のフォールバックを含む新規/更新テストで確認)
- [x] `./gradlew detekt`