### PR TITLE
Switch web UI background by time of day

### DIFF
--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -16,6 +16,8 @@
     | { type: 'choose'; title: string; description: string; candidates: string[] }
     | { type: 'speak'; title: string; description: string }
 
+  type Atmosphere = 'morning' | 'day' | 'night' | 'vote'
+
   type PlayerStatus = 'alive' | 'executed' | 'attacked'
   type PlayerEntry = { name: string; status: PlayerStatus; claimedRole: string | null }
 
@@ -31,6 +33,8 @@
   let status = '接続中...'
   let entries: LogEntry[] = []
   let input: InputState = { type: 'idle' }
+  let atmosphere: Atmosphere | null = null
+  $: document.body.className = atmosphere ? `atmosphere-${atmosphere}` : ''
   let speakText = ''
   let logEl: HTMLElement
   let ws: WebSocket
@@ -75,6 +79,9 @@
         break
       case 'playerStatus':
         players = msg.players as PlayerEntry[]
+        break
+      case 'atmosphere':
+        atmosphere = msg.value as Atmosphere
         break
       case 'divination':
         divination = msg as unknown as DivinationData
@@ -298,21 +305,28 @@
 </div>
 
 <style>
+  :global(body) { margin: 0; transition: background-color 0.6s ease, color 0.6s ease; }
+  :global(body.atmosphere-morning) { background-color: #ffe3c2; }
+  :global(body.atmosphere-day) { background-color: #eaf4ff; }
+  :global(body.atmosphere-night) { background-color: #33406b; color: #eee; }
+  :global(body.atmosphere-night) .status { color: #cdd6f0; }
+  :global(body.atmosphere-vote) { background-color: #f6dede; }
+
   .layout { display: flex; gap: 16px; max-width: 1100px; margin: 0 auto; padding: 16px; font-family: sans-serif; }
   .main { flex: 1; min-width: 0; }
-  .panel { width: 240px; flex-shrink: 0; border: 1px solid #ccc; border-radius: 4px; padding: 12px; background: #fafafa; align-self: flex-start; }
+  .panel { width: 240px; flex-shrink: 0; border: 1px solid #ccc; border-radius: 4px; padding: 12px; background: #fafafa; color: #333; align-self: flex-start; }
   h1 { margin: 0 0 4px; }
   h2 { margin: 0 0 10px; font-size: 1em; color: #444; }
   .panel-section { margin: 14px 0 6px; }
   .status { color: #666; margin-bottom: 8px; }
   .controls { margin: 8px 0; }
-  .log { border: 1px solid #ccc; height: 500px; overflow-y: auto; padding: 8px; background: #fafafa; }
+  .log { border: 1px solid #ccc; height: 500px; overflow-y: auto; padding: 8px; background: #fafafa; color: #333; }
   .event { margin: 4px 0; line-height: 1.4; }
   .title { font-weight: bold; color: #444; }
   .intent { color: #888; font-size: 0.9em; }
   .role-badge { display: inline-block; margin-left: 4px; padding: 1px 6px; border-radius: 3px; font-size: 0.8em; background: #dde6f7; color: #33507a; }
   .epilogue { margin: 16px 0 0; padding: 12px; background: #eef; border-left: 4px solid #88a; white-space: pre-wrap; font-family: inherit; }
-  .input-area { margin-bottom: 8px; padding: 12px; border: 2px solid #88a; background: #f0f0fa; }
+  .input-area { margin-bottom: 8px; padding: 12px; border: 2px solid #88a; background: #f0f0fa; color: #333; }
   .input-title { font-weight: bold; margin: 0 0 4px; }
   .input-description { color: #666; font-size: 0.9em; margin: 0 0 10px; }
   button { margin: 4px; padding: 6px 14px; cursor: pointer; }

--- a/src/main/kotlin/werewolf/game/GameEvent.kt
+++ b/src/main/kotlin/werewolf/game/GameEvent.kt
@@ -107,6 +107,16 @@ sealed class GameEvent : Recallable() {
     }
 
     @ConsistentCopyVisibility
+    data class VoteStarted private constructor(val day: Int, private val allPlayers: AllPlayers) : GameEvent() {
+        override val title = "投票開始"
+        override fun body() = "${day}日目の投票が始まります。"
+        override val recipients: Notifiable = allPlayers
+        companion object {
+            fun send(day: Int, allPlayers: AllPlayers) = VoteStarted(day, allPlayers).dispatch()
+        }
+    }
+
+    @ConsistentCopyVisibility
     data class ConclaveStarted private constructor(val day: Int, private val wolves: Wolves) : GameEvent() {
         override val title = "密談開始"
         override fun body() = "${day}日目の密談が始まります。"

--- a/src/main/kotlin/werewolf/human/HumanIO.kt
+++ b/src/main/kotlin/werewolf/human/HumanIO.kt
@@ -2,6 +2,7 @@ package werewolf.human
 
 import werewolf.game.ChronicleView
 import werewolf.game.RecallView
+import werewolf.view.Atmosphere
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
 import werewolf.view.PlayerStatusView
@@ -10,6 +11,7 @@ interface HumanIO {
     fun display(view: RecallView)
     fun updatePlayerStatusPanel(view: PlayerStatusView)
     fun updateDivinationPanel(view: DivinationView)
+    fun updateAtmosphere(atmosphere: Atmosphere)
     fun promptChoice(view: ChoiceView): String
     fun promptFreeText(title: String, description: String): String
     fun watchEpilogue(chronicles: List<ChronicleView>)

--- a/src/main/kotlin/werewolf/human/HumanPlayer.kt
+++ b/src/main/kotlin/werewolf/human/HumanPlayer.kt
@@ -11,7 +11,9 @@ import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
 import werewolf.game.StatementType
+import werewolf.game.TimeOfDay
 import werewolf.game.selectableTypes
+import werewolf.view.Atmosphere
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
 import werewolf.view.PlayerStatusView
@@ -45,6 +47,17 @@ class HumanPlayer(role: Role, override val name: String, private val io: HumanIO
             lastDivinationSummary = currentDivination
             io.updateDivinationPanel(currentDivination)
         }
+        atmosphereOf(event)?.let { io.updateAtmosphere(it) }
+    }
+
+    private fun atmosphereOf(event: GameEvent): Atmosphere? = when (event) {
+        is GameEvent.TimeChanged -> when (event.timeOfDay) {
+            TimeOfDay.Morning -> Atmosphere.MORNING
+            is TimeOfDay.Night -> Atmosphere.NIGHT
+        }
+        is GameEvent.DiscussionStarted -> Atmosphere.DAY
+        is GameEvent.VoteStarted -> Atmosphere.VOTE
+        else -> null
     }
 
     override fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim {

--- a/src/main/kotlin/werewolf/human/console/ConsoleHumanIO.kt
+++ b/src/main/kotlin/werewolf/human/console/ConsoleHumanIO.kt
@@ -4,6 +4,7 @@ import werewolf.game.ChronicleView
 import werewolf.game.GameOverSignal
 import werewolf.game.RecallView
 import werewolf.human.HumanIO
+import werewolf.view.Atmosphere
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
 import werewolf.view.PlayerStatusView
@@ -20,6 +21,10 @@ class ConsoleHumanIO : HumanIO {
 
     override fun updateDivinationPanel(view: DivinationView) {
         // Console has no persistent panel; divination info is visible in the event log
+    }
+
+    override fun updateAtmosphere(atmosphere: Atmosphere) {
+        // Console has no visual background; time-of-day is visible in the event log
     }
 
     override fun display(view: RecallView) = when (view) {

--- a/src/main/kotlin/werewolf/human/web/WebHumanIO.kt
+++ b/src/main/kotlin/werewolf/human/web/WebHumanIO.kt
@@ -6,6 +6,7 @@ import werewolf.game.ChronicleView
 import werewolf.game.GameOverSignal
 import werewolf.game.RecallView
 import werewolf.human.HumanIO
+import werewolf.view.Atmosphere
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
 import werewolf.view.PlayerStatus
@@ -42,6 +43,10 @@ class WebHumanIO : HumanIO {
     override fun updatePlayerStatusPanel(view: PlayerStatusView) {
         val playersJson = view.players.joinToString(",") { it.toJson() }
         enqueue("""{"type":"playerStatus","players":[$playersJson]}""")
+    }
+
+    override fun updateAtmosphere(atmosphere: Atmosphere) {
+        enqueue("""{"type":"atmosphere","value":${atmosphere.toJson()}}""")
     }
 
     override fun display(view: RecallView) {
@@ -88,6 +93,13 @@ private fun PlayerStatus.toJson(): String = when (this) {
     PlayerStatus.ALIVE -> "\"alive\""
     PlayerStatus.EXECUTED -> "\"executed\""
     PlayerStatus.ATTACKED -> "\"attacked\""
+}
+
+private fun Atmosphere.toJson(): String = when (this) {
+    Atmosphere.MORNING -> "\"morning\""
+    Atmosphere.DAY -> "\"day\""
+    Atmosphere.NIGHT -> "\"night\""
+    Atmosphere.VOTE -> "\"vote\""
 }
 
 private fun RecallView.toJson(): String = when (this) {

--- a/src/main/kotlin/werewolf/phase/DayPhase.kt
+++ b/src/main/kotlin/werewolf/phase/DayPhase.kt
@@ -1,5 +1,7 @@
 package werewolf.phase
 
+import werewolf.game.AllPlayers
+import werewolf.game.GameEvent
 import werewolf.game.MajorityVoteResolver
 import werewolf.game.Oracle
 import werewolf.game.PlayerManager
@@ -12,6 +14,7 @@ class DayPhase(
 ) : Phase {
     override fun proceed(): Phase {
         OpenDiscussion(playerManager, nightNumber).conduct()
+        GameEvent.VoteStarted.send(nightNumber, AllPlayers(playerManager))
         val votes = playerManager.players.map { it.selectTarget(SelectionContext.Vote(it, playerManager.players)) }
         val mostVoted = MajorityVoteResolver.resolveNonEmpty(votes)
         playerManager.execute(mostVoted)

--- a/src/main/kotlin/werewolf/view/Atmosphere.kt
+++ b/src/main/kotlin/werewolf/view/Atmosphere.kt
@@ -1,0 +1,3 @@
+package werewolf.view
+
+enum class Atmosphere { MORNING, DAY, NIGHT, VOTE }

--- a/src/test/kotlin/werewolf/DayPhaseTest.kt
+++ b/src/test/kotlin/werewolf/DayPhaseTest.kt
@@ -14,6 +14,8 @@ class DayPhaseTest {
         role: Role, name: String, private val voteTarget: Player? = null
     ) : ReceivingPlayer(role, name) {
         var discussedCount = 0
+        val receivedEvents = mutableListOf<GameEvent>()
+        override fun onReceive(event: GameEvent) { receivedEvents += event }
         override fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim {
             discussedCount++
             return Claim(this, context, Statement.Plain(this, ""), claimableRoles, reportEligibility, "")
@@ -54,6 +56,27 @@ class DayPhaseTest {
         DayPhase(setup.playerManager, setup.oracle, 1).proceed()
 
         assertFalse(setup.playerManager.players.contains(victim))
+    }
+
+    @Test
+    fun `VoteStarted is sent after discussion ends and before the execution result`() {
+        val victim = DayPlayer(Role.VILLAGER, "Victim")
+        val wolf = DayPlayer(Role.WEREWOLF, "Wolf", victim)
+        val v1 = DayPlayer(Role.VILLAGER, "V1", victim)
+        val v2 = DayPlayer(Role.VILLAGER, "V2", victim)
+        val v3 = DayPlayer(Role.VILLAGER, "V3", victim)
+        val setup = TestLodge(
+            wolf to Role.WEREWOLF,
+            victim to Role.VILLAGER, v1 to Role.VILLAGER, v2 to Role.VILLAGER, v3 to Role.VILLAGER,
+        ).create()
+
+        DayPhase(setup.playerManager, setup.oracle, 1).proceed()
+
+        val lastStatementIndex = wolf.receivedEvents.indexOfLast { it is GameEvent.StatementMade }
+        val voteStartedIndex = wolf.receivedEvents.indexOfFirst { it is GameEvent.VoteStarted }
+        val executedIndex = wolf.receivedEvents.indexOfFirst { it is GameEvent.PlayerExecuted }
+        assertTrue(lastStatementIndex in 0..<voteStartedIndex)
+        assertTrue(voteStartedIndex in 0..<executedIndex)
     }
 
     @Test

--- a/src/test/kotlin/werewolf/GameNoteTest.kt
+++ b/src/test/kotlin/werewolf/GameNoteTest.kt
@@ -4,7 +4,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import werewolf.game.AllPlayers
-import werewolf.game.ChronicleView
 import werewolf.game.DivineResult
 import werewolf.game.GameEvent
 import werewolf.game.GameSetup
@@ -12,11 +11,9 @@ import werewolf.game.MediumResult
 import werewolf.game.RecallView
 import werewolf.game.Role
 import werewolf.game.Statement
-import werewolf.human.HumanIO
 import werewolf.human.HumanPlayer
 import werewolf.phase.InitialPhase
 import werewolf.view.Atmosphere
-import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
 import werewolf.view.PlayerStatus
 import werewolf.view.PlayerStatusView
@@ -24,16 +21,13 @@ import werewolf.view.ReportEntry
 
 class GameNoteTest {
 
-    private class CapturingIO : HumanIO {
+    private class CapturingIO : NothingHumanIO() {
         val panels = mutableListOf<PlayerStatusView>()
         val divinationPanels = mutableListOf<DivinationView>()
         override fun display(view: RecallView) {}
         override fun updatePlayerStatusPanel(view: PlayerStatusView) { panels += view }
         override fun updateDivinationPanel(view: DivinationView) { divinationPanels += view }
         override fun updateAtmosphere(atmosphere: Atmosphere) {}
-        override fun promptChoice(view: ChoiceView): String = error("not expected")
-        override fun promptFreeText(title: String, description: String): String = error("not expected")
-        override fun watchEpilogue(chronicles: List<ChronicleView>) {}
     }
 
     private class SilentPlayer(role: Role, name: String) : NothingPlayer(role, name) {

--- a/src/test/kotlin/werewolf/GameNoteTest.kt
+++ b/src/test/kotlin/werewolf/GameNoteTest.kt
@@ -15,6 +15,7 @@ import werewolf.game.Statement
 import werewolf.human.HumanIO
 import werewolf.human.HumanPlayer
 import werewolf.phase.InitialPhase
+import werewolf.view.Atmosphere
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
 import werewolf.view.PlayerStatus
@@ -29,6 +30,7 @@ class GameNoteTest {
         override fun display(view: RecallView) {}
         override fun updatePlayerStatusPanel(view: PlayerStatusView) { panels += view }
         override fun updateDivinationPanel(view: DivinationView) { divinationPanels += view }
+        override fun updateAtmosphere(atmosphere: Atmosphere) {}
         override fun promptChoice(view: ChoiceView): String = error("not expected")
         override fun promptFreeText(title: String, description: String): String = error("not expected")
         override fun watchEpilogue(chronicles: List<ChronicleView>) {}

--- a/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
@@ -3,6 +3,7 @@ package werewolf
 import werewolf.game.*
 import werewolf.human.HumanPlayer
 import werewolf.human.HumanIO
+import werewolf.view.Atmosphere
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
 import werewolf.view.PlayerStatusView
@@ -21,6 +22,7 @@ class HumanPlayerEpilogueTest {
         override fun display(view: RecallView) {}
         override fun updatePlayerStatusPanel(view: PlayerStatusView) {}
         override fun updateDivinationPanel(view: DivinationView) {}
+        override fun updateAtmosphere(atmosphere: Atmosphere) {}
         override fun promptFreeText(title: String, description: String): String = "human speaks"
         override fun promptChoice(view: ChoiceView): String = view.options.first()
         override fun watchEpilogue(chronicles: List<ChronicleView>) { capturedChronicles = chronicles }

--- a/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
@@ -2,7 +2,6 @@ package werewolf
 
 import werewolf.game.*
 import werewolf.human.HumanPlayer
-import werewolf.human.HumanIO
 import werewolf.view.Atmosphere
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
@@ -17,7 +16,7 @@ import kotlin.test.assertTrue
 
 class HumanPlayerEpilogueTest {
 
-    private class SpeakingIO : HumanIO {
+    private class SpeakingIO : NothingHumanIO() {
         var capturedChronicles: List<ChronicleView> = emptyList()
         override fun display(view: RecallView) {}
         override fun updatePlayerStatusPanel(view: PlayerStatusView) {}

--- a/src/test/kotlin/werewolf/HumanPlayerTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerTest.kt
@@ -14,8 +14,11 @@ import werewolf.game.Role
 import werewolf.game.SelectionContext
 import werewolf.game.Statement
 import werewolf.game.StatementType
+import werewolf.game.TimeOfDay
+import werewolf.game.Wolves
 import werewolf.human.HumanIO
 import werewolf.human.HumanPlayer
+import werewolf.view.Atmosphere
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
 import werewolf.view.PlayerStatusView
@@ -29,11 +32,13 @@ class HumanPlayerTest {
         private val queue = ArrayDeque(choiceAnswers.toList())
         val promptedChoices = mutableListOf<ChoiceView>()
         val displayedViews = mutableListOf<RecallView>()
+        val capturedAtmospheres = mutableListOf<Atmosphere>()
         var capturedChronicles: List<ChronicleView> = emptyList()
 
         override fun display(view: RecallView) { displayedViews += view }
         override fun updatePlayerStatusPanel(view: PlayerStatusView) {}
         override fun updateDivinationPanel(view: DivinationView) {}
+        override fun updateAtmosphere(atmosphere: Atmosphere) { capturedAtmospheres += atmosphere }
         override fun promptChoice(view: ChoiceView): String {
             promptedChoices += view
             return queue.removeFirst()
@@ -263,6 +268,62 @@ class HumanPlayerTest {
         val statement = human.discuss(context)
 
         assertEquals(Statement.RoleClaim(human, Role.SEER, "信じてください"), statement)
+    }
+
+    @Test
+    fun `TimeChanged to Morning updates atmosphere to MORNING`() {
+        val io = CapturingIO()
+        val human = HumanPlayer(Role.VILLAGER, "Human", io)
+        val allPlayers = AllPlayers(TestLodge(human to Role.VILLAGER).create().playerManager)
+
+        GameEvent.TimeChanged.send(TimeOfDay.Morning, allPlayers)
+
+        assertEquals(listOf(Atmosphere.MORNING), io.capturedAtmospheres)
+    }
+
+    @Test
+    fun `TimeChanged to Night updates atmosphere to NIGHT`() {
+        val io = CapturingIO()
+        val human = HumanPlayer(Role.VILLAGER, "Human", io)
+        val allPlayers = AllPlayers(TestLodge(human to Role.VILLAGER).create().playerManager)
+
+        GameEvent.TimeChanged.send(TimeOfDay.Night(1), allPlayers)
+
+        assertEquals(listOf(Atmosphere.NIGHT), io.capturedAtmospheres)
+    }
+
+    @Test
+    fun `DiscussionStarted updates atmosphere to DAY`() {
+        val io = CapturingIO()
+        val human = HumanPlayer(Role.VILLAGER, "Human", io)
+        val allPlayers = AllPlayers(TestLodge(human to Role.VILLAGER).create().playerManager)
+
+        GameEvent.DiscussionStarted.send(1, allPlayers)
+
+        assertEquals(listOf(Atmosphere.DAY), io.capturedAtmospheres)
+    }
+
+    @Test
+    fun `VoteStarted updates atmosphere to VOTE`() {
+        val io = CapturingIO()
+        val human = HumanPlayer(Role.VILLAGER, "Human", io)
+        val allPlayers = AllPlayers(TestLodge(human to Role.VILLAGER).create().playerManager)
+
+        GameEvent.VoteStarted.send(1, allPlayers)
+
+        assertEquals(listOf(Atmosphere.VOTE), io.capturedAtmospheres)
+    }
+
+    @Test
+    fun `ConclaveStarted does not update atmosphere since it is part of night`() {
+        val io = CapturingIO()
+        val human = HumanPlayer(Role.WEREWOLF, "Human", io)
+        val wolf2 = ReceivingPlayer(Role.WEREWOLF, "Wolf2")
+        val setup = TestLodge(human to Role.WEREWOLF, wolf2 to Role.WEREWOLF).create()
+
+        GameEvent.ConclaveStarted.send(1, Wolves(setup.oracle, setup.playerManager))
+
+        assertTrue(io.capturedAtmospheres.isEmpty())
     }
 
     @Test

--- a/src/test/kotlin/werewolf/HumanPlayerTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerTest.kt
@@ -16,7 +16,6 @@ import werewolf.game.Statement
 import werewolf.game.StatementType
 import werewolf.game.TimeOfDay
 import werewolf.game.Wolves
-import werewolf.human.HumanIO
 import werewolf.human.HumanPlayer
 import werewolf.view.Atmosphere
 import werewolf.view.ChoiceView
@@ -28,7 +27,7 @@ class HumanPlayerTest {
     private class CapturingIO(
         vararg choiceAnswers: String,
         private val freeTextAnswer: String = "",
-    ) : HumanIO {
+    ) : NothingHumanIO() {
         private val queue = ArrayDeque(choiceAnswers.toList())
         val promptedChoices = mutableListOf<ChoiceView>()
         val displayedViews = mutableListOf<RecallView>()

--- a/src/test/kotlin/werewolf/InitialPhaseTest.kt
+++ b/src/test/kotlin/werewolf/InitialPhaseTest.kt
@@ -10,11 +10,6 @@ import kotlin.test.assertTrue
 
 class InitialPhaseTest {
 
-    private class RecordingPlayer(role: Role, name: String) : NothingPlayer(role, name) {
-        val received = mutableListOf<GameEvent>()
-        override fun onReceive(event: GameEvent) { received.add(event) }
-    }
-
     @Test
     fun `each player is notified of their assigned role`() {
         val villager = RecordingPlayer(Role.VILLAGER, "Villager")

--- a/src/test/kotlin/werewolf/MorningPhaseTest.kt
+++ b/src/test/kotlin/werewolf/MorningPhaseTest.kt
@@ -10,12 +10,7 @@ import kotlin.test.assertNull
 
 class MorningPhaseTest {
 
-    private class RecordingPlayer(role: Role, name: String) : ReceivingPlayer(role, name) {
-        val morningReports = mutableListOf<GameEvent.MorningReport>()
-        override fun onReceive(event: GameEvent) {
-            if (event is GameEvent.MorningReport) morningReports.add(event)
-        }
-    }
+    private fun RecordingPlayer.morningReports() = received.filterIsInstance<GameEvent.MorningReport>()
 
     @Test
     fun `returns DayPhase`() {
@@ -36,7 +31,7 @@ class MorningPhaseTest {
 
         MorningPhase(setup.playerManager, setup.oracle, 1).proceed()
 
-        assertNull(observer.morningReports.single().victim)
+        assertNull(observer.morningReports().single().victim)
     }
 
     @Test
@@ -52,7 +47,7 @@ class MorningPhaseTest {
 
         MorningPhase(setup.playerManager, setup.oracle, 1).proceed()
 
-        assertEquals(villager1, observer.morningReports.single().victim)
+        assertEquals(villager1, observer.morningReports().single().victim)
     }
 
     @Test
@@ -69,7 +64,7 @@ class MorningPhaseTest {
         MorningPhase(setup.playerManager, setup.oracle, 1).proceed()
         MorningPhase(setup.playerManager, setup.oracle, 2).proceed()
 
-        assertEquals(villager1, observer.morningReports[0].victim)
-        assertNull(observer.morningReports[1].victim)
+        assertEquals(villager1, observer.morningReports()[0].victim)
+        assertNull(observer.morningReports()[1].victim)
     }
 }

--- a/src/test/kotlin/werewolf/NightPhaseTest.kt
+++ b/src/test/kotlin/werewolf/NightPhaseTest.kt
@@ -18,11 +18,6 @@ class NightPhaseTest {
         override fun choose(context: SelectionContext): Choice = Choice(this, context, target, "固定ターゲット")
     }
 
-    private open class RecordingPlayer(role: Role, name: String) : ReceivingPlayer(role, name) {
-        val received = mutableListOf<GameEvent>()
-        override fun onReceive(event: GameEvent) { received.add(event) }
-    }
-
     private class ConclaveWolf(name: String) : ReceivingPlayer(Role.WEREWOLF, name) {
         val heardStatements = mutableListOf<GameEvent.WerewolfStatementMade>()
         override fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim =

--- a/src/test/kotlin/werewolf/NothingHumanIO.kt
+++ b/src/test/kotlin/werewolf/NothingHumanIO.kt
@@ -1,0 +1,19 @@
+package werewolf
+
+import werewolf.game.ChronicleView
+import werewolf.game.RecallView
+import werewolf.human.HumanIO
+import werewolf.view.Atmosphere
+import werewolf.view.ChoiceView
+import werewolf.view.DivinationView
+import werewolf.view.PlayerStatusView
+
+open class NothingHumanIO : HumanIO {
+    override fun display(view: RecallView) { error("display not expected") }
+    override fun updatePlayerStatusPanel(view: PlayerStatusView) { error("updatePlayerStatusPanel not expected") }
+    override fun updateDivinationPanel(view: DivinationView) { error("updateDivinationPanel not expected") }
+    override fun updateAtmosphere(atmosphere: Atmosphere) { error("updateAtmosphere not expected") }
+    override fun promptChoice(view: ChoiceView): String = error("promptChoice not expected")
+    override fun promptFreeText(title: String, description: String): String = error("promptFreeText not expected")
+    override fun watchEpilogue(chronicles: List<ChronicleView>) { error("watchEpilogue not expected") }
+}

--- a/src/test/kotlin/werewolf/RecordingPlayer.kt
+++ b/src/test/kotlin/werewolf/RecordingPlayer.kt
@@ -1,0 +1,9 @@
+package werewolf
+
+import werewolf.game.GameEvent
+import werewolf.game.Role
+
+open class RecordingPlayer(role: Role, name: String) : ReceivingPlayer(role, name) {
+    val received = mutableListOf<GameEvent>()
+    override fun onReceive(event: GameEvent) { received.add(event) }
+}


### PR DESCRIPTION
## Summary
- 朝・議論・投票・夜の切り替わりに応じてWeb UIの背景色が変わるようにした
- `HumanIO`に`updateAtmosphere(atmosphere: Atmosphere)`を追加し、`HumanPlayer`が`GameEvent`（`TimeChanged`/`DiscussionStarted`/`VoteStarted`）を`view.Atmosphere`へ変換してpushする
- 投票開始を表す`GameEvent.VoteStarted`を新設し、`DayPhase`で議論後・投票開始前に発火させた（`DiscussionStarted`と同じ扱い）
- `SelectionContext`（Attack/Divine/Guard/Vote個別の選択パネルの色分け）と勝敗演出は今回のスコープ外（#289の残りの完了条件として別PRで対応予定）

## Test plan
- [x] `./gradlew check`（detekt / svelte-check / build / test）が通ることを確認
- [x] `HumanPlayerTest`に`TimeChanged`/`DiscussionStarted`/`VoteStarted`/`ConclaveStarted`それぞれのAtmosphere変換テストを追加
- [x] `DayPhaseTest`に`VoteStarted`が発言後・処刑通知前に送られることを検証するテストを追加
- [x] ユーザー本人がWeb UIを実際に動かし、背景の切り替わりを確認済み

Refs #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)