### PR TITLE
Switch web UI selection panel color by SelectionContext (Attack/Divine/Guard/Vote)

### DIFF
--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -17,6 +17,7 @@
     | { type: 'speak'; title: string; description: string }
 
   type Atmosphere = 'morning' | 'day' | 'night' | 'vote'
+  type SelectionMood = 'attack' | 'divine' | 'guard' | 'vote'
 
   type PlayerStatus = 'alive' | 'executed' | 'attacked'
   type PlayerEntry = { name: string; status: PlayerStatus; claimedRole: string | null }
@@ -34,6 +35,7 @@
   let entries: LogEntry[] = []
   let input: InputState = { type: 'idle' }
   let atmosphere: Atmosphere | null = null
+  let selectionMood: SelectionMood | null = null
   $: document.body.className = atmosphere ? `atmosphere-${atmosphere}` : ''
   let speakText = ''
   let logEl: HTMLElement
@@ -82,6 +84,9 @@
         break
       case 'atmosphere':
         atmosphere = msg.value as Atmosphere
+        break
+      case 'selectionMood':
+        selectionMood = msg.value as SelectionMood
         break
       case 'divination':
         divination = msg as unknown as DivinationData
@@ -151,7 +156,7 @@
     </div>
 
     {#if input.type === 'choose'}
-      <div class="input-area">
+      <div class="input-area {selectionMood ? `mood-${selectionMood}` : ''}">
         <p class="input-title">{input.title}</p>
         <p class="input-description">{input.description}</p>
         <div>
@@ -326,7 +331,15 @@
   .intent { color: #888; font-size: 0.9em; }
   .role-badge { display: inline-block; margin-left: 4px; padding: 1px 6px; border-radius: 3px; font-size: 0.8em; background: #dde6f7; color: #33507a; }
   .epilogue { margin: 16px 0 0; padding: 12px; background: #eef; border-left: 4px solid #88a; white-space: pre-wrap; font-family: inherit; }
-  .input-area { margin-bottom: 8px; padding: 12px; border: 2px solid #88a; background: #f0f0fa; color: #333; }
+  .input-area { margin-bottom: 8px; padding: 12px; border: 2px solid #88a; background: #f0f0fa; color: #333; transition: background-color 0.4s ease, border-color 0.4s ease, color 0.4s ease; }
+  .input-area.mood-attack { background: #2a0f0f; border-color: #7a1f1f; color: #f2d9d9; }
+  .input-area.mood-attack .input-description { color: #d9a8a8; }
+  .input-area.mood-divine { background: #241b3d; border-color: #7a5fc4; color: #e6dcfa; }
+  .input-area.mood-divine .input-description { color: #bfaee0; }
+  .input-area.mood-guard { background: #16301f; border-color: #3f8a5c; color: #dff2e6; }
+  .input-area.mood-guard .input-description { color: #a9d4bb; }
+  .input-area.mood-vote { background: #3a2020; border-color: #b45a5a; color: #f7dede; }
+  .input-area.mood-vote .input-description { color: #d9aaaa; }
   .input-title { font-weight: bold; margin: 0 0 4px; }
   .input-description { color: #666; font-size: 0.9em; margin: 0 0 10px; }
   button { margin: 4px; padding: 6px 14px; cursor: pointer; }

--- a/src/main/kotlin/werewolf/human/HumanIO.kt
+++ b/src/main/kotlin/werewolf/human/HumanIO.kt
@@ -6,12 +6,14 @@ import werewolf.view.Atmosphere
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
 import werewolf.view.PlayerStatusView
+import werewolf.view.SelectionMood
 
 interface HumanIO {
     fun display(view: RecallView)
     fun updatePlayerStatusPanel(view: PlayerStatusView)
     fun updateDivinationPanel(view: DivinationView)
     fun updateAtmosphere(atmosphere: Atmosphere)
+    fun updateSelectionMood(mood: SelectionMood)
     fun promptChoice(view: ChoiceView): String
     fun promptFreeText(title: String, description: String): String
     fun watchEpilogue(chronicles: List<ChronicleView>)

--- a/src/main/kotlin/werewolf/human/HumanPlayer.kt
+++ b/src/main/kotlin/werewolf/human/HumanPlayer.kt
@@ -17,6 +17,7 @@ import werewolf.view.Atmosphere
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
 import werewolf.view.PlayerStatusView
+import werewolf.view.SelectionMood
 
 class HumanPlayer(role: Role, override val name: String, private val io: HumanIO) : Player(role) {
     companion object {
@@ -28,10 +29,18 @@ class HumanPlayer(role: Role, override val name: String, private val io: HumanIO
     private var lastDivinationSummary: DivinationView? = null
 
     override fun choose(context: SelectionContext): Choice {
+        io.updateSelectionMood(moodOf(context))
         val selected = select(context.title, context.description, context.candidates()) { it.name }
         val choice = Choice(this, context, selected, "プレイヤーが選択")
         io.display(choice.toRecallView())
         return choice
+    }
+
+    private fun moodOf(context: SelectionContext): SelectionMood = when (context) {
+        is SelectionContext.Attack -> SelectionMood.ATTACK
+        is SelectionContext.Divine -> SelectionMood.DIVINE
+        is SelectionContext.Guard -> SelectionMood.GUARD
+        is SelectionContext.Vote -> SelectionMood.VOTE
     }
 
     override fun onReceive(event: GameEvent) {

--- a/src/main/kotlin/werewolf/human/console/ConsoleHumanIO.kt
+++ b/src/main/kotlin/werewolf/human/console/ConsoleHumanIO.kt
@@ -8,6 +8,7 @@ import werewolf.view.Atmosphere
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
 import werewolf.view.PlayerStatusView
+import werewolf.view.SelectionMood
 
 class ConsoleHumanIO : HumanIO {
 
@@ -25,6 +26,10 @@ class ConsoleHumanIO : HumanIO {
 
     override fun updateAtmosphere(atmosphere: Atmosphere) {
         // Console has no visual background; time-of-day is visible in the event log
+    }
+
+    override fun updateSelectionMood(mood: SelectionMood) {
+        // Console has no visual selection panel; the choice prompt itself conveys this
     }
 
     override fun display(view: RecallView) = when (view) {

--- a/src/main/kotlin/werewolf/human/web/WebHumanIO.kt
+++ b/src/main/kotlin/werewolf/human/web/WebHumanIO.kt
@@ -13,6 +13,7 @@ import werewolf.view.PlayerStatus
 import werewolf.view.PlayerStatusView
 import werewolf.view.PlayerSummary
 import werewolf.view.ReportEntry
+import werewolf.view.SelectionMood
 
 class WebHumanIO : HumanIO {
     val outgoing = Channel<String>(Channel.UNLIMITED)
@@ -47,6 +48,10 @@ class WebHumanIO : HumanIO {
 
     override fun updateAtmosphere(atmosphere: Atmosphere) {
         enqueue("""{"type":"atmosphere","value":${atmosphere.toJson()}}""")
+    }
+
+    override fun updateSelectionMood(mood: SelectionMood) {
+        enqueue("""{"type":"selectionMood","value":${mood.toJson()}}""")
     }
 
     override fun display(view: RecallView) {
@@ -100,6 +105,13 @@ private fun Atmosphere.toJson(): String = when (this) {
     Atmosphere.DAY -> "\"day\""
     Atmosphere.NIGHT -> "\"night\""
     Atmosphere.VOTE -> "\"vote\""
+}
+
+private fun SelectionMood.toJson(): String = when (this) {
+    SelectionMood.ATTACK -> "\"attack\""
+    SelectionMood.DIVINE -> "\"divine\""
+    SelectionMood.GUARD -> "\"guard\""
+    SelectionMood.VOTE -> "\"vote\""
 }
 
 private fun RecallView.toJson(): String = when (this) {

--- a/src/main/kotlin/werewolf/view/SelectionMood.kt
+++ b/src/main/kotlin/werewolf/view/SelectionMood.kt
@@ -1,0 +1,3 @@
+package werewolf.view
+
+enum class SelectionMood { ATTACK, DIVINE, GUARD, VOTE }

--- a/src/test/kotlin/werewolf/HumanPlayerTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerTest.kt
@@ -21,6 +21,7 @@ import werewolf.view.Atmosphere
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
 import werewolf.view.PlayerStatusView
+import werewolf.view.SelectionMood
 
 class HumanPlayerTest {
 
@@ -32,12 +33,14 @@ class HumanPlayerTest {
         val promptedChoices = mutableListOf<ChoiceView>()
         val displayedViews = mutableListOf<RecallView>()
         val capturedAtmospheres = mutableListOf<Atmosphere>()
+        val capturedSelectionMoods = mutableListOf<SelectionMood>()
         var capturedChronicles: List<ChronicleView> = emptyList()
 
         override fun display(view: RecallView) { displayedViews += view }
         override fun updatePlayerStatusPanel(view: PlayerStatusView) {}
         override fun updateDivinationPanel(view: DivinationView) {}
         override fun updateAtmosphere(atmosphere: Atmosphere) { capturedAtmospheres += atmosphere }
+        override fun updateSelectionMood(mood: SelectionMood) { capturedSelectionMoods += mood }
         override fun promptChoice(view: ChoiceView): String {
             promptedChoices += view
             return queue.removeFirst()
@@ -86,6 +89,54 @@ class HumanPlayerTest {
             listOf<RecallView>(RecallView.SelfAction("投票", "Alice", "プレイヤーが選択")),
             io.displayedViews,
         )
+    }
+
+    @Test
+    fun `choose with Attack context updates selection mood to ATTACK`() {
+        val alice = NothingPlayer(Role.VILLAGER, "Alice")
+        val io = CapturingIO("Alice")
+        val human = HumanPlayer(Role.WEREWOLF, "Human", io)
+        val context = SelectionContext.Attack(human, listOf(human, alice), emptyList())
+
+        human.selectTarget(context)
+
+        assertEquals(listOf(SelectionMood.ATTACK), io.capturedSelectionMoods)
+    }
+
+    @Test
+    fun `choose with Divine context updates selection mood to DIVINE`() {
+        val alice = NothingPlayer(Role.VILLAGER, "Alice")
+        val io = CapturingIO("Alice")
+        val human = HumanPlayer(Role.SEER, "Human", io)
+        val context = SelectionContext.Divine(human, listOf(human, alice), emptyList())
+
+        human.selectTarget(context)
+
+        assertEquals(listOf(SelectionMood.DIVINE), io.capturedSelectionMoods)
+    }
+
+    @Test
+    fun `choose with Guard context updates selection mood to GUARD`() {
+        val alice = NothingPlayer(Role.VILLAGER, "Alice")
+        val io = CapturingIO("Alice")
+        val human = HumanPlayer(Role.HUNTER, "Human", io)
+        val context = SelectionContext.Guard(human, listOf(human, alice))
+
+        human.selectTarget(context)
+
+        assertEquals(listOf(SelectionMood.GUARD), io.capturedSelectionMoods)
+    }
+
+    @Test
+    fun `choose with Vote context updates selection mood to VOTE`() {
+        val alice = NothingPlayer(Role.VILLAGER, "Alice")
+        val io = CapturingIO("Alice")
+        val human = HumanPlayer(Role.VILLAGER, "Human", io)
+        val context = SelectionContext.Vote(human, listOf(human, alice))
+
+        human.selectTarget(context)
+
+        assertEquals(listOf(SelectionMood.VOTE), io.capturedSelectionMoods)
     }
 
     @Test

--- a/src/test/kotlin/werewolf/NothingHumanIO.kt
+++ b/src/test/kotlin/werewolf/NothingHumanIO.kt
@@ -7,12 +7,14 @@ import werewolf.view.Atmosphere
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
 import werewolf.view.PlayerStatusView
+import werewolf.view.SelectionMood
 
 open class NothingHumanIO : HumanIO {
     override fun display(view: RecallView) { error("display not expected") }
     override fun updatePlayerStatusPanel(view: PlayerStatusView) { error("updatePlayerStatusPanel not expected") }
     override fun updateDivinationPanel(view: DivinationView) { error("updateDivinationPanel not expected") }
     override fun updateAtmosphere(atmosphere: Atmosphere) { error("updateAtmosphere not expected") }
+    override fun updateSelectionMood(mood: SelectionMood) { error("updateSelectionMood not expected") }
     override fun promptChoice(view: ChoiceView): String = error("promptChoice not expected")
     override fun promptFreeText(title: String, description: String): String = error("promptFreeText not expected")
     override fun watchEpilogue(chronicles: List<ChronicleView>) { error("watchEpilogue not expected") }


### PR DESCRIPTION
## Summary
- SelectionContext（Attack/Divine/Guard/Vote）に応じてWeb UIの選択パネルの背景色・枠色が変わるようにした
- `HumanIO`に`updateSelectionMood(mood: SelectionMood)`を追加し、`HumanPlayer`が`SelectionContext`を`view.SelectionMood`へ変換してpushする（判定ロジックは`HumanPlayer`側、`WebHumanIO`/`App.svelte`はロジックを持たない）
- 勝敗演出は今回のスコープ外（#289の残りの完了条件として別PRで対応予定）

## Test plan
- [x] `./gradlew check`（detekt / svelte-check / build / test）が通ることを確認
- [x] `HumanPlayerTest`にAttack/Divine/Guard/VoteそれぞれのSelectionMood変換テストを追加

Refs #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)