### PR TITLE
Switch epilogue background by winning side and player result

### DIFF
--- a/frontend/svelte/src/App.svelte
+++ b/frontend/svelte/src/App.svelte
@@ -18,6 +18,7 @@
 
   type Atmosphere = 'morning' | 'day' | 'night' | 'vote'
   type SelectionMood = 'attack' | 'divine' | 'guard' | 'vote'
+  type EpilogueMood = 'citizenWin' | 'citizenLose' | 'werewolfWin' | 'werewolfLose'
 
   type PlayerStatus = 'alive' | 'executed' | 'attacked'
   type PlayerEntry = { name: string; status: PlayerStatus; claimedRole: string | null }
@@ -36,6 +37,7 @@
   let input: InputState = { type: 'idle' }
   let atmosphere: Atmosphere | null = null
   let selectionMood: SelectionMood | null = null
+  let epilogueMood: EpilogueMood | null = null
   $: document.body.className = atmosphere ? `atmosphere-${atmosphere}` : ''
   let speakText = ''
   let logEl: HTMLElement
@@ -87,6 +89,9 @@
         break
       case 'selectionMood':
         selectionMood = msg.value as SelectionMood
+        break
+      case 'epilogueMood':
+        epilogueMood = msg.value as EpilogueMood
         break
       case 'divination':
         divination = msg as unknown as DivinationData
@@ -196,7 +201,7 @@
             {#if entry.intent}<br /><span class="intent">  [{entry.intent}]</span>{/if}
           </div>
         {:else if entry.type === 'epilogue'}
-          <pre class="epilogue">{entry.chronicles.map(formatChronicle).join('\n')}</pre>
+          <pre class="epilogue {epilogueMood ? `mood-${epilogueMood}` : ''}">{entry.chronicles.map(formatChronicle).join('\n')}</pre>
         {/if}
       {/each}
     </div>
@@ -331,6 +336,10 @@
   .intent { color: #888; font-size: 0.9em; }
   .role-badge { display: inline-block; margin-left: 4px; padding: 1px 6px; border-radius: 3px; font-size: 0.8em; background: #dde6f7; color: #33507a; }
   .epilogue { margin: 16px 0 0; padding: 12px; background: #eef; border-left: 4px solid #88a; white-space: pre-wrap; font-family: inherit; }
+  .epilogue.mood-citizenWin { background: #eef7ee; border-color: #4a9a5a; color: #2a4a2f; }
+  .epilogue.mood-werewolfWin { background: #2a1030; border-color: #8a3fae; color: #f0d9f7; }
+  .epilogue.mood-citizenLose { background: #2a0f0f; border-color: #7a1f1f; color: #f2d9d9; }
+  .epilogue.mood-werewolfLose { background: #1c1c24; border-color: #555566; color: #ccccd9; }
   .input-area { margin-bottom: 8px; padding: 12px; border: 2px solid #88a; background: #f0f0fa; color: #333; transition: background-color 0.4s ease, border-color 0.4s ease, color 0.4s ease; }
   .input-area.mood-attack { background: #2a0f0f; border-color: #7a1f1f; color: #f2d9d9; }
   .input-area.mood-attack .input-description { color: #d9a8a8; }

--- a/src/main/kotlin/werewolf/game/GameEvent.kt
+++ b/src/main/kotlin/werewolf/game/GameEvent.kt
@@ -158,12 +158,12 @@ sealed class GameEvent : Recallable() {
     }
 
     @ConsistentCopyVisibility
-    data class GameResult private constructor(val isWinner: Boolean, private val recipient: Player) : GameEvent() {
+    data class GameResult private constructor(val winnerSide: Side, val isWinner: Boolean, private val recipient: Player) : GameEvent() {
         override val title = "勝敗結果"
         override fun body() = if (isWinner) "あなたは勝利しました。" else "あなたは敗北しました。"
         override val recipients: Notifiable = recipient
         companion object {
-            fun send(isWinner: Boolean, recipient: Player) = GameResult(isWinner, recipient).dispatch()
+            fun send(winnerSide: Side, isWinner: Boolean, recipient: Player) = GameResult(winnerSide, isWinner, recipient).dispatch()
         }
     }
 

--- a/src/main/kotlin/werewolf/human/HumanIO.kt
+++ b/src/main/kotlin/werewolf/human/HumanIO.kt
@@ -5,6 +5,7 @@ import werewolf.game.RecallView
 import werewolf.view.Atmosphere
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
+import werewolf.view.EpilogueMood
 import werewolf.view.PlayerStatusView
 import werewolf.view.SelectionMood
 
@@ -14,6 +15,7 @@ interface HumanIO {
     fun updateDivinationPanel(view: DivinationView)
     fun updateAtmosphere(atmosphere: Atmosphere)
     fun updateSelectionMood(mood: SelectionMood)
+    fun updateEpilogueMood(mood: EpilogueMood)
     fun promptChoice(view: ChoiceView): String
     fun promptFreeText(title: String, description: String): String
     fun watchEpilogue(chronicles: List<ChronicleView>)

--- a/src/main/kotlin/werewolf/human/HumanPlayer.kt
+++ b/src/main/kotlin/werewolf/human/HumanPlayer.kt
@@ -9,6 +9,7 @@ import werewolf.game.Player
 import werewolf.game.ReportEligibility
 import werewolf.game.Role
 import werewolf.game.SelectionContext
+import werewolf.game.Side
 import werewolf.game.Statement
 import werewolf.game.StatementType
 import werewolf.game.TimeOfDay
@@ -16,6 +17,7 @@ import werewolf.game.selectableTypes
 import werewolf.view.Atmosphere
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
+import werewolf.view.EpilogueMood
 import werewolf.view.PlayerStatusView
 import werewolf.view.SelectionMood
 
@@ -57,6 +59,7 @@ class HumanPlayer(role: Role, override val name: String, private val io: HumanIO
             io.updateDivinationPanel(currentDivination)
         }
         atmosphereOf(event)?.let { io.updateAtmosphere(it) }
+        epilogueMoodOf(event)?.let { io.updateEpilogueMood(it) }
     }
 
     private fun atmosphereOf(event: GameEvent): Atmosphere? = when (event) {
@@ -67,6 +70,14 @@ class HumanPlayer(role: Role, override val name: String, private val io: HumanIO
         is GameEvent.DiscussionStarted -> Atmosphere.DAY
         is GameEvent.VoteStarted -> Atmosphere.VOTE
         else -> null
+    }
+
+    private fun epilogueMoodOf(event: GameEvent): EpilogueMood? {
+        if (event !is GameEvent.GameResult) return null
+        return when (event.winnerSide) {
+            Side.CITIZEN -> if (event.isWinner) EpilogueMood.CITIZEN_WIN else EpilogueMood.CITIZEN_LOSE
+            Side.WEREWOLF -> if (event.isWinner) EpilogueMood.WEREWOLF_WIN else EpilogueMood.WEREWOLF_LOSE
+        }
     }
 
     override fun speak(context: DiscussionContext, claimableRoles: Set<Role>, reportEligibility: ReportEligibility): Claim {

--- a/src/main/kotlin/werewolf/human/console/ConsoleHumanIO.kt
+++ b/src/main/kotlin/werewolf/human/console/ConsoleHumanIO.kt
@@ -7,6 +7,7 @@ import werewolf.human.HumanIO
 import werewolf.view.Atmosphere
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
+import werewolf.view.EpilogueMood
 import werewolf.view.PlayerStatusView
 import werewolf.view.SelectionMood
 
@@ -30,6 +31,10 @@ class ConsoleHumanIO : HumanIO {
 
     override fun updateSelectionMood(mood: SelectionMood) {
         // Console has no visual selection panel; the choice prompt itself conveys this
+    }
+
+    override fun updateEpilogueMood(mood: EpilogueMood) {
+        // Console has no visual background; the GameResult event itself conveys this
     }
 
     override fun display(view: RecallView) = when (view) {

--- a/src/main/kotlin/werewolf/human/web/WebHumanIO.kt
+++ b/src/main/kotlin/werewolf/human/web/WebHumanIO.kt
@@ -9,6 +9,7 @@ import werewolf.human.HumanIO
 import werewolf.view.Atmosphere
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
+import werewolf.view.EpilogueMood
 import werewolf.view.PlayerStatus
 import werewolf.view.PlayerStatusView
 import werewolf.view.PlayerSummary
@@ -52,6 +53,10 @@ class WebHumanIO : HumanIO {
 
     override fun updateSelectionMood(mood: SelectionMood) {
         enqueue("""{"type":"selectionMood","value":${mood.toJson()}}""")
+    }
+
+    override fun updateEpilogueMood(mood: EpilogueMood) {
+        enqueue("""{"type":"epilogueMood","value":${mood.toJson()}}""")
     }
 
     override fun display(view: RecallView) {
@@ -112,6 +117,13 @@ private fun SelectionMood.toJson(): String = when (this) {
     SelectionMood.DIVINE -> "\"divine\""
     SelectionMood.GUARD -> "\"guard\""
     SelectionMood.VOTE -> "\"vote\""
+}
+
+private fun EpilogueMood.toJson(): String = when (this) {
+    EpilogueMood.CITIZEN_WIN -> "\"citizenWin\""
+    EpilogueMood.CITIZEN_LOSE -> "\"citizenLose\""
+    EpilogueMood.WEREWOLF_WIN -> "\"werewolfWin\""
+    EpilogueMood.WEREWOLF_LOSE -> "\"werewolfLose\""
 }
 
 private fun RecallView.toJson(): String = when (this) {

--- a/src/main/kotlin/werewolf/phase/Epilogue.kt
+++ b/src/main/kotlin/werewolf/phase/Epilogue.kt
@@ -16,7 +16,7 @@ class Epilogue(
         when (signal) {
             is GameOverSignal.Completed -> {
                 GameEvent.GameOver.send(signal.winningSide, AllPlayers(playerManager))
-                playerManager.allPlayers.forEach { GameEvent.GameResult.send(oracle.isWinner(it, signal.winningSide), it) }
+                playerManager.allPlayers.forEach { GameEvent.GameResult.send(signal.winningSide, oracle.isWinner(it, signal.winningSide), it) }
             }
             is GameOverSignal.Aborted -> Unit
         }

--- a/src/main/kotlin/werewolf/view/EpilogueMood.kt
+++ b/src/main/kotlin/werewolf/view/EpilogueMood.kt
@@ -1,0 +1,3 @@
+package werewolf.view
+
+enum class EpilogueMood { CITIZEN_WIN, CITIZEN_LOSE, WEREWOLF_WIN, WEREWOLF_LOSE }

--- a/src/test/kotlin/werewolf/EpilogueTest.kt
+++ b/src/test/kotlin/werewolf/EpilogueTest.kt
@@ -52,6 +52,8 @@ class EpilogueTest {
 
         assertEquals(false, wolf.gameResult?.isWinner)
         assertEquals(true, villager.gameResult?.isWinner)
+        assertEquals(Side.CITIZEN, wolf.gameResult?.winnerSide)
+        assertEquals(Side.CITIZEN, villager.gameResult?.winnerSide)
     }
 
     @Test

--- a/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerEpilogueTest.kt
@@ -5,6 +5,7 @@ import werewolf.human.HumanPlayer
 import werewolf.view.Atmosphere
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
+import werewolf.view.EpilogueMood
 import werewolf.view.PlayerStatusView
 import werewolf.phase.Conclave
 import werewolf.phase.Epilogue
@@ -22,6 +23,7 @@ class HumanPlayerEpilogueTest {
         override fun updatePlayerStatusPanel(view: PlayerStatusView) {}
         override fun updateDivinationPanel(view: DivinationView) {}
         override fun updateAtmosphere(atmosphere: Atmosphere) {}
+        override fun updateEpilogueMood(mood: EpilogueMood) {}
         override fun promptFreeText(title: String, description: String): String = "human speaks"
         override fun promptChoice(view: ChoiceView): String = view.options.first()
         override fun watchEpilogue(chronicles: List<ChronicleView>) { capturedChronicles = chronicles }

--- a/src/test/kotlin/werewolf/HumanPlayerTest.kt
+++ b/src/test/kotlin/werewolf/HumanPlayerTest.kt
@@ -12,6 +12,7 @@ import werewolf.game.MediumResult
 import werewolf.game.RecallView
 import werewolf.game.Role
 import werewolf.game.SelectionContext
+import werewolf.game.Side
 import werewolf.game.Statement
 import werewolf.game.StatementType
 import werewolf.game.TimeOfDay
@@ -20,6 +21,7 @@ import werewolf.human.HumanPlayer
 import werewolf.view.Atmosphere
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
+import werewolf.view.EpilogueMood
 import werewolf.view.PlayerStatusView
 import werewolf.view.SelectionMood
 
@@ -34,6 +36,7 @@ class HumanPlayerTest {
         val displayedViews = mutableListOf<RecallView>()
         val capturedAtmospheres = mutableListOf<Atmosphere>()
         val capturedSelectionMoods = mutableListOf<SelectionMood>()
+        val capturedEpilogueMoods = mutableListOf<EpilogueMood>()
         var capturedChronicles: List<ChronicleView> = emptyList()
 
         override fun display(view: RecallView) { displayedViews += view }
@@ -41,6 +44,7 @@ class HumanPlayerTest {
         override fun updateDivinationPanel(view: DivinationView) {}
         override fun updateAtmosphere(atmosphere: Atmosphere) { capturedAtmospheres += atmosphere }
         override fun updateSelectionMood(mood: SelectionMood) { capturedSelectionMoods += mood }
+        override fun updateEpilogueMood(mood: EpilogueMood) { capturedEpilogueMoods += mood }
         override fun promptChoice(view: ChoiceView): String {
             promptedChoices += view
             return queue.removeFirst()
@@ -374,6 +378,46 @@ class HumanPlayerTest {
         GameEvent.ConclaveStarted.send(1, Wolves(setup.oracle, setup.playerManager))
 
         assertTrue(io.capturedAtmospheres.isEmpty())
+    }
+
+    @Test
+    fun `GameResult with citizen win updates epilogue mood to CITIZEN_WIN`() {
+        val io = CapturingIO()
+        val human = HumanPlayer(Role.VILLAGER, "Human", io)
+
+        GameEvent.GameResult.send(Side.CITIZEN, true, human)
+
+        assertEquals(listOf(EpilogueMood.CITIZEN_WIN), io.capturedEpilogueMoods)
+    }
+
+    @Test
+    fun `GameResult with citizen win and werewolf player updates epilogue mood to CITIZEN_LOSE`() {
+        val io = CapturingIO()
+        val human = HumanPlayer(Role.WEREWOLF, "Human", io)
+
+        GameEvent.GameResult.send(Side.CITIZEN, false, human)
+
+        assertEquals(listOf(EpilogueMood.CITIZEN_LOSE), io.capturedEpilogueMoods)
+    }
+
+    @Test
+    fun `GameResult with werewolf win updates epilogue mood to WEREWOLF_WIN`() {
+        val io = CapturingIO()
+        val human = HumanPlayer(Role.WEREWOLF, "Human", io)
+
+        GameEvent.GameResult.send(Side.WEREWOLF, true, human)
+
+        assertEquals(listOf(EpilogueMood.WEREWOLF_WIN), io.capturedEpilogueMoods)
+    }
+
+    @Test
+    fun `GameResult with werewolf win and villager player updates epilogue mood to WEREWOLF_LOSE`() {
+        val io = CapturingIO()
+        val human = HumanPlayer(Role.VILLAGER, "Human", io)
+
+        GameEvent.GameResult.send(Side.WEREWOLF, false, human)
+
+        assertEquals(listOf(EpilogueMood.WEREWOLF_LOSE), io.capturedEpilogueMoods)
     }
 
     @Test

--- a/src/test/kotlin/werewolf/NothingHumanIO.kt
+++ b/src/test/kotlin/werewolf/NothingHumanIO.kt
@@ -6,6 +6,7 @@ import werewolf.human.HumanIO
 import werewolf.view.Atmosphere
 import werewolf.view.ChoiceView
 import werewolf.view.DivinationView
+import werewolf.view.EpilogueMood
 import werewolf.view.PlayerStatusView
 import werewolf.view.SelectionMood
 
@@ -15,6 +16,7 @@ open class NothingHumanIO : HumanIO {
     override fun updateDivinationPanel(view: DivinationView) { error("updateDivinationPanel not expected") }
     override fun updateAtmosphere(atmosphere: Atmosphere) { error("updateAtmosphere not expected") }
     override fun updateSelectionMood(mood: SelectionMood) { error("updateSelectionMood not expected") }
+    override fun updateEpilogueMood(mood: EpilogueMood) { error("updateEpilogueMood not expected") }
     override fun promptChoice(view: ChoiceView): String = error("promptChoice not expected")
     override fun promptFreeText(title: String, description: String): String = error("promptFreeText not expected")
     override fun watchEpilogue(chronicles: List<ChronicleView>) { error("watchEpilogue not expected") }


### PR DESCRIPTION
## Summary
- `GameResult` イベントに `winnerSide`（勝利陣営）を追加
- `HumanPlayer` が勝敗×陣営（人狼側/村人側）から `EpilogueMood`（CITIZEN_WIN/CITIZEN_LOSE/WEREWOLF_WIN/WEREWOLF_LOSE）を導出し、`HumanIO` 経由でWeb UIに伝える
- Web UIはエピローグ欄の背景色を `EpilogueMood` に応じて切り替える

Closes #289

## Test plan
- [x] `./gradlew check`（test/detekt/npmCheck含む）が成功することを確認